### PR TITLE
Add ComboBox.clear() API.

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -1580,6 +1580,7 @@ Justification ScriptingApi::Content::ScriptLabel::getJustification()
 
 struct ScriptingApi::Content::ScriptComboBox::Wrapper
 {
+    API_VOID_METHOD_WRAPPER_0(ScriptComboBox, clear);
 	API_VOID_METHOD_WRAPPER_1(ScriptComboBox, addItem);
 	API_METHOD_WRAPPER_0(ScriptComboBox, getItemText);
 };
@@ -1608,6 +1609,7 @@ ScriptComponent(base, name)
 
 	initInternalPropertyFromValueTreeOrDefault(Items);
 
+    ADD_API_METHOD_0(clear);
 	ADD_API_METHOD_1(addItem);
 	ADD_API_METHOD_0(getItemText);
 }
@@ -1615,6 +1617,13 @@ ScriptComponent(base, name)
 ScriptCreatedComponentWrapper * ScriptingApi::Content::ScriptComboBox::createComponentWrapper(ScriptContentComponent *content, int index)
 {
 	return new ScriptCreatedComponentWrappers::ComboBoxWrapper(content, this, index);
+}
+
+void ScriptingApi::Content::ScriptComboBox::clear()
+{
+    setScriptObjectProperty(Items, "", sendNotification);
+    setScriptObjectProperty(ScriptComponent::Properties::min, 1, dontSendNotification);
+    setScriptObjectProperty(ScriptComponent::Properties::max, 1, dontSendNotification);
 }
 
 void ScriptingApi::Content::ScriptComboBox::addItem(const String &itemName)

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -607,6 +607,9 @@ public:
 		/** Adds an item to a combo box. */
 		void addItem(const String &newName);
 
+        /** Removes all items from a combo box. */
+        void clear();
+
 		// ========================================================================================================
 
 		struct Wrapper;

--- a/hi_scripting/scripting/api/ScriptingApiWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiWrappers.cpp
@@ -823,6 +823,12 @@ var ScriptingApi::Content::Wrapper::clear (const var::NativeFunctionArgs& args)
 		thisObject->clear();
 	}
 
+    if (ScriptingApi::Content::ScriptComboBox* thisObject = GET_OBJECT(Content::ScriptComboBox))
+    {
+        CHECK_ARGUMENTS("clear()", 0);
+        thisObject->clear();
+    }
+
 	return var();
 };
 


### PR DESCRIPTION
Not sure if I'm doing this completely correctly (as I couldn't find this resulting method in auto-generated API docs within the HISE interface) but here's a `.clear` method on `ScriptComboBox`.

Why is this useful? I found myself in a situation where I dynamically added elements to a `ComboBox` from within a script, but found that HISE would continue appending elements every time I compiled the script, resulting in a hard-coded list of hundreds of elements. With `.clear()`, scripts can now ensure that they're starting with a completely blank slate before populating a ComboBox.