### PR TITLE
Take lock while iterating over voices array in ModulatorSynth::enablePitchModulation.

### DIFF
--- a/hi_dsp/modules/ModulatorSynth.cpp
+++ b/hi_dsp/modules/ModulatorSynth.cpp
@@ -935,9 +935,12 @@ void ModulatorSynth::enablePitchModulation(bool shouldBeEnabled)
 
 	if (allowEmptyPitchValues() || shouldBeEnabled)
 	{
+        // Take this lock on the Synthesizer while we iterate over voices, to prevent anyone
+        // else from modifying the array during that time.
+        const ScopedLock sl (lock);
 		for (int i = 0; i < voices.size(); i++)
 		{
-			static_cast<ModulatorSynthVoice*>(getVoice(i))->enablePitchModulation(shouldBeEnabled);
+            static_cast<ModulatorSynthVoice*>(getVoice(i))->enablePitchModulation(shouldBeEnabled);
 		}
 	}
 }

--- a/hi_dsp/modules/ModulatorSynth.cpp
+++ b/hi_dsp/modules/ModulatorSynth.cpp
@@ -935,12 +935,12 @@ void ModulatorSynth::enablePitchModulation(bool shouldBeEnabled)
 
 	if (allowEmptyPitchValues() || shouldBeEnabled)
 	{
-        // Take this lock on the Synthesizer while we iterate over voices, to prevent anyone
-        // else from modifying the array during that time.
-        const ScopedLock sl (lock);
+		// Take this lock on the Synthesizer while we iterate over voices, to prevent anyone
+		// else from modifying the array during that time.
+		const ScopedLock sl (lock);
 		for (int i = 0; i < voices.size(); i++)
 		{
-            static_cast<ModulatorSynthVoice*>(getVoice(i))->enablePitchModulation(shouldBeEnabled);
+			static_cast<ModulatorSynthVoice*>(getVoice(i))->enablePitchModulation(shouldBeEnabled);
 		}
 	}
 }


### PR DESCRIPTION
This should fix https://github.com/christophhart/HISE/issues/87, although I'm not sure if it's the most performant or correct way to do so.