### PR TITLE
Add option to embed all image files in binary, not just referenced ones.

### DIFF
--- a/hi_backend/backend/CompileExporter.cpp
+++ b/hi_backend/backend/CompileExporter.cpp
@@ -62,12 +62,33 @@ void loadOtherReferencedImages(ModulatorSynthChain* chainToExport)
 	}
 }
 
+void loadAllImages(ModulatorSynthChain* chainToExport)
+{
+	auto mc = chainToExport->getMainController();
+
+	auto& handler = GET_PROJECT_HANDLER(chainToExport);
+
+	auto imageDirectory = handler.getSubDirectory(ProjectHandler::SubDirectories::Images);
+
+	Array<File> allFiles;
+	imageDirectory.findChildFiles(allFiles, File::findFiles, true);
+	for (int i = 0; i < allFiles.size(); i++)
+	{
+		auto f = allFiles[i];
+		ImagePool::loadImageFromReference(mc, "{PROJECT_FOLDER}" + f.getFileName());
+	}
+}
+
 ValueTree BaseExporter::exportReferencedImageFiles()
 {
 	// Export the interface
 
 
 	loadOtherReferencedImages(chainToExport);
+
+    if (SettingWindows::getSettingValue((int)SettingWindows::CompilerSettingWindow::Attributes::UseIPP) == "All Images") {
+        loadAllImages(chainToExport);
+    }
 
 	ImagePool *imagePool = chainToExport->getMainController()->getSampleManager().getImagePool();
 

--- a/hi_core/hi_core/SettingsWindows.cpp
+++ b/hi_core/hi_core/SettingsWindows.cpp
@@ -333,6 +333,7 @@ String SettingWindows::CompilerSettingWindow::getAttributeNameForSetting(int att
 	case Attributes::HisePath: return "HisePath";
 	case Attributes::VisualStudioVersion: return "VisualStudioVersion";
 	case Attributes::UseIPP: return "UseIPP";
+    case Attributes::EmbedImages: return "EmbedImages";
 	case Attributes::numCompilerSettingAttributes: return "";
 	default: return "";
 	}
@@ -345,6 +346,7 @@ XmlElement * SettingWindows::CompilerSettingWindow::createNewSettingsFile() cons
 	addFileAsChildElement(*xml, (int)Attributes::HisePath, "", "Path to HISE modules");
 	addChildElementWithOptions(*xml, (int)Attributes::VisualStudioVersion, "Visual Studio 2017", "Installed VisualStudio version", "Visual Studio 2015\nVisual Studio 2017");
 	addChildElementWithOptions(*xml, (int)Attributes::UseIPP, "Yes", "Use IPP", "Yes\nNo");
+    addChildElementWithOptions(*xml, (int)Attributes::EmbedImages, "Only Referenced Images", "Embed Images in Binary", "Only Referenced Images\nAll Images");
 
 	return xml;
 }

--- a/hi_core/hi_core/SettingsWindows.h
+++ b/hi_core/hi_core/SettingsWindows.h
@@ -202,6 +202,7 @@ public:
 			HisePath = (int)ProjectSettingWindow::Attributes::numAttributes,
 			VisualStudioVersion,
 			UseIPP,
+            EmbedImages,
 			numCompilerSettingAttributes
 		};
 


### PR DESCRIPTION
This new compiler option allows scripts to reference images from the `Images` folder in an exported binary (tested as plugin or standalone), even if the images are not statically referenced in an interface, which should make it easier to dynamically switch images at runtime.

![image](https://user-images.githubusercontent.com/213293/34950918-8df50fb6-f9e2-11e7-88c4-90681ee5e0fa.png)
