### PR TITLE
Only add IPP flags to Projucer if useIpp is enabled.

### DIFF
--- a/hi_backend/backend/CompileExporter.cpp
+++ b/hi_backend/backend/CompileExporter.cpp
@@ -1469,14 +1469,17 @@ void CompileExporter::ProjectTemplateHelpers::handleCompilerInfo(CompileExporter
 
 
 #if JUCE_MAC
-	REPLACE_WILDCARD_WITH_STRING("%IPP_COMPILER_FLAGS%", "/opt/intel/ipp/lib/libippi.a  /opt/intel/ipp/lib/libipps.a /opt/intel/ipp/lib/libippvm.a /opt/intel/ipp/lib/libippcore.a");
-	REPLACE_WILDCARD_WITH_STRING("%IPP_HEADER%", "/opt/intel/ipp/include");
-	REPLACE_WILDCARD_WITH_STRING("%IPP_LIBRARY%", "/opt/intel/ipp/lib");
-#else
-	REPLACE_WILDCARD_WITH_STRING("%IPP_COMPILER_FLAGS%", String());
-	REPLACE_WILDCARD_WITH_STRING("%IPP_HEADER%", String());
-	REPLACE_WILDCARD_WITH_STRING("%IPP_LIBRARY%", String());
+    if (exporter->useIpp) {
+        REPLACE_WILDCARD_WITH_STRING("%IPP_COMPILER_FLAGS%", "/opt/intel/ipp/lib/libippi.a  /opt/intel/ipp/lib/libipps.a /opt/intel/ipp/lib/libippvm.a /opt/intel/ipp/lib/libippcore.a");
+        REPLACE_WILDCARD_WITH_STRING("%IPP_HEADER%", "/opt/intel/ipp/include");
+        REPLACE_WILDCARD_WITH_STRING("%IPP_LIBRARY%", "/opt/intel/ipp/lib");
+    } else
 #endif
+    {
+        REPLACE_WILDCARD_WITH_STRING("%IPP_COMPILER_FLAGS%", String());
+        REPLACE_WILDCARD_WITH_STRING("%IPP_HEADER%", String());
+        REPLACE_WILDCARD_WITH_STRING("%IPP_LIBRARY%", String());
+    }
 }
 
 void CompileExporter::ProjectTemplateHelpers::handleCompanyInfo(CompileExporter* exporter, String& templateProject)


### PR DESCRIPTION
I'm not sure if there's an easier way to automatically disable compilation errors on machines without IPP installed, but this patch will prevent IPP linker flags from being added if the `useIpp` option is disabled. This should make project building much easier on macOS without IPP installed.