### PR TITLE
Fix: hi_streaming: old-style dependency includes preventing build in latest (5.2.0) JUCE.

### DIFF
--- a/hi_streaming/hi_streaming.h
+++ b/hi_streaming/hi_streaming.h
@@ -58,10 +58,10 @@ END_JUCE_MODULE_DECLARATION
 
 #include <atomic>
 
-#include "../JUCE/modules/juce_core/juce_core.h"
-#include "../JUCE/modules/juce_audio_basics/juce_audio_basics.h"
-#include "../JUCE/modules/juce_data_structures/juce_data_structures.h"
-#include "../hi_lac/hi_lac.h"
+#include <juce_core/juce_core.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_data_structures/juce_data_structures.h>
+#include <hi_lac/hi_lac.h>
 
 
 #if USE_IPP


### PR DESCRIPTION
Hey Christoph,

I don't know if you accept pull requests, but I had to fix this while testing the streaming demo and I see that you have used the new way of inclusion in hi_lac module, so I decided to spent a few minutes and send this your way.

Cheers.