### PR TITLE
Replaced ScopedPointer, removed using namespace, updated to juce6 API

### DIFF
--- a/hi_lac/hi_lac.h
+++ b/hi_lac/hi_lac.h
@@ -74,7 +74,7 @@ SampleMap bugs:
 #define HI_LAC_INCLUDED
 
 #include "AppConfig.h"
-#include "../JUCE/modules/juce_audio_formats/juce_audio_formats.h"
+#include "juce_audio_formats/juce_audio_formats.h"
 
 // This is the current HLAC version. HLAC has full backward compatibility.
 #define HLAC_VERSION 3

--- a/hi_lac/hlac/BitCompressors.cpp
+++ b/hi_lac/hlac/BitCompressors.cpp
@@ -30,7 +30,7 @@
  *   ===========================================================================
  */
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 void printRuler()
 {
@@ -53,7 +53,7 @@ void printBinary(int val)
 }
 #endif
 
-void printBinary(int16 val)
+void printBinary(int16_t val)
 {
 	int i;
 	char str[17];
@@ -65,10 +65,10 @@ void printBinary(int16 val)
 }
 
 
-uint16 compressInt16(int16 input, int bitDepth)
+uint16_t compressInt16(int16_t input, int bitDepth)
 {
 	const int a = (1 << (bitDepth - 1)) - 1;
-	return (uint16)((int)input + a);
+	return (uint16_t)((int)input + a);
 }
 
 #if USE_SSE
@@ -86,12 +86,12 @@ void compressInt16Block(int16* input, int16* output, int bitDepth, int numToComp
 }
 #endif
 
-constexpr uint16 getBitMask(int bitDepth) { return (1 << (bitDepth - 1)) - 1; }
+constexpr uint16_t getBitMask(int bitDepth) { return (1 << (bitDepth - 1)) - 1; }
 
-int16 decompressUInt16(uint16 input, int bitDepth)
+int16_t decompressUInt16(uint16_t input, int bitDepth)
 {
-	const int16 sub = (1 << (bitDepth - 1)) - 1;
-	return (int16)input - sub;
+	const int16_t sub = (1 << (bitDepth - 1)) - 1;
+	return (int16_t)input - sub;
 }
 
 #if USE_SSE
@@ -113,7 +113,7 @@ void decompressInt16Block(int16* input, int16* output, uint8 bitDepth, int numTo
 }
 #endif
 
-void packArrayOfInt16(int16* d, int numValues, uint8 bitDepth)
+void packArrayOfInt16(int16_t* d, int numValues, uint8_t bitDepth)
 {
 	for (int i = 0; i < numValues; i++)
 	{
@@ -122,9 +122,9 @@ void packArrayOfInt16(int16* d, int numValues, uint8 bitDepth)
 }
 
 
-void unpackArrayOfInt16(int16* d, int /*numValues*/, uint8 bitDepth)
+void unpackArrayOfInt16(int16_t* d, int /*numValues*/, uint8_t bitDepth)
 {
-	jassert(reinterpret_cast<uint64>(d) % 16 == 0);
+	jassert(reinterpret_cast<uint64_t>(d) % 16 == 0);
 
 #if HI_ENABLE_LEGACY_CPU_SUPPORT || !JUCE_WINDOWS
 	for (int i = 0; i < 8; i++)
@@ -153,23 +153,23 @@ int BitCompressors::ZeroBit::getAllowedBitRange() const
 	return 0;
 }
 
-bool BitCompressors::ZeroBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::ZeroBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
-	ignoreUnused(destination, data, numValues);
+    juce::ignoreUnused(destination, data, numValues);
 
 	return true;
 }
 
-bool BitCompressors::ZeroBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::ZeroBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
-	ignoreUnused(destination, data, numValuesToDecompress);
+    juce::ignoreUnused(destination, data, numValuesToDecompress);
 
 	return true;
 }
 
 int BitCompressors::ZeroBit::getByteAmount(int numValuesToCompress)
 {
-	ignoreUnused(numValuesToCompress);
+    juce::ignoreUnused(numValuesToCompress);
 
 	return 0;
 }
@@ -180,13 +180,13 @@ int BitCompressors::OneBit::getAllowedBitRange() const
 	return 1;
 }
 
-bool BitCompressors::OneBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::OneBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
-	const int16 mask = 0b0000000000000001;
+	const int16_t mask = 0b0000000000000001;
 
 	while (numValues >= 8)
 	{
-		uint8 target = 0;
+		uint8_t target = 0;
 
 		target |= (*data++ & mask);
 		target |= ((*data++ & mask) << 1);
@@ -204,7 +204,7 @@ bool BitCompressors::OneBit::compress(uint8* destination, const int16* data, int
 
 	if (numValues != 0)
 	{
-		uint8 lastByte = 0;
+		uint8_t lastByte = 0;
 		int shiftAmount = 0;
 
 		while (--numValues >= 0)
@@ -221,14 +221,14 @@ bool BitCompressors::OneBit::compress(uint8* destination, const int16* data, int
 
 
 
-bool BitCompressors::OneBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::OneBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
-	const uint8 masks[8] = { 0b00000001, 0b00000010, 0b00000100, 0b00001000,
+	const uint8_t masks[8] = { 0b00000001, 0b00000010, 0b00000100, 0b00001000,
 		0b00010000, 0b00100000, 0b01000000, 0b10000000 };
 
 	while (numValuesToDecompress >= 8)
 	{
-		const uint8 byte = *data;
+		const uint8_t byte = *data;
 
 		*destination++ = byte & masks[0];
 		*destination++ = (byte & masks[1]) >> 1;
@@ -246,7 +246,7 @@ bool BitCompressors::OneBit::decompress(int16* destination, const uint8* data, i
 	if (numValuesToDecompress > 0)
 	{
 		int maskIndex = 0;
-		uint8 lastByte = *data;
+		uint8_t lastByte = *data;
 
 		while (--numValuesToDecompress >= 0)
 		{
@@ -269,27 +269,27 @@ int BitCompressors::TwoBit::getAllowedBitRange() const
 	return 2;
 }
 
-bool BitCompressors::TwoBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::TwoBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
-	const uint16 signMask =  0b1000000000000000;
-	const uint16 valueMask = 0b0000000000000001;
-	const uint16 valueMovedMask = 0b0000000000000010;
+	const uint16_t signMask =  0b1000000000000000;
+	const uint16_t valueMask = 0b0000000000000001;
+	const uint16_t valueMovedMask = 0b0000000000000010;
 
 	while (numValues >= 4)
 	{
-		uint8 target = 0;
+		uint8_t target = 0;
 
-		const int16 value1 = *data++;
+		const int16_t value1 = *data++;
 		
 		target |= (value1 & valueMask) | ((value1 & signMask) != 0 ? valueMovedMask : 0);
 
-		const int16 value2 = *data++;
+		const int16_t value2 = *data++;
 		target |= (((value2 & valueMask) | ((value2 & signMask) != 0 ? valueMovedMask : 0)) << 2);
 
-		const int16 value3 = *data++;
+		const int16_t value3 = *data++;
 		target |= (((value3 & valueMask) | ((value3 & signMask) != 0 ? valueMovedMask : 0)) << 4);
 
-		const int16 value4 = *data++;
+		const int16_t value4 = *data++;
 		target |= (((value4 & valueMask) | ((value4 & signMask) != 0 ? valueMovedMask : 0)) << 6);
 
 		numValues -= 4;
@@ -299,12 +299,12 @@ bool BitCompressors::TwoBit::compress(uint8* destination, const int16* data, int
 
 	if (numValues != 0)
 	{
-		uint8 lastByte = 0;
+		uint8_t lastByte = 0;
 		int shiftAmount = 0;
 
 		while (--numValues >= 0)
 		{
-			const int16 value = *data++;
+			const int16_t value = *data++;
 
 			lastByte |= (((value & valueMask) | ((value & signMask) != 0 ? valueMovedMask : 0)) << (2*shiftAmount++));
 		}
@@ -316,32 +316,32 @@ bool BitCompressors::TwoBit::compress(uint8* destination, const int16* data, int
 	return true;
 }
 
-bool BitCompressors::TwoBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::TwoBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
-	const uint8 signMasks[4] =  { 0b00000010, 0b00001000, 0b00100000, 0b10000000 };
-	const uint8 valueMasks[4] = { 0b00000001, 0b00000100, 0b00010000, 0b01000000 };
+	const uint8_t signMasks[4] =  { 0b00000010, 0b00001000, 0b00100000, 0b10000000 };
+	const uint8_t valueMasks[4] = { 0b00000001, 0b00000100, 0b00010000, 0b01000000 };
 
 	while (numValuesToDecompress >= 4)
 	{
-		const uint8 byte = *data;
+		const uint8_t byte = *data;
 
-		const int16 sign1 = ((byte & signMasks[0]) != 0) ? -1 : 1;
-		const int16 value1 = (int16)(byte & valueMasks[0]);
+		const int16_t sign1 = ((byte & signMasks[0]) != 0) ? -1 : 1;
+		const int16_t value1 = (int16_t)(byte & valueMasks[0]);
 
 		*destination++ = value1 * sign1;
 
-		const int16 sign2 = ((byte & signMasks[1]) != 0) ? -1 : 1;
-		const int16 value2 = (int16)((byte & valueMasks[1]) >> 2);
+		const int16_t sign2 = ((byte & signMasks[1]) != 0) ? -1 : 1;
+		const int16_t value2 = (int16_t)((byte & valueMasks[1]) >> 2);
 
 		*destination++ = value2 * sign2;
 
-		const int16 sign3 = ((byte & signMasks[2]) != 0) ? -1 : 1;
-		const int16 value3 = (int16)((byte & valueMasks[2]) >> 4);
+		const int16_t sign3 = ((byte & signMasks[2]) != 0) ? -1 : 1;
+		const int16_t value3 = (int16_t)((byte & valueMasks[2]) >> 4);
 
 		*destination++ = value3 * sign3;
 
-		const int16 sign4 = ((byte & signMasks[3]) != 0) ? -1 : 1;
-		*destination++ = (int16)((byte & valueMasks[3]) >> 6) * sign4;
+		const int16_t sign4 = ((byte & signMasks[3]) != 0) ? -1 : 1;
+		*destination++ = (int16_t)((byte & valueMasks[3]) >> 6) * sign4;
 
 		numValuesToDecompress -= 4;
 		++data;
@@ -351,12 +351,12 @@ bool BitCompressors::TwoBit::decompress(int16* destination, const uint8* data, i
 	{
 		int maskIndex = 0;
 		
-		uint8 lastByte = *data;
+		uint8_t lastByte = *data;
 
 		while (--numValuesToDecompress >= 0)
 		{
-			const int16 sign = ((lastByte & signMasks[maskIndex]) != 0) ? -1 : 1;
-			*destination++ = (int16)((lastByte & valueMasks[maskIndex]) >> (maskIndex*2)) * sign;
+			const int16_t sign = ((lastByte & signMasks[maskIndex]) != 0) ? -1 : 1;
+			*destination++ = (int16_t)((lastByte & valueMasks[maskIndex]) >> (maskIndex*2)) * sign;
             
             ++maskIndex;
 		}
@@ -381,28 +381,28 @@ int BitCompressors::FourBit::getAllowedBitRange() const
 	return 4;
 }
 
-bool BitCompressors::FourBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::FourBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
-	const uint16 valueMovedMask = 0b0000000000001000;
+	const uint16_t valueMovedMask = 0b0000000000001000;
 
 
 	while (numValues >= 2)
 	{
-		uint16 target;
+		uint16_t target;
 
-		const int16 value1 = *data++;
-		const int16 absValue1 = (int16)abs(value1);
+		const int16_t value1 = *data++;
+		const int16_t absValue1 = (int16_t)abs(value1);
 
-		const int16 signMask1 = (value1 != absValue1) ? valueMovedMask : 0;
+		const int16_t signMask1 = (value1 != absValue1) ? valueMovedMask : 0;
 		target = (absValue1 | signMask1);
 
-		const int16 value2 = *data++;
-		const int16 absValue2 = (int16)abs(value2);
-		const int16 signMask2 = (value2 != absValue2) ? valueMovedMask : 0;
+		const int16_t value2 = *data++;
+		const int16_t absValue2 = (int16_t)abs(value2);
+		const int16_t signMask2 = (value2 != absValue2) ? valueMovedMask : 0;
 
 		target |= ((absValue2 | signMask2) << 4);
 
-		*destination++ = (uint8)target;
+		*destination++ = (uint8_t)target;
 
 		numValues -= 2;
 
@@ -411,42 +411,42 @@ bool BitCompressors::FourBit::compress(uint8* destination, const int16* data, in
 
 	if (numValues != 0)
 	{
-		uint16 lastByte = 0;
+		uint16_t lastByte = 0;
 		
 		while (--numValues >= 0)
 		{
-			const int16 value1 = *data++;
-			const int16 absValue1 = (int16)abs(value1);
+			const int16_t value1 = *data++;
+			const int16_t absValue1 = (int16_t)abs(value1);
 
-			const int16 signMask1 = (value1 != absValue1) ? valueMovedMask : 0;
+			const int16_t signMask1 = (value1 != absValue1) ? valueMovedMask : 0;
 			lastByte = (absValue1 | signMask1);
 		}
 
-		*destination = (uint8)lastByte;
+		*destination = (uint8_t)lastByte;
 	}
 
 
 	return true;
 }
 
-bool BitCompressors::FourBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::FourBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
 	
 
-	const uint8 signMasks[2] =  { 0b00001000, 0b10000000 };
-	const uint8 valueMasks[2] = { 0b00000111, 0b01110000 };
+	const uint8_t signMasks[2] =  { 0b00001000, 0b10000000 };
+	const uint8_t valueMasks[2] = { 0b00000111, 0b01110000 };
 
 	while (numValuesToDecompress >= 2)
 	{
-		const uint8 byte = *data;
+		const uint8_t byte = *data;
 
-		const int16 sign1 = ((byte & signMasks[0]) != 0) ? -1 : 1;
-		const int16 value1 = (int16)(byte & valueMasks[0]);
+		const int16_t sign1 = ((byte & signMasks[0]) != 0) ? -1 : 1;
+		const int16_t value1 = (int16_t)(byte & valueMasks[0]);
 
 		*destination++ = value1 * sign1;
 
-		const int16 sign2 = ((byte & signMasks[1]) != 0) ? -1 : 1;
-		const int16 value2 = (int16)((byte & valueMasks[1]) >> 4);
+		const int16_t sign2 = ((byte & signMasks[1]) != 0) ? -1 : 1;
+		const int16_t value2 = (int16_t)((byte & valueMasks[1]) >> 4);
 
 		*destination++ = value2 * sign2;
 
@@ -456,12 +456,12 @@ bool BitCompressors::FourBit::decompress(int16* destination, const uint8* data, 
 
 	if (numValuesToDecompress > 0)
 	{
-		uint8 lastByte = *data;
+		uint8_t lastByte = *data;
 
 		while (--numValuesToDecompress >= 0)
 		{
-			const int16 sign1 = ((lastByte & signMasks[0]) != 0) ? -1 : 1;
-			const int16 value1 = (int16)(lastByte & valueMasks[0]);
+			const int16_t sign1 = ((lastByte & signMasks[0]) != 0) ? -1 : 1;
+			const int16_t value1 = (int16_t)(lastByte & valueMasks[0]);
 
 			*destination++ = value1 * sign1;
 		}
@@ -479,11 +479,11 @@ int BitCompressors::FourBit::getByteAmount(int numValuesToCompress)
 }
 
 
-void compress6Bit(uint8* sixBytes, const int16* eightValues)
+void compress6Bit(uint8_t* sixBytes, const int16_t* eightValues)
 {
-	uint16* threeShorts = reinterpret_cast<uint16*>(sixBytes);
+	uint16_t* threeShorts = reinterpret_cast<uint16_t*>(sixBytes);
 
-	int16 pData[8];
+	int16_t pData[8];
 	memcpy(pData, eightValues, 16);
 
 	packArrayOfInt16(pData, 8, 6);
@@ -500,9 +500,9 @@ void compress6Bit(uint8* sixBytes, const int16* eightValues)
 	threeShorts[2] |= pData[7];
 }
 
-void decompress6Bit(int16* eightValues, const uint8* sixBytes)
+void decompress6Bit(int16_t* eightValues, const uint8_t* sixBytes)
 {
-	const uint16* dataBlock = reinterpret_cast<const uint16*>(sixBytes);
+	const uint16_t* dataBlock = reinterpret_cast<const uint16_t*>(sixBytes);
 
 	eightValues[0] = (dataBlock[0] & 0b1111110000000000) >> 10;
 	eightValues[1] = (dataBlock[0] & 0b0000001111110000) >> 4;
@@ -524,7 +524,7 @@ int BitCompressors::SixBit::getAllowedBitRange() const
 }
 
 
-bool BitCompressors::SixBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::SixBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
 
 	while (numValues >= 8)
@@ -536,12 +536,12 @@ bool BitCompressors::SixBit::compress(uint8* destination, const int16* data, int
 		numValues -= 8;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValues);
+	memcpy(destination, data, sizeof(int16_t) * numValues);
 
 	return true;
 }
 
-bool BitCompressors::SixBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::SixBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
 #if JUCE_IOS
 	while (numValuesToDecompress >= 8)
@@ -556,7 +556,7 @@ bool BitCompressors::SixBit::decompress(int16* destination, const uint8* data, i
 
 	while (numValuesToDecompress >= 64)
 	{
-		const uint16* dataBlock = reinterpret_cast<const uint16*>(data);
+		const uint16_t* dataBlock = reinterpret_cast<const uint16_t*>(data);
 
 		destination[0] = (dataBlock[0] & 0b1111110000000000) >> 10;
 		destination[1] = (dataBlock[0] & 0b0000001111110000) >> 4;
@@ -670,7 +670,7 @@ bool BitCompressors::SixBit::decompress(int16* destination, const uint8* data, i
 	}
 #endif
 
-	memcpy(destination, data, sizeof(int16) * numValuesToDecompress);
+	memcpy(destination, data, sizeof(int16_t) * numValuesToDecompress);
 
 	return true;
 }
@@ -691,22 +691,22 @@ int BitCompressors::EightBit::getAllowedBitRange() const
 	return 8;
 }
 
-bool BitCompressors::EightBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::EightBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
 	while (--numValues >= 0)
 	{
-		*destination++ = (uint8)*data++;
+		*destination++ = (uint8_t)*data++;
 	}
 
 	return true;
 }
 
-bool BitCompressors::EightBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::EightBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
     while (--numValuesToDecompress >= 0)
 	{
-		const int8 value = *reinterpret_cast<const int8*>(data++);
-		*destination++ = (int16)value;
+		const int8_t value = *reinterpret_cast<const int8_t*>(data++);
+		*destination++ = (int16_t)value;
 	}
 
 	return true;
@@ -717,9 +717,9 @@ int BitCompressors::EightBit::getByteAmount(int numValuesToCompress)
 	return numValuesToCompress;
 }
 
-void compress10Bit(void* tenBytes, const int16* eightValues)
+void compress10Bit(void* tenBytes, const int16_t* eightValues)
 {
-	uint16 pData[8];
+	uint16_t pData[8];
 
 	pData[0] = compressInt16(eightValues[0], 10);
 	pData[1] = compressInt16(eightValues[1], 10);
@@ -731,7 +731,7 @@ void compress10Bit(void* tenBytes, const int16* eightValues)
 	pData[7] = compressInt16(eightValues[7], 10);
 
 
-	uint16* fiveShorts = reinterpret_cast<uint16*>(tenBytes);
+	uint16_t* fiveShorts = reinterpret_cast<uint16_t*>(tenBytes);
 
 	fiveShorts[0] = pData[0] << 6;
 	fiveShorts[0] |= pData[1] >> 4;
@@ -747,9 +747,9 @@ void compress10Bit(void* tenBytes, const int16* eightValues)
 	fiveShorts[4] |= pData[7];
 }
 
-void decompress10Bit(uint16* eightValues, void* tenBytes)
+void decompress10Bit(uint16_t* eightValues, void* tenBytes)
 {
-	const uint16* dataBlock = reinterpret_cast<const uint16*>(tenBytes);
+	const uint16_t* dataBlock = reinterpret_cast<const uint16_t*>(tenBytes);
 
 	eightValues[0] = (dataBlock[0] & 0b1111111111000000) >> 6;
 	eightValues[1] = (dataBlock[0] & 0b0000000000111111) << 4;
@@ -764,7 +764,7 @@ void decompress10Bit(uint16* eightValues, void* tenBytes)
 	eightValues[6] |= (dataBlock[4] & 0b1111110000000000) >> 10;
 	eightValues[7] = (dataBlock[4] & 0b0000001111111111);
 
-	unpackArrayOfInt16(reinterpret_cast<int16*>(eightValues), 8, 10);
+	unpackArrayOfInt16(reinterpret_cast<int16_t*>(eightValues), 8, 10);
 }
 
 int BitCompressors::TenBit::getAllowedBitRange() const
@@ -772,7 +772,7 @@ int BitCompressors::TenBit::getAllowedBitRange() const
 	return 10;
 }
 
-bool BitCompressors::TenBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::TenBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
 	while (numValues >= 8)
 	{
@@ -783,23 +783,23 @@ bool BitCompressors::TenBit::compress(uint8* destination, const int16* data, int
 		numValues -= 8;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValues);
+	memcpy(destination, data, sizeof(int16_t) * numValues);
 
 	return true;
 }
 
-bool BitCompressors::TenBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::TenBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
 	while (numValuesToDecompress >= 8)
 	{
-		decompress10Bit(reinterpret_cast<uint16*>(destination), (void*)data);
+		decompress10Bit(reinterpret_cast<uint16_t*>(destination), (void*)data);
 
 		destination += 8;
 		data += 10;
 		numValuesToDecompress -= 8;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValuesToDecompress);
+	memcpy(destination, data, sizeof(int16_t) * numValuesToDecompress);
 
 	return true;
 }
@@ -818,16 +818,16 @@ int BitCompressors::TwelveBit::getAllowedBitRange() const
 }
 
 
-bool BitCompressors::TwelveBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::TwelveBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
 	while (numValues >= 4)
 	{
-		const uint16 v1 = compressInt16(data[0], 12);
-		const uint16 v2 = compressInt16(data[1], 12);
-		const uint16 v3 = compressInt16(data[2], 12);
-		const uint16 v4 = compressInt16(data[3], 12);
+		const uint16_t v1 = compressInt16(data[0], 12);
+		const uint16_t v2 = compressInt16(data[1], 12);
+		const uint16_t v3 = compressInt16(data[2], 12);
+		const uint16_t v4 = compressInt16(data[3], 12);
 
-		uint16* dataBlock = reinterpret_cast<uint16*>(destination);
+		auto* dataBlock = reinterpret_cast<uint16_t*>(destination);
 
 		dataBlock[0] = v1 << 4;
 		dataBlock[0] |= v2 >> 8;
@@ -841,12 +841,12 @@ bool BitCompressors::TwelveBit::compress(uint8* destination, const int16* data, 
 		numValues -= 4;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValues);
+	memcpy(destination, data, sizeof(int16_t) * numValues);
 
 	return true;
 }
 
-bool BitCompressors::TwelveBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::TwelveBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
 #if USE_SSE
 
@@ -884,11 +884,11 @@ bool BitCompressors::TwelveBit::decompress(int16* destination, const uint8* data
 
 #else
 
-	int16* dst = destination;
+	auto* dst = destination;
 
 	while (numValuesToDecompress >= 4)
 	{
-		const uint16* dataBlock = reinterpret_cast<const uint16*>(data);
+		const auto* dataBlock = reinterpret_cast<const uint16_t*>(data);
 
 		dst[0] = (dataBlock[0] & 0b1111111111110000) >> 4;
 		dst[1] = (dataBlock[0] & 0b0000000000001111) << 8;
@@ -910,7 +910,7 @@ bool BitCompressors::TwelveBit::decompress(int16* destination, const uint8* data
 	
 	destination = dst;
 
-	memcpy(destination, data, sizeof(int16) * numValuesToDecompress);
+	memcpy(destination, data, sizeof(int16_t) * numValuesToDecompress);
 
 #endif
 
@@ -933,11 +933,11 @@ int BitCompressors::TwelveBit::getByteAmount(int numValuesToCompress)
 
 
 
-void compress14Bit(uint8* fourteenBytes, const int16* eightValues)
+void compress14Bit(uint8_t* fourteenBytes, const int16_t* eightValues)
 {
-	uint16* sevenShorts = reinterpret_cast<uint16*>(fourteenBytes);
+	auto* sevenShorts = reinterpret_cast<uint16_t*>(fourteenBytes);
 
-	int16 pData[8];
+	int16_t pData[8];
 	memcpy(pData, eightValues, 16);
 
 	packArrayOfInt16(pData, 8, 14);
@@ -958,9 +958,9 @@ void compress14Bit(uint8* fourteenBytes, const int16* eightValues)
 	sevenShorts[6] |= pData[7];
 }
 
-void decompress14Bit(int16* eightValues, const uint8* fourteenBytes)
+void decompress14Bit(int16_t* eightValues, const uint8_t* fourteenBytes)
 {
-	const uint16* dataBlock = reinterpret_cast<const uint16*>(fourteenBytes);
+	const auto* dataBlock = reinterpret_cast<const uint16_t*>(fourteenBytes);
 
 	eightValues[0] = (dataBlock[0] & 0b1111111111111100) >> 2;
 	eightValues[1] = (dataBlock[0] & 0b0000000000000011) << 12;
@@ -985,7 +985,7 @@ int BitCompressors::FourteenBit::getAllowedBitRange() const
 	return 14;
 }
 
-bool BitCompressors::FourteenBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::FourteenBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
 	while (numValues >= 8)
 	{
@@ -995,12 +995,12 @@ bool BitCompressors::FourteenBit::compress(uint8* destination, const int16* data
 		numValues -= 8;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValues);
+	memcpy(destination, data, sizeof(int16_t) * numValues);
 
 	return true;
 }
 
-bool BitCompressors::FourteenBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::FourteenBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
 	while (numValuesToDecompress >= 8)
 	{
@@ -1011,7 +1011,7 @@ bool BitCompressors::FourteenBit::decompress(int16* destination, const uint8* da
 		numValuesToDecompress -= 8;
 	}
 
-	memcpy(destination, data, sizeof(int16) * numValuesToDecompress);
+	memcpy(destination, data, sizeof(int16_t) * numValuesToDecompress);
 
 	return true;
 }
@@ -1032,30 +1032,30 @@ int BitCompressors::SixteenBit::getAllowedBitRange() const
 	return 16;
 }
 
-bool BitCompressors::SixteenBit::compress(uint8* destination, const int16* data, int numValues)
+bool BitCompressors::SixteenBit::compress(uint8_t* destination, const int16_t* data, int numValues)
 {
-	memcpy(destination, data, sizeof(int16) * numValues);
+	memcpy(destination, data, sizeof(int16_t) * numValues);
 	return true;
 }
 
-bool BitCompressors::SixteenBit::decompress(int16* destination, const uint8* data, int numValuesToDecompress)
+bool BitCompressors::SixteenBit::decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress)
 {
-	memcpy(destination, data, sizeof(int16) * numValuesToDecompress);
+	memcpy(destination, data, sizeof(int16_t) * numValuesToDecompress);
 	return true;
 }
 
 int BitCompressors::SixteenBit::getByteAmount(int numValuesToCompress)
 {
-	return numValuesToCompress * sizeof(int16);
+	return numValuesToCompress * sizeof(int16_t);
 }
 
 
 
 
 
-uint8 BitCompressors::getMinBitDepthForData(const int16* data, int numValues, int8 expectedBitDepth)
+uint8_t BitCompressors::getMinBitDepthForData(const int16_t* data, int numValues, int8_t expectedBitDepth)
 {
-	ignoreUnused(expectedBitDepth);
+    juce::ignoreUnused(expectedBitDepth);
 
 	bool isZero = true;
 
@@ -1090,11 +1090,11 @@ uint8 BitCompressors::getMinBitDepthForData(const int16* data, int numValues, in
 		return 1;
 	}
 
-	for (uint8 bitDepth = 2; bitDepth < 16; bitDepth++)
+	for (uint8_t bitDepth = 2; bitDepth < 16; bitDepth++)
 	{
 		bool canBeCompressed = true;
 
-		const uint16 mask = getBitMask(bitDepth);
+		const uint16_t mask = getBitMask(bitDepth);
 
 		for (int i = 0; i < numValues; i++)
 		{
@@ -1122,12 +1122,12 @@ uint8 BitCompressors::getMinBitDepthForData(const int16* data, int numValues, in
 	return 16;
 }
 
-BitCompressors::Base* BitCompressors::Collection::getSuitableCompressorForBitRate(uint8 bitRate)
+BitCompressors::Base* BitCompressors::Collection::getSuitableCompressorForBitRate(uint8_t bitRate)
 {
 	return compressors[bitRate];
 }
 
-BitCompressors::Base* BitCompressors::Collection::getSuitableCompressorForData(const int16* data, int numValues)
+BitCompressors::Base* BitCompressors::Collection::getSuitableCompressorForData(const int16_t* data, int numValues)
 {
 	auto bitDepth = getMinBitDepthForData(data, numValues);
 
@@ -1155,7 +1155,7 @@ BitCompressors::Base* BitCompressors::Collection::getSuitableCompressorForData(c
 	return nullptr;
 }
 
-int BitCompressors::Collection::getNumBytesForBitRate(uint8 bitRate, int elements)
+int BitCompressors::Collection::getNumBytesForBitRate(uint8_t bitRate, int elements)
 {
 	if (useOddCompressors)
 	{

--- a/hi_lac/hlac/BitCompressors.h
+++ b/hi_lac/hlac/BitCompressors.h
@@ -34,7 +34,7 @@
 #ifndef BITCOMPRESSORS_H_INCLUDED
 #define BITCOMPRESSORS_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 #define LOG_RATIO(x) 
 
@@ -52,9 +52,9 @@ struct BitCompressors
 		virtual ~Base() {};
 
 		virtual int getAllowedBitRange() const { return -1; };
-		virtual bool compress(uint8* destination, const int16* data, int numValues) { ignoreUnused(destination, data, numValues); return false; }
-		virtual bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) { ignoreUnused(destination, data, numValuesToDecompress); return false; }
-		virtual int getByteAmount(int numValuesToCompress) { ignoreUnused(numValuesToCompress); return 0; };
+		virtual bool compress(uint8_t* destination, const int16_t* data, int numValues) { juce::ignoreUnused(destination, data, numValues); return false; }
+		virtual bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) { juce::ignoreUnused(destination, data, numValuesToDecompress); return false; }
+		virtual int getByteAmount(int numValuesToCompress) { juce::ignoreUnused(numValuesToCompress); return 0; };
 	};
 
 	struct Collection
@@ -83,11 +83,11 @@ struct BitCompressors
 			compressors.add(new SixteenBit());
 		}
 
-		Base* getSuitableCompressorForBitRate(uint8 bitRate);
+		Base* getSuitableCompressorForBitRate(uint8_t bitRate);
 
-		Base* getSuitableCompressorForData(const int16* data, int numValues);
+		Base* getSuitableCompressorForData(const int16_t* data, int numValues);
 
-		int getNumBytesForBitRate(uint8 bitRate, int elements);
+		int getNumBytesForBitRate(uint8_t bitRate, int elements);
 
 	private:
 
@@ -98,26 +98,26 @@ struct BitCompressors
 
 		bool useOddCompressors = true;
 
-		OwnedArray<Base> compressors;
+        juce::OwnedArray<Base> compressors;
 	};
 
 
-	static uint8 getMinBitDepthForData(const int16* data, int numValues, int8 expectedBitDepth = -1);
+	static uint8_t getMinBitDepthForData(const int16_t* data, int numValues, int8_t expectedBitDepth = -1);
 
 
 	struct ZeroBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;;
 		int getByteAmount(int numValuesToCompress) override;;
 	};
 
 	struct OneBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;;
 		int getByteAmount(int numValuesToCompress) override;;
 		
 	};
@@ -125,40 +125,40 @@ struct BitCompressors
 	struct TwoBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
 	struct FourBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
 	struct SixBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
 	struct EightBit: public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
 	struct TenBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
@@ -179,8 +179,8 @@ struct BitCompressors
 #endif
 
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 
 #if USE_SSE
@@ -193,16 +193,16 @@ struct BitCompressors
 	struct FourteenBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 
 	struct SixteenBit : public Base
 	{
 		int getAllowedBitRange() const override;
-		bool compress(uint8* destination, const int16* data, int numValues) override;
-		bool decompress(int16* destination, const uint8* data, int numValuesToDecompress) override;
+		bool compress(uint8_t* destination, const int16_t* data, int numValues) override;
+		bool decompress(int16_t* destination, const uint8_t* data, int numValuesToDecompress) override;
 		int getByteAmount(int numValuesToCompress) override;
 	};
 

--- a/hi_lac/hlac/CompressionHelpers.cpp
+++ b/hi_lac/hlac/CompressionHelpers.cpp
@@ -30,9 +30,9 @@
  *   ===========================================================================
  */
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
-CompressionHelpers::AudioBufferInt16::AudioBufferInt16(AudioSampleBuffer& b, int channelToUse, uint8 normalizeBeforeStoring, uint8 normalisationThreshold)
+CompressionHelpers::AudioBufferInt16::AudioBufferInt16(juce::AudioSampleBuffer& b, int channelToUse, uint8_t normalizeBeforeStoring, uint8_t normalisationThreshold)
 {
 	allocate(b.getNumSamples());
 	
@@ -45,11 +45,11 @@ CompressionHelpers::AudioBufferInt16::AudioBufferInt16(AudioSampleBuffer& b, int
 	}
 	else
 	{
-		AudioDataConverters::convertFloatToInt16LE(b.getReadPointer(channelToUse), data, b.getNumSamples());
+        juce::AudioDataConverters::convertFloatToInt16LE(b.getReadPointer(channelToUse), data, b.getNumSamples());
 	}
 }
 
-CompressionHelpers::AudioBufferInt16::AudioBufferInt16(int16* externalData_, int numSamples)
+CompressionHelpers::AudioBufferInt16::AudioBufferInt16(int16_t* externalData_, int numSamples)
 {
 	size = numSamples;
 
@@ -58,10 +58,10 @@ CompressionHelpers::AudioBufferInt16::AudioBufferInt16(int16* externalData_, int
 	externalData = externalData_;
 }
 
-CompressionHelpers::AudioBufferInt16::AudioBufferInt16(const int16* externalData_, int numSamples)
+CompressionHelpers::AudioBufferInt16::AudioBufferInt16(const int16_t* externalData_, int numSamples)
 {
 	size = numSamples;
-	externalData = const_cast<int16*>(externalData_);
+	externalData = const_cast<int16_t*>(externalData_);
 	isReadOnly = true;
 }
 
@@ -76,9 +76,9 @@ CompressionHelpers::AudioBufferInt16::~AudioBufferInt16()
 	deAllocate();
 }
 
-AudioSampleBuffer CompressionHelpers::AudioBufferInt16::getFloatBuffer() const
+juce::AudioSampleBuffer CompressionHelpers::AudioBufferInt16::getFloatBuffer() const
 {
-	AudioSampleBuffer b(1, size);
+    juce::AudioSampleBuffer b(1, size);
 
 	map.normalisedInt16ToFloat(b.getWritePointer(0), data, 0, size);
 
@@ -96,12 +96,12 @@ void CompressionHelpers::AudioBufferInt16::reverse(int startSample, int numSampl
 
 	for (int i = 0; i < numToReverse; i++)
 	{
-		int16 temp = *s;
+		int16_t temp = *s;
 		*s++ = *t;
 		*t-- = temp;
 	}
 
-	const int fadeLength = jmin<int>(500, numSamples-1);
+	const int fadeLength = juce::jmin<int>(500, numSamples-1);
 
 	auto s2 = getWritePointer(startSample + numSamples - fadeLength);
 	
@@ -109,7 +109,7 @@ void CompressionHelpers::AudioBufferInt16::reverse(int startSample, int numSampl
 
 	for (int i = 0; i < fadeLength; i++)
 	{
-		s2[i] = (int16)((float)s2[i] * g);
+		s2[i] = (int16_t)((float)s2[i] * g);
 		g -= 1.0f / (float)(fadeLength-1);
 	}
 
@@ -117,7 +117,7 @@ void CompressionHelpers::AudioBufferInt16::reverse(int startSample, int numSampl
 
 void CompressionHelpers::AudioBufferInt16::negate()
 {
-	int16* d = getWritePointer();
+	auto* d = getWritePointer();
 
 	for (int i = 0; i < size; i++)
 	{
@@ -128,9 +128,9 @@ void CompressionHelpers::AudioBufferInt16::negate()
 
 void CompressionHelpers::AudioBufferInt16::applyGainRamp(int startOffset, int rampLength, float startGain, float endGain)
 {
-	int16* d = getWritePointer(startOffset);
+	auto* d = getWritePointer(startOffset);
 
-	const int numToDo = jmin<int>(size - startOffset, rampLength);
+	const int numToDo = juce::jmin<int>(size - startOffset, rampLength);
 
 	const float delta = (endGain - startGain) / (float)(rampLength-1);
 
@@ -138,12 +138,12 @@ void CompressionHelpers::AudioBufferInt16::applyGainRamp(int startOffset, int ra
 
 	for (int i = 0; i < numToDo; i++)
 	{
-		d[i] = (int16)(level * (float)d[i]);
+		d[i] = (int16_t)(level * (float)d[i]);
 		level += delta;
 	}
 }
 
-int16* CompressionHelpers::AudioBufferInt16::getWritePointer(int startSample /*= 0*/)
+int16_t* CompressionHelpers::AudioBufferInt16::getWritePointer(int startSample /*= 0*/)
 {
 	jassert(startSample < size);
 
@@ -157,7 +157,7 @@ int16* CompressionHelpers::AudioBufferInt16::getWritePointer(int startSample /*=
 	return externalData != nullptr ? externalData + startSample : data + startSample;
 }
 
-const int16* CompressionHelpers::AudioBufferInt16::getReadPointer(int startSample /*= 0*/) const
+const int16_t* CompressionHelpers::AudioBufferInt16::getReadPointer(int startSample /*= 0*/) const
 {
 	jassert(startSample < size);
 	
@@ -171,15 +171,15 @@ void CompressionHelpers::AudioBufferInt16::allocate(int newNumSamples)
 	if (size != 0)
 	{
 #if  JUCE_WINDOWS
-		data = static_cast<int16*>(_aligned_malloc(size * sizeof(int16), 16));
+		data = static_cast<int16_t*>(_aligned_malloc(size * sizeof(int16_t), 16));
 #else
-        data = static_cast<int16*>(malloc(size * sizeof(int16)));
+        data = static_cast<int16_t*>(malloc(size * sizeof(int16_t)));
 #endif
 
         jassert(data != nullptr);
         
 		if (data != nullptr)
-			memset(data, 0, size * sizeof(int16));
+			memset(data, 0, size * sizeof(int16_t));
 		else
 			size = 0;
 	}
@@ -198,64 +198,57 @@ void CompressionHelpers::AudioBufferInt16::deAllocate()
 	}
 }
 
-AudioSampleBuffer CompressionHelpers::loadFile(const File& f, double& speed)
+juce::AudioSampleBuffer CompressionHelpers::loadFile(const juce::File& f, double& speed)
 {
 	if (!f.existsAsFile())
 	{
-		throw String("File " + f.getFullPathName() + " does not exist");
+		throw juce::String("File " + f.getFullPathName() + " does not exist");
 	}
 	
-	AudioFormatManager afm;
+    juce::AudioFormatManager afm;
 	afm.registerBasicFormats();
 
-	MemoryBlock mb;
+    juce::MemoryBlock mb;
 
-	FileInputStream fis(f);
+    juce::FileInputStream fis(f);
 
 	fis.readIntoMemoryBlock(mb);
 
+	std::unique_ptr<juce::InputStream> mis(new juce::MemoryInputStream(mb, false));
 
-	std::unique_ptr<InputStream> mis(new MemoryInputStream(mb, false));
+	auto reader = afm.createReaderFor(std::move(mis));
 
-	ScopedPointer<AudioFormatReader> reader = afm.createReaderFor(std::move(mis));
+	if (!reader)
+        throw juce::String("File " + f.getFileName() + " can not be opened");
 
-	if (reader != nullptr)
-	{
-		AudioSampleBuffer b(reader->numChannels, (int)reader->lengthInSamples);
+    juce::AudioSampleBuffer b(reader->numChannels, (int)reader->lengthInSamples);
 
-		double start = Time::getMillisecondCounterHiRes();
-		reader->read(&b, 0, (int)reader->lengthInSamples, 0, true, true);
-		double stop = Time::getMillisecondCounterHiRes();
-		
-		double sampleLength = reader->lengthInSamples / reader->sampleRate;
+    double start = juce::Time::getMillisecondCounterHiRes();
+    reader->read(&b, 0, (int)reader->lengthInSamples, 0, true, true);
+    double stop = juce::Time::getMillisecondCounterHiRes();
 
-		double delta = (stop - start) / 1000.0;
+    double sampleLength = reader->lengthInSamples / reader->sampleRate;
 
-		speed = sampleLength / delta;
+    double delta = (stop - start) / 1000.0;
 
-		
+    speed = sampleLength / delta;
 
-		return b;
-	}
-	else
-	{
-		throw String("File " + f.getFileName() + " can not be opened");
-	}
+    return b;
 }
 
-float CompressionHelpers::getFLACRatio(const File& f, double& speed)
+float CompressionHelpers::getFLACRatio(const juce::File& f, double& speed)
 {
-	FlacAudioFormat flac;
+    juce::FlacAudioFormat flac;
 
-	AudioFormatManager afm;
+    juce::AudioFormatManager afm;
 
 	afm.registerBasicFormats();
 
-	ScopedPointer<AudioFormatReader> reader = afm.createReaderFor(f);
+	auto reader = afm.createReaderFor(f);
 
-	MemoryOutputStream* mos = new MemoryOutputStream();
+    auto* mos = new juce::MemoryOutputStream();
 
-	ScopedPointer<AudioFormatWriter> writer = flac.createWriterFor(mos, reader->sampleRate, reader->numChannels, 16, reader->metadataValues, 5);
+	auto writer = flac.createWriterFor(mos, reader->sampleRate, reader->numChannels, 16, reader->metadataValues, 5);
 
 	writer->writeFromAudioReader(*reader, 0, reader->lengthInSamples);
 
@@ -263,17 +256,17 @@ float CompressionHelpers::getFLACRatio(const File& f, double& speed)
 
 	const int flacSize = (int)mos->getDataSize();
 
-	MemoryInputStream* mis = new MemoryInputStream(mos->getMemoryBlock(), true);
+	auto* mis = new juce::MemoryInputStream(mos->getMemoryBlock(), true);
 
-	ScopedPointer<AudioFormatReader> flacReader = flac.createReaderFor(mis, true);
+	auto flacReader = flac.createReaderFor(mis, true);
 
-	AudioSampleBuffer b(flacReader->numChannels, (int)flacReader->lengthInSamples);
+    juce::AudioSampleBuffer b(flacReader->numChannels, (int)flacReader->lengthInSamples);
 
-	double start = Time::getMillisecondCounterHiRes();
+	double start = juce::Time::getMillisecondCounterHiRes();
 
 	flacReader->read(&b, 0, (int)flacReader->lengthInSamples, 0, true, true);
 
-	double stop = Time::getMillisecondCounterHiRes();
+	double stop = juce::Time::getMillisecondCounterHiRes();
 
 	double sampleLength = flacReader->lengthInSamples / flacReader->sampleRate;
 
@@ -281,23 +274,23 @@ float CompressionHelpers::getFLACRatio(const File& f, double& speed)
 
 	speed = sampleLength / delta;
 
-	Logger::writeToLog("FLAC Decoding Performance: " + String(speed, 1) + "x realtime");
+    juce::Logger::writeToLog("FLAC Decoding Performance: " + juce::String(speed, 1) + "x realtime");
 
 	return (float)flacSize / (float)fileUncompressed;
 
 }
 
-uint8 CompressionHelpers::getPossibleBitReductionAmount(const AudioBufferInt16& b)
+uint8_t CompressionHelpers::getPossibleBitReductionAmount(const AudioBufferInt16& b)
 {
 	return BitCompressors::getMinBitDepthForData(b.getReadPointer(), b.size);
 }
 
-int CompressionHelpers::getBlockAmount(AudioSampleBuffer& b)
+int CompressionHelpers::getBlockAmount(juce::AudioSampleBuffer& b)
 {
 	return b.getNumSamples() / COMPRESSION_BLOCK_SIZE + 1;
 }
 
-uint8 CompressionHelpers::getBitrateForCycleLength(const AudioBufferInt16& block, int cycleLength, AudioBufferInt16& workBuffer)
+uint8_t CompressionHelpers::getBitrateForCycleLength(const AudioBufferInt16& block, int cycleLength, AudioBufferInt16& workBuffer)
 {
 	auto part = getPart(block, 0, cycleLength);
 
@@ -306,7 +299,7 @@ uint8 CompressionHelpers::getBitrateForCycleLength(const AudioBufferInt16& block
 	return BitCompressors::getMinBitDepthForData(workBuffer.getReadPointer(), cycleLength);
 }
 
-void CompressionHelpers::normaliseBlock(int16* data, int numSamples, int normalisationAmount, int direction, bool /*useDither*/)
+void CompressionHelpers::normaliseBlock(int16_t* data, int numSamples, int normalisationAmount, int direction, bool /*useDither*/)
 {
 	int shiftAmount = 1 << normalisationAmount;
 
@@ -319,9 +312,9 @@ void CompressionHelpers::normaliseBlock(int16* data, int numSamples, int normali
 
 			//jassert(v > INT16_MIN && v < INT16_MAX);
 
-			v = jlimit<int>(INT16_MIN, INT16_MAX, v);
+			v = juce::jlimit<int>(INT16_MIN, INT16_MAX, v);
 
-			data[i] = (int16)v;
+			data[i] = (int16_t)v;
 		}
 	}
 	else
@@ -330,7 +323,7 @@ void CompressionHelpers::normaliseBlock(int16* data, int numSamples, int normali
 		{
 			int v = (int)data[i];
 			v /= shiftAmount;
-			data[i] = (int16)v;
+			data[i] = (int16_t)v;
 		}
 	}
 
@@ -356,11 +349,11 @@ int CompressionHelpers::getCycleLengthWithLowestBitRate(const AudioBufferInt16& 
 	return lowestCycleSize;
 }
 
-uint8 CompressionHelpers::getBitReductionWithTemplate(AudioBufferInt16& lastCycle, AudioBufferInt16& nextCycle, bool removeDc)
+uint8_t CompressionHelpers::getBitReductionWithTemplate(AudioBufferInt16& lastCycle, AudioBufferInt16& nextCycle, bool removeDc)
 {
 	jassert(lastCycle.size == nextCycle.size);
 
-	uint8 templateBitRate = getPossibleBitReductionAmount(lastCycle);
+	uint8_t templateBitRate = getPossibleBitReductionAmount(lastCycle);
 
 	AudioBufferInt16 workBuffer(lastCycle.size);
 
@@ -369,7 +362,7 @@ uint8 CompressionHelpers::getBitReductionWithTemplate(AudioBufferInt16& lastCycl
 	if(removeDc)
 		IntVectorOperations::removeDCOffset(workBuffer.getWritePointer(), lastCycle.size);
 
-	int8 deltaBitRate = getPossibleBitReductionAmount(workBuffer);
+	int8_t deltaBitRate = getPossibleBitReductionAmount(workBuffer);
 
 	if (deltaBitRate < 0 || deltaBitRate > templateBitRate)
 		return 0;
@@ -380,33 +373,33 @@ uint8 CompressionHelpers::getBitReductionWithTemplate(AudioBufferInt16& lastCycl
 
 CompressionHelpers::AudioBufferInt16 CompressionHelpers::getPart(AudioBufferInt16& b, int startIndex, int numSamples)
 {
-	int16* d = b.getWritePointer(startIndex);
+	auto* d = b.getWritePointer(startIndex);
 
 	return AudioBufferInt16(d, numSamples);
 }
 
 CompressionHelpers::AudioBufferInt16 CompressionHelpers::getPart(const AudioBufferInt16& b, int startIndex, int numSamples)
 {
-	const int16* d = b.getReadPointer(startIndex);
+	const auto* d = b.getReadPointer(startIndex);
 
 	return AudioBufferInt16(d, numSamples);
 }
 
-AudioSampleBuffer CompressionHelpers::getPart(AudioSampleBuffer& b, int startIndex, int numSamples)
+juce::AudioSampleBuffer CompressionHelpers::getPart(juce::AudioSampleBuffer& b, int startIndex, int numSamples)
 {
 	return getPart(b, 0, startIndex, numSamples);
 }
 
 
-AudioSampleBuffer CompressionHelpers::getPart(AudioSampleBuffer& b, int channelIndex, int startIndex, int numSamples)
+juce::AudioSampleBuffer CompressionHelpers::getPart(juce::AudioSampleBuffer& b, int channelIndex, int startIndex, int numSamples)
 {
 	float* d = b.getWritePointer(channelIndex, startIndex);
 
-	return AudioSampleBuffer(&d, 1, numSamples);
+    return { &d, 1, numSamples };
 }
 
 
-AudioSampleBuffer CompressionHelpers::getPart(HiseSampleBuffer& b, int startIndex, int numSamples)
+juce::AudioSampleBuffer CompressionHelpers::getPart(HiseSampleBuffer& b, int startIndex, int numSamples)
 {
 	jassert(startIndex + numSamples <= b.getNumSamples());
 
@@ -416,11 +409,11 @@ AudioSampleBuffer CompressionHelpers::getPart(HiseSampleBuffer& b, int startInde
 	}
 	else
 	{
-		AudioSampleBuffer buffer(b.getNumChannels(), numSamples);
+        juce::AudioSampleBuffer buffer(b.getNumChannels(), numSamples);
 
 		for (int i = 0; i < b.getNumChannels(); i++)
 		{
-			auto src = static_cast<const int16*>(b.getReadPointer(i, startIndex));
+			auto src = static_cast<const int16_t*>(b.getReadPointer(i, startIndex));
 
 			b.getNormaliseMap(i).normalisedInt16ToFloat(buffer.getWritePointer(i), src, 0, numSamples);
 		}
@@ -442,7 +435,7 @@ int CompressionHelpers::getPaddedSampleSize(int samplesNeeded)
     }
 }
 
-uint8 CompressionHelpers::getBitReductionForDifferential(AudioBufferInt16& b)
+uint8_t CompressionHelpers::getBitReductionForDifferential(AudioBufferInt16& b)
 {
 	AudioBufferInt16 copy(b.size);
 
@@ -476,25 +469,25 @@ int CompressionHelpers::getByteAmountForDifferential(AudioBufferInt16& b)
 }
 
 
-void CompressionHelpers::dump(const AudioBufferInt16& b, String fileName)
+void CompressionHelpers::dump(const AudioBufferInt16& b, juce::String fileName)
 {
-	AudioSampleBuffer fb = b.getFloatBuffer();
+	auto fb = b.getFloatBuffer();
 
 	dump(fb, fileName);
 }
 
 
-void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
+void CompressionHelpers::dump(const juce::AudioSampleBuffer& b, juce::String fileName)
 {
-	WavAudioFormat afm;
+    juce::WavAudioFormat afm;
     
 	bool sibling = false;
 
-	File dumpFile;
+    juce::File dumpFile;
 
-	if (File::isAbsolutePath(fileName))
+	if (juce::File::isAbsolutePath(fileName))
 	{
-		dumpFile = File(fileName);
+		dumpFile = juce::File(fileName);
 	}
 	else
 	{
@@ -505,9 +498,9 @@ void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
 		}
 
 #if JUCE_WINDOWS
-		dumpFile = File("D:\\dumps").getChildFile(fileName);
+		dumpFile = juce::File("D:\\dumps").getChildFile(fileName);
 #else
-		dumpFile = File("/Volumes/Shared/").getChildFile(fileName);
+		dumpFile = juce::File("/Volumes/Shared/").getChildFile(fileName);
 #endif
 
 		if (sibling)
@@ -517,11 +510,11 @@ void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
 	dumpFile.deleteFile();
 	dumpFile.create();
 
-	FileOutputStream* fis = new FileOutputStream(dumpFile);
-	StringPairArray metadata;
-	ScopedPointer<AudioFormatWriter> writer = afm.createWriterFor(fis, 44100, b.getNumChannels(), 16, metadata, 5);
+	auto* fis = new juce::FileOutputStream(dumpFile);
+    juce::StringPairArray metadata;
+	auto writer = afm.createWriterFor(fis, 44100, b.getNumChannels(), 16, metadata, 5);
 
-	if (writer != nullptr)
+	if (writer)
 		writer->writeFromAudioSampleBuffer(b, 0, b.getNumSamples());
 }
 
@@ -530,7 +523,7 @@ void CompressionHelpers::fastInt16ToFloat(const void* source, float* dest, int n
 {
 #if HI_ENABLE_LEGACY_CPU_SUPPORT || !JUCE_WINDOWS
 
-	AudioDataConverters::convertInt16LEToFloat(source, dest, numSamples);
+    juce::AudioDataConverters::convertInt16LEToFloat(source, dest, numSamples);
 
 #else
 
@@ -578,7 +571,7 @@ void CompressionHelpers::fastInt16ToFloat(const void* source, float* dest, int n
 
 void CompressionHelpers::applyDithering(float* data, int numSamples)
 {
-	ignoreUnused(data, numSamples);
+    juce::ignoreUnused(data, numSamples);
 
 #if 0
 	int   r1, r2;                //rectangular-PDF random numbers
@@ -615,7 +608,7 @@ void CompressionHelpers::applyDithering(float* data, int numSamples)
 #endif
 }
 
-uint8 CompressionHelpers::checkBuffersEqual(AudioSampleBuffer& workBuffer, AudioSampleBuffer& referenceBuffer)
+uint8_t CompressionHelpers::checkBuffersEqual(juce::AudioSampleBuffer& workBuffer, juce::AudioSampleBuffer& referenceBuffer)
 {
     int numToCheck = referenceBuffer.getNumSamples();
     
@@ -631,17 +624,17 @@ uint8 CompressionHelpers::checkBuffersEqual(AudioSampleBuffer& workBuffer, Audio
 	
 	if (br != 0)
 	{
-		DBG("Bit rate for error signal: " + String(br));
+		DBG("Bit rate for error signal: " + juce::String(br));
 
 
 		float* w = workBuffer.getWritePointer(0);
 		const float* r = referenceBuffer.getReadPointer(0);
 
-		FloatVectorOperations::subtract(w, r, numToCheck);
+        juce::FloatVectorOperations::subtract(w, r, numToCheck);
 
 		float x = workBuffer.getMagnitude(0, 0, numToCheck);
 
-		float db = Decibels::gainToDecibels(x);
+		float db = juce::Decibels::gainToDecibels(x);
 
 		if (db > -96.0f)
 		{
@@ -673,8 +666,8 @@ uint8 CompressionHelpers::checkBuffersEqual(AudioSampleBuffer& workBuffer, Audio
 				}
 			}
 
-			DBG("Min index: " + String(minIndex) + ", value: " + String(minValue));
-			DBG("Max index: " + String(maxIndex) + ", value: " + String(maxValue));
+			DBG("Min index: " + juce::String(minIndex) + ", value: " + juce::String(minValue));
+			DBG("Max index: " + juce::String(maxIndex) + ", value: " + juce::String(maxValue));
 		}
 		else
 			return 0;
@@ -694,7 +687,7 @@ uint8 CompressionHelpers::checkBuffersEqual(AudioSampleBuffer& workBuffer, Audio
 
 		if (brR != 0)
 		{
-			DBG("Second channel error: " + String(br));
+			DBG("Second channel error: " + juce::String(br));
 
 			//DUMP(wbInt);
 			DUMP(referenceBuffer);
@@ -709,7 +702,7 @@ uint8 CompressionHelpers::checkBuffersEqual(AudioSampleBuffer& workBuffer, Audio
 
 
 
-void CompressionHelpers::IntVectorOperations::sub(int16* dst, const int16* src1, const int16* src2, int numValues)
+void CompressionHelpers::IntVectorOperations::sub(int16_t* dst, const int16_t* src1, const int16_t* src2, int numValues)
 {
 	for (int s = 0; s < numValues; s++)
 	{
@@ -718,7 +711,7 @@ void CompressionHelpers::IntVectorOperations::sub(int16* dst, const int16* src1,
 }
 
 
-void CompressionHelpers::IntVectorOperations::sub(int16* dst, const int16* src, int numValues)
+void CompressionHelpers::IntVectorOperations::sub(int16_t* dst, const int16_t* src, int numValues)
 {
 	for (int i = 0; i < numValues; i++)
 	{
@@ -726,7 +719,7 @@ void CompressionHelpers::IntVectorOperations::sub(int16* dst, const int16* src, 
 	}
 }
 
-void CompressionHelpers::IntVectorOperations::add(int16* dst, const int16* src, int numSamples)
+void CompressionHelpers::IntVectorOperations::add(int16_t* dst, const int16_t* src, int numSamples)
 {
 	for (int i = 0; i < numSamples; i++)
 	{
@@ -735,7 +728,7 @@ void CompressionHelpers::IntVectorOperations::add(int16* dst, const int16* src, 
 }
 
 
-void CompressionHelpers::IntVectorOperations::mul(int16*dst, const int16 value, int numSamples)
+void CompressionHelpers::IntVectorOperations::mul(int16_t* dst, const int16_t value, int numSamples)
 {
 	for (int i = 0; i < numSamples; i++)
 	{
@@ -744,7 +737,7 @@ void CompressionHelpers::IntVectorOperations::mul(int16*dst, const int16 value, 
 }
 
 
-void CompressionHelpers::IntVectorOperations::div(int16* dst, const int16 value, int numSamples)
+void CompressionHelpers::IntVectorOperations::div(int16_t* dst, const int16_t value, int numSamples)
 {
 	for (int i = 0; i < numSamples; i++)
 	{
@@ -752,16 +745,16 @@ void CompressionHelpers::IntVectorOperations::div(int16* dst, const int16 value,
 	}
 }
 
-int16 CompressionHelpers::IntVectorOperations::removeDCOffset(int16* data, int numValues)
+int16_t CompressionHelpers::IntVectorOperations::removeDCOffset(int16_t* data, int numValues)
 {
-	int64 sum = 0;
+	int64_t sum = 0;
 
 	for (int i = 0; i < numValues; i++)
 	{
 		sum += data[i];
 	}
 
-	int16 dcOffset = (int16)(sum /= numValues);
+	auto dcOffset = (int16_t)(sum /= numValues);
 
 	for (int i = 0; i < numValues; i++)
 	{
@@ -771,27 +764,27 @@ int16 CompressionHelpers::IntVectorOperations::removeDCOffset(int16* data, int n
 	return dcOffset;
 }
 
-int16 CompressionHelpers::IntVectorOperations::max(const int16* d, int numValues)
+int16_t CompressionHelpers::IntVectorOperations::max(const int16_t* d, int numValues)
 {
-	int16 m = 0;
+	int16_t m = 0;
 
 	for (int i = 0; i < numValues; i++)
 	{
-		m = jmax<int16>(m, (int16)abs(d[i]));
+		m = juce::jmax<int16_t>(m, (int16_t)abs(d[i]));
 	}
 
 	return m;
 }
 
 
-void CompressionHelpers::IntVectorOperations::clear(int16* d, int numValues)
+void CompressionHelpers::IntVectorOperations::clear(int16_t* d, int numValues)
 {
-	memset(d, 0, sizeof(int16)*numValues);
+	memset(d, 0, sizeof(int16_t)*numValues);
 }
 
 int CompressionHelpers::Diff::getNumFullValues(int bufferSize)
 {
-	jassert(isPowerOfTwo(bufferSize));
+	jassert(juce::isPowerOfTwo(bufferSize));
 
 	return bufferSize / 4 + 1;
 }
@@ -799,7 +792,7 @@ int CompressionHelpers::Diff::getNumFullValues(int bufferSize)
 
 int CompressionHelpers::Diff::getNumErrorValues(int bufferSize)
 {
-	jassert(isPowerOfTwo(bufferSize));
+	jassert(juce::isPowerOfTwo(bufferSize));
 
 	return bufferSize - getNumFullValues(bufferSize);
 }
@@ -836,14 +829,14 @@ CompressionHelpers::AudioBufferInt16 CompressionHelpers::Diff::createBufferWithE
 {
 	AudioBufferInt16 workBuffer(b.size);
 
-	distributeFullSamples(workBuffer, reinterpret_cast<const uint16*>(packedFullValues.getReadPointer()), packedFullValues.size);
+	distributeFullSamples(workBuffer, reinterpret_cast<const uint16_t*>(packedFullValues.getReadPointer()), packedFullValues.size);
 
 	IntVectorOperations::sub(workBuffer.getWritePointer(), b.getReadPointer(), b.size);
 
 	AudioBufferInt16 packedBuffer(getNumErrorValues(b.size));
 
-	int16* w = packedBuffer.getWritePointer();
-	const int16* r = workBuffer.getReadPointer();
+	auto* w = packedBuffer.getWritePointer();
+	const auto* r = workBuffer.getReadPointer();
 
 	for (int i = 0; i < b.size - 4; i += 4)
 	{
@@ -870,12 +863,12 @@ void CompressionHelpers::Diff::downSampleBuffer(AudioBufferInt16& b)
 {
 	jassert(b.size % 4 == 0);
 	
-	int16* d = b.getWritePointer();
+	auto* d = b.getWritePointer();
 
 	for (int i = 0; i < b.size - 4; i += 4)
 	{
-		int16 firstValue = d[0];
-		int16 lastValue = d[4];
+		int16_t firstValue = d[0];
+		int16_t lastValue = d[4];
 
 		d[1] = 3 * firstValue / 4 + lastValue / 4;
 		d[2] = firstValue / 2 + lastValue / 2;
@@ -894,19 +887,19 @@ void CompressionHelpers::Diff::downSampleBuffer(AudioBufferInt16& b)
 
 #define OPTIMIZED 0
 
-void CompressionHelpers::Diff::distributeFullSamples(AudioBufferInt16& dst, const uint16* fullSamplesPacked, int numSamples)
+void CompressionHelpers::Diff::distributeFullSamples(AudioBufferInt16& dst, const uint16_t* fullSamplesPacked, int numSamples)
 {
 	// Use this only on power two block sizes (512 samples = 128 four packs + 1 last value)
-	jassert(isPowerOfTwo(numSamples - 1));
+	jassert(juce::isPowerOfTwo(numSamples - 1));
 
 	// Needs 128 bit alignment for the destination buffer.
-	jassert(reinterpret_cast<uint64>(dst.getReadPointer()) % 16 == 0);
+	jassert(reinterpret_cast<uint64_t>(dst.getReadPointer()) % 16 == 0);
 
-	jassert(reinterpret_cast<uint64>(fullSamplesPacked) % 16 == 0);
+	jassert(reinterpret_cast<uint64_t>(fullSamplesPacked) % 16 == 0);
 
-	int16* d = dst.getWritePointer();
+	auto* d = dst.getWritePointer();
 
-	int16* r = const_cast<int16*>(reinterpret_cast<const int16*>(fullSamplesPacked));
+	auto* r = const_cast<int16_t*>(reinterpret_cast<const int16_t*>(fullSamplesPacked));
 
 	int thisValue = 0;
 	int nextValue = 0;
@@ -918,10 +911,10 @@ void CompressionHelpers::Diff::distributeFullSamples(AudioBufferInt16& dst, cons
 		thisValue = (int)r[i];
 		nextValue = (int)r[i + 1];
 
-		d[0] = (int16)(thisValue);
-		d[1] = (int16)((3 * thisValue + nextValue) / 4);
-		d[2] = (int16)((thisValue + nextValue) / 2);
-		d[3] = (int16)((thisValue + 3 * nextValue) / 4);
+		d[0] = (int16_t)(thisValue);
+		d[1] = (int16_t)((3 * thisValue + nextValue) / 4);
+		d[2] = (int16_t)((thisValue + nextValue) / 2);
+		d[3] = (int16_t)((thisValue + 3 * nextValue) / 4);
 
 		d += 4;
 	}
@@ -1002,22 +995,22 @@ void CompressionHelpers::Diff::distributeFullSamples(AudioBufferInt16& dst, cons
 	thisValue = r[numSamples - 2];
 	nextValue = r[numSamples - 1];
 	
-	d[0] = (int16)(thisValue);
-	d[1] = (int16)((2 * thisValue + nextValue) / 3);
-	d[2] = (int16)((thisValue + 2 * nextValue) / 3);
-	d[3] = (int16)(nextValue);
+	d[0] = (int16_t)(thisValue);
+	d[1] = (int16_t)((2 * thisValue + nextValue) / 3);
+	d[2] = (int16_t)((thisValue + 2 * nextValue) / 3);
+	d[3] = (int16_t)(nextValue);
 }
 
-void CompressionHelpers::Diff::addErrorSignal(AudioBufferInt16& dst, const uint16* errorSignalPacked, int numSamples)
+void CompressionHelpers::Diff::addErrorSignal(AudioBufferInt16& dst, const uint16_t* errorSignalPacked, int numSamples)
 {
-	jassert(isPowerOfTwo(4*(numSamples+1)/3));
+	jassert(juce::isPowerOfTwo(4*(numSamples+1)/3));
 
 	// Needs 64 bit alignment for the destination buffer.
-	jassert(reinterpret_cast<uint64>(dst.getReadPointer()) % 16 == 0);
+	jassert(reinterpret_cast<uint64_t>(dst.getReadPointer()) % 16 == 0);
 
-	int16* d = dst.getWritePointer();
+	auto* d = dst.getWritePointer();
 
-	int16* e = const_cast<int16*>(reinterpret_cast<const int16*>(errorSignalPacked));
+	auto* e = const_cast<int16_t*>(reinterpret_cast<const int16_t*>(errorSignalPacked));
 
 	int counter = 0;
 
@@ -1087,19 +1080,19 @@ void CompressionHelpers::Diff::addErrorSignal(AudioBufferInt16& dst, const uint1
 #endif
 }
 
-uint64 CompressionHelpers::Misc::NumberOfSetBits(uint64 i)
+uint64_t CompressionHelpers::Misc::NumberOfSetBits(uint64_t i)
 {
 #if JUCE_MSVC && JUCE_64BIT && !HI_ENABLE_LEGACY_CPU_SUPPORT
 	return __popcnt64(i);
 #else
     
-    BigInteger b((int64)i);
+    juce::BigInteger b((int64_t)i);
     return b.countNumberOfSetBits();
     
 #endif
 }
 
-uint8 CompressionHelpers::Misc::getSampleRateIndex(double sampleRate)
+uint8_t CompressionHelpers::Misc::getSampleRateIndex(double sampleRate)
 {
 	if (sampleRate == 44100.0)
 		return 0;
@@ -1115,61 +1108,61 @@ uint8 CompressionHelpers::Misc::getSampleRateIndex(double sampleRate)
 	return 0;
 }
 
-uint32 CompressionHelpers::Misc::createChecksum()
+uint32_t CompressionHelpers::Misc::createChecksum()
 {
-	Random r;
+    juce::Random r;
 	r.setSeedRandomly();
 	r.setSeedRandomly();
 	r.setSeedRandomly();
 
-	uint16 randomNumber = (uint16)r.nextInt(Range<int>(2, UINT16_MAX));
+	auto randomNumber = (uint16_t)r.nextInt(juce::Range<int>(2, UINT16_MAX));
 
-	uint8* d = reinterpret_cast<uint8*>(&randomNumber);
-	uint16 product = (uint16)(d[0] * d[1]);
+	auto* d = reinterpret_cast<uint8_t*>(&randomNumber);
+	auto product = (uint16_t)(d[0] * d[1]);
 
-	uint32 result;
+	uint32_t result;
 
-	uint16* resultPointer = reinterpret_cast<uint16*>(&result);
+	auto* resultPointer = reinterpret_cast<uint16_t*>(&result);
 	resultPointer[0] = randomNumber;
 	resultPointer[1] = product;
 
 	return result;
 }
 
-bool CompressionHelpers::Misc::validateChecksum(uint32 data)
+bool CompressionHelpers::Misc::validateChecksum(uint32_t data)
 {
 	if (data == 0) return false;
 
-	uint16* numbers = reinterpret_cast<uint16*>(&data);
+	auto* numbers = reinterpret_cast<uint16_t*>(&data);
 
-	uint16 randomNumber = numbers[0];
-	uint16 product = numbers[1];
+	auto randomNumber = numbers[0];
+	auto product = numbers[1];
 
-	uint8* bytes = reinterpret_cast<uint8*>(&randomNumber);
+	auto* bytes = reinterpret_cast<uint8_t*>(&randomNumber);
 
-	return (uint16)(bytes[0] * bytes[1]) == product;
+	return (uint16_t)(bytes[0] * bytes[1]) == product;
 }
 
-#define CHECK_FLAG(x) if(!readAndCheckFlag(fis, x)) { if(listener != nullptr) listener->criticalErrorOccured("Read error"); return false; }
+#define CHECK_FLAG(x) if(!readAndCheckFlag(fis.get(), x)) { if(listener != nullptr) listener->criticalErrorOccured("Read error"); return false; }
 
 #define VERBOSE_LOG(x) if(listener != nullptr) listener->logVerboseMessage(x);
 #define STATUS_LOG(x) if(listener != nullptr) listener->logStatusMessage(x);
 
-var HlacArchiver::readMetadataFromArchive(const File& sourceFile)
+juce::var HlacArchiver::readMetadataFromArchive(const juce::File& sourceFile)
 {
-	ScopedPointer<FileInputStream> fis = new FileInputStream(sourceFile);
+	auto fis = sourceFile.createInputStream();
 
-	auto flag = readFlag(fis);
+	auto flag = readFlag(fis.get());
 
 	if (flag == Flag::BeginMetadata)
 	{
-		auto obj = JSON::parse(fis->readString());
+		auto obj = juce::JSON::parse(fis->readString());
 
-		if (readFlag(fis) == Flag::EndMetadata)
+		if (readFlag(fis.get()) == Flag::EndMetadata)
 			return obj;
 	}
 	
-	return var();
+	return juce::var();
 }
 
 bool HlacArchiver::extractSampleData(const DecompressData& data)
@@ -1191,15 +1184,15 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 		}
 	}
 
-	Array<File> parts;
+    juce::Array<juce::File> parts;
 
-	sourceFile.getParentDirectory().findChildFiles(parts, File::findFiles, false, sourceFile.getFileNameWithoutExtension() + ".*");
+	sourceFile.getParentDirectory().findChildFiles(parts, juce::File::findFiles, false, sourceFile.getFileNameWithoutExtension() + ".*");
 
 	const int numParts = parts.size();
 
-	ScopedPointer<FileInputStream> fis = new FileInputStream(sourceFile);
+	auto fis = sourceFile.createInputStream();
 
-	FlacAudioFormat flacFormat;
+    juce::FlacAudioFormat flacFormat;
 	hlac::HiseLosslessAudioFormat hlacFormat;
 
 	CHECK_FLAG(Flag::BeginMetadata);
@@ -1208,24 +1201,24 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 	VERBOSE_LOG(metadataString);
 
-	StringPairArray metadata;
+    juce::StringPairArray metadata;
 
 	int partIndex = 1;
 
-	currentFlag = readFlag(fis);
+	currentFlag = readFlag(fis.get());
 
 	if (currentFlag == Flag::BeginHeaderFile)
 	{
 		VERBOSE_LOG("    Read Header file");
 
 		auto numBytesForHeaderFile = fis->readInt64();
-		VERBOSE_LOG(String(numBytesForHeaderFile) + String(" bytes"));
+		VERBOSE_LOG(juce::String(numBytesForHeaderFile) + juce::String(" bytes"));
 		auto headerTargetFile = data.targetDirectory.getChildFile("header.dat");
 		headerTargetFile.create();
-		ScopedPointer<FileOutputStream> fos = new FileOutputStream(headerTargetFile);
+		auto fos = headerTargetFile.createOutputStream();
 		fos->writeFromInputStream(*fis, numBytesForHeaderFile);
 		CHECK_FLAG(Flag::EndHeaderFile);
-		currentFlag = readFlag(fis);
+		currentFlag = readFlag(fis.get());
 	}
 
 	while (currentFlag == Flag::BeginName)
@@ -1245,14 +1238,14 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 		*data.totalProgress = totalProgress + totalPartProgress;
 
 		CHECK_FLAG(Flag::BeginTime);
-		auto archiveTime = Time::fromISO8601(fis->readString());
+		auto archiveTime = juce::Time::fromISO8601(fis->readString());
 		CHECK_FLAG(Flag::EndTime);
 
 		if (thread->threadShouldExit())
 			return false;
 
 		
-		File targetHlacFile = targetDirectory.getChildFile(name);
+		auto targetHlacFile = targetDirectory.getChildFile(name);
 
 		bool overwriteThisFile = true;
 
@@ -1268,7 +1261,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 		if (targetHlacFile.existsAsFile() && option == OverwriteOption::OverwriteIfNewer)
 		{
-			Time existingTime = targetHlacFile.getCreationTime();
+            juce::Time existingTime = targetHlacFile.getCreationTime();
 
 			if (archiveTime > existingTime)
 				targetHlacFile.deleteFile();
@@ -1283,12 +1276,12 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			bool ok = true;
 
-			File tmpFlacFile = targetHlacFile.getSiblingFile("TmpFlac.flac").getNonexistentSibling();
+            auto tmpFlacFile = targetHlacFile.getSiblingFile("TmpFlac.flac").getNonexistentSibling();
 
 			if (tmpFlacFile.existsAsFile())
 				tmpFlacFile.deleteFile();
 
-			ScopedPointer<FileOutputStream> flacTempWriteStream = new FileOutputStream(tmpFlacFile);
+			auto flacTempWriteStream = tmpFlacFile.createOutputStream();
 
 			CHECK_FLAG(Flag::BeginMonolithLength);
 			auto bytesToRead = fis->readInt64();
@@ -1300,15 +1293,13 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			flacTempWriteStream->writeFromInputStream(*fis, bytesToRead);
 
-			currentFlag = readFlag(fis);
+			currentFlag = readFlag(fis.get());
 
 			while (currentFlag == Flag::SplitMonolith)
 			{
 				partIndex++;
 
-				fis = nullptr;
-
-				fis = new FileInputStream(getPartFile(sourceFile, partIndex));
+				fis = getPartFile(sourceFile, partIndex).createInputStream();
 
 				CHECK_FLAG(Flag::BeginMonolithLength);
 				bytesToRead = fis->readInt64();
@@ -1318,7 +1309,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 				flacTempWriteStream->writeFromInputStream(*fis, bytesToRead);
 
-				currentFlag = readFlag(fis);
+				currentFlag = readFlag(fis.get());
 			}
 
 			if (thread->threadShouldExit())
@@ -1329,29 +1320,27 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 			flacTempWriteStream->flush();
 			flacTempWriteStream = nullptr;
 
-			FileInputStream* flacTempInputStream = new FileInputStream(tmpFlacFile);
+			auto* flacTempInputStream = new juce::FileInputStream(tmpFlacFile);
 
 			jassert(flacTempInputStream->openedOk());
 
-			ScopedPointer<AudioFormatReader> flacReader = flacFormat.createReaderFor(flacTempInputStream, true);
+			std::unique_ptr<juce::AudioFormatReader> flacReader (flacFormat.createReaderFor(flacTempInputStream, true));
 
-			if (flacReader == nullptr)
+			if (!flacReader)
 				return false;
 
-			VERBOSE_LOG("    Samplerate: " + String(flacReader->sampleRate, 1));
-			VERBOSE_LOG("    Channels: " + String(flacReader->numChannels));
-			VERBOSE_LOG("    Length: " + String(flacReader->lengthInSamples));
+			VERBOSE_LOG("    Samplerate: " + juce::String(flacReader->sampleRate, 1));
+			VERBOSE_LOG("    Channels: " + juce::String(flacReader->numChannels));
+			VERBOSE_LOG("    Length: " + juce::String(flacReader->lengthInSamples));
 
-			FileOutputStream* monolithOutputStream; 
-			ScopedPointer<AudioFormatWriter> writer;
+            juce::ScopedPointer<juce::AudioFormatWriter> writer;
 
 			if (!data.debugLogMode)
 			{
 				if (targetHlacFile.existsAsFile())
 					targetHlacFile.create();
 
-				monolithOutputStream = new FileOutputStream(targetHlacFile);
-				writer = hlacFormat.createWriterFor(monolithOutputStream, flacReader->sampleRate, flacReader->numChannels, 5, metadata, 5);
+				writer = hlacFormat.createWriterFor(new juce::FileOutputStream(targetHlacFile), flacReader->sampleRate, flacReader->numChannels, 5, metadata, 5);
 			}
 
 			STATUS_LOG("Decompressing " + name);
@@ -1373,14 +1362,14 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 			if(!data.debugLogMode)
 				dynamic_cast<HiseLosslessAudioFormatWriter*>(writer.get())->setOptions(options);
 
-			AudioSampleBuffer tempBuffer(flacReader->numChannels, data.debugLogMode ? 0 : bufferSize);
+            juce::AudioSampleBuffer tempBuffer(flacReader->numChannels, data.debugLogMode ? 0 : bufferSize);
 
-			for (int64 readerOffset = 0; readerOffset < flacReader->lengthInSamples; readerOffset += bufferSize)
+			for (int64_t readerOffset = 0; readerOffset < flacReader->lengthInSamples; readerOffset += bufferSize)
 			{
 				if (thread->threadShouldExit())
 					return false;
 
-				const int numToRead = jmin<int>(bufferSize, (int)(flacReader->lengthInSamples - readerOffset));
+				const int numToRead = juce::jmin<int>(bufferSize, (int)(flacReader->lengthInSamples - readerOffset));
 
 				if (!data.debugLogMode)
 				{
@@ -1414,7 +1403,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			flacReader = nullptr;
 			tmpFlacFile.deleteFile();
-			currentFlag = readFlag(fis);
+			currentFlag = readFlag(fis.get());
 		}
 		else
 		{
@@ -1426,14 +1415,14 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			CHECK_FLAG(Flag::BeginMonolith);
 			fis->skipNextBytes(bytesToSkip);
-			currentFlag = readFlag(fis);
+			currentFlag = readFlag(fis.get());
 
 			while (currentFlag == Flag::SplitMonolith)
 			{
 				partIndex++;
 
 				fis = nullptr;
-				fis = new FileInputStream(getPartFile(sourceFile, partIndex));
+				fis = getPartFile(sourceFile, partIndex).createInputStream();
 
 				CHECK_FLAG(Flag::BeginMonolithLength);
 				bytesToSkip = fis->readInt64();
@@ -1445,11 +1434,11 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 				CHECK_FLAG(Flag::ResumeMonolith);
 				fis->skipNextBytes(bytesToSkip);
 
-				currentFlag = readFlag(fis);
+				currentFlag = readFlag(fis.get());
 			}
 
 			jassert(currentFlag == Flag::EndMonolith);
-			currentFlag = readFlag(fis);
+			currentFlag = readFlag(fis.get());
 		}
 	}
 
@@ -1462,24 +1451,24 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 #define WRITE_FLAG(x) writeFlag(fos, x)
 
-FileInputStream* HlacArchiver::writeTempFile(AudioFormatReader* reader, int bitDepth)
+juce::FileInputStream* HlacArchiver::writeTempFile(juce::AudioFormatReader* reader, int bitDepth)
 {
-	FlacAudioFormat flacFormat;
+    juce::FlacAudioFormat flacFormat;
 
-	StringPairArray metadata;
+    juce::StringPairArray metadata;
 
 	tmpFile.deleteFile();
-	FileOutputStream* tempOutput = new FileOutputStream(tmpFile);
+	auto* tempOutput = new juce::FileOutputStream(tmpFile);
 
 	const int bufferSize = 8192 * 32;
 
-	AudioSampleBuffer tempBuffer(reader->numChannels, bufferSize);
+    juce::AudioSampleBuffer tempBuffer(reader->numChannels, bufferSize);
 
-	ScopedPointer<AudioFormatWriter> writer = flacFormat.createWriterFor(tempOutput, reader->sampleRate, reader->numChannels, bitDepth, metadata, 9);
+	auto writer = flacFormat.createWriterFor(tempOutput, reader->sampleRate, reader->numChannels, bitDepth, metadata, 9);
 
 	bool writeResult = true;
 
-	dynamic_cast<HiseLosslessAudioFormatReader*>(reader)->setTargetAudioDataType(AudioDataConverters::float32BE);
+	dynamic_cast<HiseLosslessAudioFormatReader*>(reader)->setTargetAudioDataType(juce::AudioDataConverters::float32BE);
 
 	for (int offsetInReader = 0; offsetInReader < reader->lengthInSamples; offsetInReader += bufferSize)
 	{
@@ -1498,7 +1487,7 @@ FileInputStream* HlacArchiver::writeTempFile(AudioFormatReader* reader, int bitD
 		if (progress != nullptr)
 			*progress = partProgress;
 
-		const int numToRead = jmin<int>(bufferSize, (int)(reader->lengthInSamples - offsetInReader));
+		const int numToRead = juce::jmin<int>(bufferSize, (int)(reader->lengthInSamples - offsetInReader));
 
 		reader->read(&tempBuffer, 0, numToRead, offsetInReader, true, true);
 
@@ -1506,7 +1495,7 @@ FileInputStream* HlacArchiver::writeTempFile(AudioFormatReader* reader, int bitD
 
 		if (!writeResult)
 		{
-			listener->criticalErrorOccured("Error at writing from temp buffer at position " + String(offsetInReader) + ", chunk-length: " + String(numToRead));
+			listener->criticalErrorOccured("Error at writing from temp buffer at position " + juce::String(offsetInReader) + ", chunk-length: " + juce::String(numToRead));
 			return nullptr;
 		}
 	}
@@ -1514,7 +1503,7 @@ FileInputStream* HlacArchiver::writeTempFile(AudioFormatReader* reader, int bitD
 	tempOutput->flush();
 	writer = nullptr;
 
-	return new FileInputStream(tmpFile);
+	return new juce::FileInputStream(tmpFile);
 }
 
 #define CHECK_FILE_WRITE_OP if (!ok) { listener->criticalErrorOccured("file write error at " + fos->getFile().getFileName()); return; }
@@ -1667,22 +1656,21 @@ void HlacArchiver::compressSampleData(const CompressData& data)
 	}
 #else
 
-    ignoreUnused(data);
+    juce::ignoreUnused(data);
 
 
 #endif
 }
 
-String HlacArchiver::getMetadataJSON(const File& sourceFile)
+juce::String HlacArchiver::getMetadataJSON(const juce::File& sourceFile)
 {
-	ScopedPointer<FileInputStream> fis = new FileInputStream(sourceFile);
-
+	auto fis = sourceFile.createInputStream();
 	return fis->readString();
 }
 
 #define RETURN_FLAG(x) if(f == Flag::x) return #x;
 
-String HlacArchiver::getFlagName(Flag f)
+juce::String HlacArchiver::getFlagName(Flag f)
 {
 	RETURN_FLAG(BeginMetadata);
 	RETURN_FLAG(EndMetadata);
@@ -1703,16 +1691,16 @@ String HlacArchiver::getFlagName(Flag f)
 
 #undef RETURN
 
-File HlacArchiver::getPartFile(const File& originalFile, int partIndex)
+juce::File HlacArchiver::getPartFile(const juce::File& originalFile, int partIndex)
 {
-	String newFileName = originalFile.getFileNameWithoutExtension() + ".hr" + String(partIndex);
+	auto newFileName = originalFile.getFileNameWithoutExtension() + ".hr" + juce::String(partIndex);
 
 	VERBOSE_LOG("New Part " + newFileName);
 
 	return originalFile.getSiblingFile(newFileName);
 }
 
-bool HlacArchiver::writeFlag(FileOutputStream* fos, Flag flag)
+bool HlacArchiver::writeFlag(juce::FileOutputStream* fos, Flag flag)
 {
 	VERBOSE_LOG("    W " + getFlagName(flag));
 
@@ -1722,7 +1710,7 @@ bool HlacArchiver::writeFlag(FileOutputStream* fos, Flag flag)
 	return false;
 }
 
-bool HlacArchiver::readAndCheckFlag(FileInputStream* fis, Flag flag)
+bool HlacArchiver::readAndCheckFlag(juce::FileInputStream* fis, Flag flag)
 {
 	VERBOSE_LOG("    R " + getFlagName(flag));
 
@@ -1736,7 +1724,7 @@ bool HlacArchiver::readAndCheckFlag(FileInputStream* fis, Flag flag)
 	return false;
 }
 
-HlacArchiver::Flag HlacArchiver::readFlag(FileInputStream* fis)
+HlacArchiver::Flag HlacArchiver::readFlag(juce::FileInputStream* fis)
 {
 	const Flag actualFlag = (Flag)fis->readInt();
 	VERBOSE_LOG("    R " + getFlagName(actualFlag));
@@ -1748,7 +1736,7 @@ HlacArchiver::Flag HlacArchiver::readFlag(FileInputStream* fis)
 #undef STATUS_LOG
 
 
-void CompressionHelpers::NormaliseMap::normalisedInt16ToFloat(float* destination, const int16* src, int start, int numSamples) const
+void CompressionHelpers::NormaliseMap::normalisedInt16ToFloat(float* destination, const int16_t* src, int start, int numSamples) const
 {
 	if (!active)
 	{
@@ -1769,7 +1757,7 @@ void CompressionHelpers::NormaliseMap::normalisedInt16ToFloat(float* destination
 		auto thisAmount = getTableData()[tableIndex];
 
 		int nextLimit = (tableIndex + 1) * normaliseBlockSize;
-		nextLimit = jmin<int>(nextLimit, totalLimit);
+		nextLimit = juce::jmin<int>(nextLimit, totalLimit);
 		int numThisTime = nextLimit - index;
 
 		if (numThisTime == 0)
@@ -1809,26 +1797,26 @@ void CompressionHelpers::NormaliseMap::normalisedInt16ToFloat(float* destination
 	}
 }
 
-void CompressionHelpers::NormaliseMap::setUseStaticNormalisation(uint8 staticNormalisationAmount)
+void CompressionHelpers::NormaliseMap::setUseStaticNormalisation(uint8_t staticNormalisationAmount)
 {
 	normalisationMode = Mode::StaticNormalisation;
 	memset(preallocated, staticNormalisationAmount, PreallocatedSize);
 }
 
-bool CompressionHelpers::NormaliseMap::writeNormalisationHeader(OutputStream& output)
+bool CompressionHelpers::NormaliseMap::writeNormalisationHeader(juce::OutputStream& output)
 {
 	// Can't use this with a non-fixed size block size...
 	jassert(allocated == nullptr);
 
 	constexpr int numBytes = COMPRESSION_BLOCK_SIZE / normaliseBlockSize;
 
-	String s;
+    juce::String s;
 
 	s << "Normalisation bits: ";
-	s << "0: " << String((int)preallocated[0]) << "\t";
-	s << "1: " << String((int)preallocated[1]) << "\t";
-	s << "2: " << String((int)preallocated[2]) << "\t";
-	s << "3: " << String((int)preallocated[3]) << "\t";
+	s << "0: " << juce::String((int)preallocated[0]) << "\t";
+	s << "1: " << juce::String((int)preallocated[1]) << "\t";
+	s << "2: " << juce::String((int)preallocated[2]) << "\t";
+	s << "3: " << juce::String((int)preallocated[3]) << "\t";
 
 	LOG(s);
 
@@ -1840,10 +1828,10 @@ void CompressionHelpers::NormaliseMap::setNormalisationValues(int readOffset, in
 {
 	active |= (normalisedValues > 0);
 
-	uint8* ptr = reinterpret_cast<uint8*>(&normalisedValues);
-	uint16 index = getIndexForSamplePosition(readOffset);
+	auto* ptr = reinterpret_cast<uint8_t*>(&normalisedValues);
+	auto  index = getIndexForSamplePosition(readOffset);
 
-	uint16 maxSize = allocated != nullptr ? numAllocated : PreallocatedSize;
+	uint16_t maxSize = allocated != nullptr ? numAllocated : PreallocatedSize;
 
 	if ((index + 3) >= maxSize)
 	{
@@ -1857,7 +1845,7 @@ void CompressionHelpers::NormaliseMap::setNormalisationValues(int readOffset, in
 	getTableData()[index + 3] = ptr[3];
 }
 
-void CompressionHelpers::NormaliseMap::normalise(const float* src, int16* dst, int numSamples)
+void CompressionHelpers::NormaliseMap::normalise(const float* src, int16_t* dst, int numSamples)
 {
 	if (normalisationMode == Mode::NoNormalisation)
 		return;
@@ -1871,10 +1859,10 @@ void CompressionHelpers::NormaliseMap::normalise(const float* src, int16* dst, i
 
 		while (index < numSamples)
 		{
-			int thisTime = jmin<int>(numSamples - index, normaliseBlockSize);
+			int thisTime = juce::jmin<int>(numSamples - index, normaliseBlockSize);
 			auto data = dst + index;
 
-			AudioDataConverters::convertFloatToInt16LE(src + index, data, thisTime);
+            juce::AudioDataConverters::convertFloatToInt16LE(src + index, data, thisTime);
 
 			CompressionHelpers::AudioBufferInt16 l(data, thisTime);
 
@@ -1888,7 +1876,7 @@ void CompressionHelpers::NormaliseMap::normalise(const float* src, int16* dst, i
 			}
 			else
 			{
-				auto normalisationAmount = jmin<uint8>(8, 16 - lMax);
+				auto normalisationAmount = juce::jmin<uint8_t>(8, 16 - lMax);
 
 				if (normalisationAmount < minNormalisation)
 					normalisationAmount = 0;
@@ -1920,7 +1908,7 @@ void CompressionHelpers::NormaliseMap::allocateTableIndexes(int numSamples)
 	}
 	else
 	{
-		uint16 newNumAllocated = (uint16)((numSamples / normaliseBlockSize) + 4);
+		auto newNumAllocated = (uint16_t)((numSamples / normaliseBlockSize) + 4);
 
 		if (newNumAllocated != numAllocated)
 		{
@@ -1942,7 +1930,7 @@ void CompressionHelpers::NormaliseMap::copyNormalisationTable(NormaliseMap& dst,
 	memcpy(dst.getTableData() + end , getTableData() + start, numIndexes);
 }
 
-void CompressionHelpers::NormaliseMap::copyIntBufferWithNormalisation(const NormaliseMap& srcMap, const int16* srcWithoutOffset, int16* dstWithoutOffset, int startSampleSource, int startSampleDst, int numSamples, bool overwriteTable)
+void CompressionHelpers::NormaliseMap::copyIntBufferWithNormalisation(const NormaliseMap& srcMap, const int16_t* srcWithoutOffset, int16_t* dstWithoutOffset, int startSampleSource, int startSampleDst, int numSamples, bool overwriteTable)
 {
 	auto srcOffset = (srcMap.getOffset() + startSampleSource) % normaliseBlockSize;
 	auto dstOffset = (getOffset() + startSampleDst) % normaliseBlockSize;
@@ -1959,7 +1947,7 @@ void CompressionHelpers::NormaliseMap::copyIntBufferWithNormalisation(const Norm
 
 	auto d = dstWithoutOffset + startSampleDst;
 	auto s = srcWithoutOffset + startSampleSource;
-	memcpy(d, s, sizeof(int16) * numSamples);
+	memcpy(d, s, sizeof(int16_t) * numSamples);
 }
 
 void CompressionHelpers::NormaliseMap::setOffset(int offsetToUse)
@@ -1972,7 +1960,7 @@ juce::int16 CompressionHelpers::NormaliseMap::size() const
 	return allocated != nullptr ? numAllocated : PreallocatedSize;
 }
 
-void CompressionHelpers::NormaliseMap::internalNormalisation(const float* src, int16* dst, int numSamples, uint8 amount) const
+void CompressionHelpers::NormaliseMap::internalNormalisation(const float* src, int16_t* dst, int numSamples, uint8_t amount) const
 {
 	if (amount == 0)
 		return;
@@ -1982,7 +1970,7 @@ void CompressionHelpers::NormaliseMap::internalNormalisation(const float* src, i
 	for (int i = 0; i < numSamples; i++)
 	{
 		auto gainedValue = src[i] * (float)gainFactor * (float)INT16_MAX;
-		dst[i] = (int16)(gainedValue);
+		dst[i] = (int16_t)(gainedValue);
 	};
 }
 

--- a/hi_lac/hlac/CompressionHelpers.h
+++ b/hi_lac/hlac/CompressionHelpers.h
@@ -34,7 +34,7 @@
 #ifndef COMPRESSIONHELPERS_H_INCLUDED
 #define COMPRESSIONHELPERS_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 #define DUMP(x) CompressionHelpers::dump(x);
 
@@ -65,17 +65,17 @@ struct CompressionHelpers
 			memset(preallocated, 0, 16);
 		}
 
-		void normalisedInt16ToFloat(float* destination, const int16* src, int start, int numSamples) const;
+		void normalisedInt16ToFloat(float* destination, const int16_t* src, int start, int numSamples) const;
 
 		/** You can use a fixed amount of normalisation instead of splitting it into chunks of 1024 samples.
 		*
 		*	Doing so will create a compromise between file size and audio quality.
 		*/
-		void setUseStaticNormalisation(uint8 staticNormalisationAmount);
+		void setUseStaticNormalisation(uint8_t staticNormalisationAmount);
 
-		bool writeNormalisationHeader(OutputStream& output);
+		bool writeNormalisationHeader(juce::OutputStream& output);
 
-		void setMode(uint8 newMode)
+		void setMode(uint8_t newMode)
 		{
 			normalisationMode = newMode;
 			active = newMode > 0;
@@ -85,50 +85,50 @@ struct CompressionHelpers
 		void setNormalisationValues(int readOffset, int normalisedValues);
 
 		/** This applies normalisation. */
-		void normalise(const float* src, int16* dst, int numSamples);
+		void normalise(const float* src, int16_t* dst, int numSamples);
 
 		void allocateTableIndexes(int numSamples);
 
 		void copyNormalisationTable(NormaliseMap& dst, int startSampleSource, int startSampleDst, int numSamples) const;
 
-		void copyIntBufferWithNormalisation(const NormaliseMap& srcMap, const int16* srcWithoutOffset, int16* dstWithoutOffset, int startSampleSource, int startSampleDst, int numSamples, bool overwriteTable);
+		void copyIntBufferWithNormalisation(const NormaliseMap& srcMap, const int16_t* srcWithoutOffset, int16_t* dstWithoutOffset, int startSampleSource, int startSampleDst, int numSamples, bool overwriteTable);
 
 		int getOffset() const { return firstOffset; }
 
 		/** If the buffers are not aligned to a 1024 sample boundary, you can set the first range length here in order to synchronise it. */
 		void setOffset(int offsetToUse);
 
-		void setThreshold(uint8 newThreshhold)
+		void setThreshold(uint8_t newThreshhold)
 		{
 			minNormalisation = newThreshhold;
 		}
 
 	private:
 
-		uint8 minNormalisation = 0;
+		uint8_t minNormalisation = 0;
 
 		friend class HiseSampleBuffer;
 
-		int16 size() const;
+		int16_t size() const;
 
-		void internalNormalisation(const float* src, int16* dst, int numSamples, uint8 amount) const;
+		void internalNormalisation(const float* src, int16_t* dst, int numSamples, uint8_t amount) const;
 
-		const uint16 getIndexForSamplePosition(int samplePosition, bool roundUp=false) const
+		const uint16_t getIndexForSamplePosition(int samplePosition, bool roundUp=false) const
 		{
 			if (roundUp)
 			{
 				auto value = std::ceil((double)samplePosition / (double)normaliseBlockSize);
-				return (uint16)roundToInt(value);
+				return (uint16_t)juce::roundToInt(value);
 			}
 			else
 			{
-				return (uint16)((samplePosition) / normaliseBlockSize);
+				return (uint16_t)((samplePosition) / normaliseBlockSize);
 			}
 
 			
 		}
 
-		const uint8 * getTableData() const
+		const uint8_t * getTableData() const
 		{
 			if (allocated != nullptr)
 				return allocated;
@@ -136,7 +136,7 @@ struct CompressionHelpers
 				return preallocated;
 		}
 
-		uint8 * getTableData()
+		uint8_t * getTableData()
 		{
 			if (allocated != nullptr)
 				return allocated;
@@ -148,12 +148,12 @@ struct CompressionHelpers
 
 		static constexpr int normaliseBlockSize = 1024;
 
-		uint8 normalisationMode = Mode::NoNormalisation;
+		uint8_t normalisationMode = Mode::NoNormalisation;
 		int firstOffset = 0;
 
-		uint8 preallocated[PreallocatedSize];
-		uint16 numAllocated = 0;
-		HeapBlock<uint8> allocated;
+		uint8_t preallocated[PreallocatedSize];
+		uint16_t numAllocated = 0;
+        juce::HeapBlock<uint8_t> allocated;
 		bool active = false;
 	};
 
@@ -165,9 +165,9 @@ struct CompressionHelpers
 	*/
 	struct AudioBufferInt16
 	{
-		AudioBufferInt16(AudioSampleBuffer& b, int channelToUse, uint8 normalisationMode, uint8 normalisationThreshold=0);
-		AudioBufferInt16(int16* externalData_, int numSamples);
-		AudioBufferInt16(const int16* externalData_, int numSamples);
+		AudioBufferInt16(juce::AudioSampleBuffer& b, int channelToUse, uint8_t normalisationMode, uint8_t normalisationThreshold=0);
+		AudioBufferInt16(int16_t* externalData_, int numSamples);
+		AudioBufferInt16(const int16_t* externalData_, int numSamples);
 		AudioBufferInt16(int size_=0);
 
 		AudioBufferInt16(AudioBufferInt16&& other)
@@ -198,15 +198,15 @@ struct CompressionHelpers
 			return *this;
 		}
 
-		~AudioBufferInt16();;
-		AudioSampleBuffer getFloatBuffer() const;
+		~AudioBufferInt16();
+        juce::AudioSampleBuffer getFloatBuffer() const;
 
 		void reverse(int startSample, int numSamples);
 		void negate();
 		void applyGainRamp(int startOffset, int rampLength, float startGain, float endGain);
 
-		int16* getWritePointer(int startSample = 0);
-		const int16* getReadPointer(int startSample = 0) const;
+		int16_t* getWritePointer(int startSample = 0);
+		const int16_t* getReadPointer(int startSample = 0) const;
 
 		int size = 0;
 
@@ -226,61 +226,61 @@ struct CompressionHelpers
 		void deAllocate();
 
 		bool isReadOnly = false;
-		int16* data = nullptr;
-		int16* externalData = nullptr;
+		int16_t* data = nullptr;
+		int16_t* externalData = nullptr;
 
 		NormaliseMap map;
 	};
 
 	/** Loads a file into a AudioSampleBuffer. */
-	static AudioSampleBuffer loadFile(const File& f, double& speed);;
+	static juce::AudioSampleBuffer loadFile(const juce::File& f, double& speed);;
 
-	static float getFLACRatio(const File& f, double& speed);
+	static float getFLACRatio(const juce::File& f, double& speed);
 
 	/** returns the lowest bit rate needed to store the data without losses. */
-	static uint8 getPossibleBitReductionAmount(const AudioBufferInt16& b);
+	static uint8_t getPossibleBitReductionAmount(const AudioBufferInt16& b);
 
 	/** returns the amount of blocks in the buffer using the global compression block size. */
-	static int getBlockAmount(AudioSampleBuffer& b);
+	static int getBlockAmount (juce::AudioSampleBuffer& b);
 
 	/** A few operations on blocks of signed 16 bit integer data. */
 	struct IntVectorOperations
 	{
 		/** Copies the values from src1 into dst, and calculates the normalized difference. */
-		static void sub(int16* dst, const int16* src1, const int16* src2, int numValues);
+		static void sub(int16_t* dst, const int16_t* src1, const int16_t* src2, int numValues);
 
 		/** dst = dst - src inplace. */
-		static void sub(int16* dst, const int16* src, int numValues);
+		static void sub(int16_t* dst, const int16_t* src, int numValues);
 
 		/** Adds the values from src to dst. */
-		static void add(int16* dst, const int16* src, int numSamples);
+		static void add(int16_t* dst, const int16_t* src, int numSamples);
 
-		static void mul(int16*dst, const int16 value, int numSamples);
+		static void mul(int16_t* dst, const int16_t value, int numSamples);
 
-		static void div(int16* dst, const int16 value, int numSamples);
+		static void div(int16_t* dst, const int16_t value, int numSamples);
 
 		/** Removes the dc offset and returns the value. */
-		static int16 removeDCOffset(int16* data, int numValues);
+		static int16_t removeDCOffset(int16_t* data, int numValues);
 
 		/** Returns the absolute max value in the data block. */
-		static int16 max(const int16* d, int numValues);
+		static int16_t max(const int16_t* d, int numValues);
 
 		/** Clears the data (sets it to zero). */
-		static void clear(int16* d, int numValues);
+		static void clear(int16_t* d, int numValues);
 	};
 
 	/** Gets the possible bit reduction amount for the next cycle with the given cycleLength. 
 	*
 	*	Don't use this directly, but use getCycleLengthWithLowestBitrate() instead. */
-	static uint8 getBitrateForCycleLength(const AudioBufferInt16& block, int cycleLength, AudioBufferInt16& workBuffer);
+	static uint8_t getBitrateForCycleLength(const AudioBufferInt16& block, int cycleLength, AudioBufferInt16& workBuffer);
 
-	static void normaliseBlock(int16* data, int numSamples, int normalisationAmount, int direction, bool applyDither=false);
+	static void normaliseBlock(int16_t* data, int numSamples, int normalisationAmount, int direction, bool applyDither=false);
 
 	/** Get the cycle length the yields the lowest bit rate for the next cycle and store the bitrate in bitRate. */
 	static int getCycleLengthWithLowestBitRate(const AudioBufferInt16& block, int& bitRate, AudioBufferInt16& workBuffer);
 
 	/** calculates the max bit reduction when applying the last cycle. */
-	static uint8 getBitReductionWithTemplate(AudioBufferInt16& lastCycle, AudioBufferInt16& nextCycle, bool removeDc);
+	static uint8_t getBitReductionWithTemplate(AudioBufferInt16& lastCycle, AudioBufferInt16& nextCycle, bool removeDc);
 
 	/** Return a section b as new AudioBufferInt16 without allocating. */
 	static AudioBufferInt16 getPart(AudioBufferInt16& b, int startIndex, int numSamples);
@@ -290,24 +290,24 @@ struct CompressionHelpers
 
 	struct Misc
 	{
-		static uint64 NumberOfSetBits(uint64 i);
+		static uint64_t NumberOfSetBits(uint64_t i);
 
-		static uint8 getSampleRateIndex(double sampleRate);
+		static uint8_t getSampleRateIndex(double sampleRate);
 
-		static uint32 createChecksum();
+		static uint32_t createChecksum();
 
-		static bool validateChecksum(uint32 data);
+		static bool validateChecksum(uint32_t data);
 	};
 
 	static int getPaddedSampleSize(int samplesNeeded);
 
-	static uint8 getBitReductionForDifferential(AudioBufferInt16& b);
+	static uint8_t getBitReductionForDifferential(AudioBufferInt16& b);
 
 	static int getByteAmountForDifferential(AudioBufferInt16& b);
 
-	static void dump(const AudioBufferInt16& b, String fileName=String());
+	static void dump(const AudioBufferInt16& b, juce::String fileName = juce::String());
 
-	static void dump(const AudioSampleBuffer& b, String fileName = String());
+	static void dump(const juce::AudioSampleBuffer& b, juce::String fileName = juce::String());
 
 	static void fastInt16ToFloat(const void* source, float* destination, int numSamples);
 
@@ -332,22 +332,22 @@ struct CompressionHelpers
 		static void downSampleBuffer(AudioBufferInt16& b);
 
 		/** Distributes the given samples from fullSamplesPacked to the destination buffer. */
-		static void distributeFullSamples(AudioBufferInt16& dst, const uint16* fullSamplesPacked, int numSamples);
+		static void distributeFullSamples(AudioBufferInt16& dst, const uint16_t* fullSamplesPacked, int numSamples);
 
-		static void addErrorSignal(AudioBufferInt16& dst, const uint16* errorSignalPacked, int numSamples);
+		static void addErrorSignal(AudioBufferInt16& dst, const uint16_t* errorSignalPacked, int numSamples);
 
 		
 
 	};
 
-	static uint8 checkBuffersEqual(AudioSampleBuffer& workBuffer, AudioSampleBuffer& referenceBuffer);
+	static uint8_t checkBuffersEqual(juce::AudioSampleBuffer& workBuffer, juce::AudioSampleBuffer& referenceBuffer);
 
-	static AudioSampleBuffer getPart(HiseSampleBuffer& b, int startIndex, int numSamples);
+	static juce::AudioSampleBuffer getPart(HiseSampleBuffer& b, int startIndex, int numSamples);
 
 	/** Return a section b as new AudioSampleBuffer without allocating. */
-	static AudioSampleBuffer getPart(AudioSampleBuffer& b, int startIndex, int numSamples);
+	static juce::AudioSampleBuffer getPart(juce::AudioSampleBuffer& b, int startIndex, int numSamples);
 
-	static AudioSampleBuffer getPart(AudioSampleBuffer& b, int channelIndex, int startIndex, int numSamples);
+	static juce::AudioSampleBuffer getPart(juce::AudioSampleBuffer& b, int channelIndex, int startIndex, int numSamples);
 };
 
 class HlacMemoryMappedAudioFormatReader;
@@ -386,11 +386,11 @@ struct HlacArchiver
 
 	struct CompressData
 	{
-		Array<File> fileList;
-		File optionalHeaderFile;
-		File targetFile;
-		String metadataJSON;
-		int64 partSize = -1;
+        juce::Array<juce::File> fileList;
+        juce::File optionalHeaderFile;
+        juce::File targetFile;
+        juce::String metadataJSON;
+		int64_t partSize = -1;
 		double* progress = nullptr;
 		double* totalProgress = nullptr;
 	};
@@ -399,8 +399,8 @@ struct HlacArchiver
 	{
 		OverwriteOption option;
 		bool supportFullDynamics = false;
-		File sourceFile;
-		File targetDirectory;
+        juce::File sourceFile;
+        juce::File targetDirectory;
 		double* progress = nullptr;
 		double* partProgress = nullptr;
 		double* totalProgress = nullptr;
@@ -408,7 +408,7 @@ struct HlacArchiver
 
 	};
 
-	HlacArchiver(Thread* threadToUse) :
+	HlacArchiver(juce::Thread* threadToUse) :
 		thread(threadToUse)
 	{}
 
@@ -416,11 +416,11 @@ struct HlacArchiver
 	{
         virtual ~Listener() {};
         
-		virtual void logStatusMessage(const String& message) = 0;
+		virtual void logStatusMessage(const juce::String& message) = 0;
 
-		virtual void logVerboseMessage(const String& verboseMessage) = 0;
+		virtual void logVerboseMessage(const juce::String& verboseMessage) = 0;
 
-		virtual void criticalErrorOccured(const String& message) = 0;
+		virtual void criticalErrorOccured(const juce::String& message) = 0;
 	};
 
 	/** Extracts the compressed data from the given file. */
@@ -429,9 +429,9 @@ struct HlacArchiver
 	/** Compressed the given data using the supplied Thread. */
 	void compressSampleData(const CompressData& data);
 
-	static String getMetadataJSON(const File& sourceFile);
+	static juce::String getMetadataJSON(const juce::File& sourceFile);
 
-	var readMetadataFromArchive(const File& archiveFile);
+    juce::var readMetadataFromArchive(const juce::File& archiveFile);
 
 	void setListener(Listener* l)
 	{
@@ -440,28 +440,28 @@ struct HlacArchiver
 
 private:
 
-	FileInputStream* writeTempFile(AudioFormatReader* reader, int bitDepth=16);
+    juce::FileInputStream* writeTempFile(juce::AudioFormatReader* reader, int bitDepth=16);
 
 	Listener* listener = nullptr;
 
-	String getFlagName(Flag f);
+    juce::String getFlagName(Flag f);
 
-	File getPartFile(const File& originalFile, int partIndex);
+    juce::File getPartFile(const juce::File& originalFile, int partIndex);
 
-	bool writeFlag(FileOutputStream* fos, Flag flag);
+	bool writeFlag(juce::FileOutputStream* fos, Flag flag);
 
-	bool readAndCheckFlag(FileInputStream* fis, Flag flag);
+	bool readAndCheckFlag(juce::FileInputStream* fis, Flag flag);
 
-	Flag readFlag(FileInputStream* fis);
+	Flag readFlag(juce::FileInputStream* fis);
 
 	Flag currentFlag = Flag::numFlags;
 
 	bool decompressMode = false;
 
-	Thread* thread = nullptr;
+    juce::Thread* thread = nullptr;
 	
 	
-	File tmpFile;
+    juce::File tmpFile;
 
 	double deltaPerFile = 0.1;
 	double fileProgress = 0.0;

--- a/hi_lac/hlac/HiseLosslessAudioFormat.cpp
+++ b/hi_lac/hlac/HiseLosslessAudioFormat.cpp
@@ -30,22 +30,22 @@
  *   ===========================================================================
  */
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 HiseLosslessAudioFormat::HiseLosslessAudioFormat() :
-	AudioFormat("HLAC", StringArray({ ".hlac", ".ch1", ".ch2", ".ch3", ".ch4", ".ch5" }))
+    juce::AudioFormat("HLAC", juce::StringArray({ ".hlac", ".ch1", ".ch2", ".ch3", ".ch4", ".ch5" }))
 {
 
 }
 
-bool HiseLosslessAudioFormat::canHandleFile(const File& fileToTest)
+bool HiseLosslessAudioFormat::canHandleFile(const juce::File& fileToTest)
 {
 	return fileToTest.getFileExtension() == ".hlac" || fileToTest.getFileExtension().contains("ch");
 }
 
-Array<int> HiseLosslessAudioFormat::getPossibleSampleRates()
+juce::Array<int> HiseLosslessAudioFormat::getPossibleSampleRates()
 {
-	Array<int> sampleRates;
+    juce::Array<int> sampleRates;
 
 	sampleRates.add(11025);
 	sampleRates.add(22050);
@@ -58,9 +58,9 @@ Array<int> HiseLosslessAudioFormat::getPossibleSampleRates()
 	return sampleRates;
 }
 
-Array<int> HiseLosslessAudioFormat::getPossibleBitDepths()
+juce::Array<int> HiseLosslessAudioFormat::getPossibleBitDepths()
 {
-	Array<int> bitRates;
+    juce::Array<int> bitRates;
 
 	bitRates.add(16); // that's it folks :)
 
@@ -83,23 +83,23 @@ bool HiseLosslessAudioFormat::isCompressed()
 	return true;
 }
 
-StringArray HiseLosslessAudioFormat::getQualityOptions()
+juce::StringArray HiseLosslessAudioFormat::getQualityOptions()
 {
-	StringArray options;
+    juce::StringArray options;
 
 	options.add("EncodeMode");
 
 	return options;
 }
 
-AudioFormatReader* HiseLosslessAudioFormat::createReaderFor(InputStream* sourceStream, bool deleteStreamIfOpeningFails)
+juce::AudioFormatReader* HiseLosslessAudioFormat::createReaderFor(juce::InputStream* sourceStream, bool deleteStreamIfOpeningFails)
 {
-	ignoreUnused(deleteStreamIfOpeningFails);
+    juce::ignoreUnused(deleteStreamIfOpeningFails);
 
 	return new HiseLosslessAudioFormatReader(sourceStream);
 }
 
-AudioFormatWriter* HiseLosslessAudioFormat::createWriterFor(OutputStream* streamToWriteTo, double sampleRateToUse, unsigned int numberOfChannels, int /*bitsPerSample*/, const StringPairArray& metadataValues, int /*qualityOptionIndex*/)
+juce::AudioFormatWriter* HiseLosslessAudioFormat::createWriterFor(juce::OutputStream* streamToWriteTo, double sampleRateToUse, unsigned int numberOfChannels, int /*bitsPerSample*/, const juce::StringPairArray& metadataValues, int /*qualityOptionIndex*/)
 {
 	HiseLosslessAudioFormatWriter::EncodeMode mode = metadataValues.getValue("EncodeMode", "Diff") == "Block" ?
 		HiseLosslessAudioFormatWriter::EncodeMode::Block :
@@ -114,17 +114,17 @@ AudioFormatWriter* HiseLosslessAudioFormat::createWriterFor(OutputStream* stream
 }
 
 
-MemoryMappedAudioFormatReader* HiseLosslessAudioFormat::createMemoryMappedReader(FileInputStream* fin)
+juce::MemoryMappedAudioFormatReader* HiseLosslessAudioFormat::createMemoryMappedReader(juce::FileInputStream* fin)
 {
 #if JUCE_64BIT
-	ScopedPointer<AudioFormatReader> normalReader = new HiseLosslessAudioFormatReader(fin);
+    juce::ScopedPointer<juce::AudioFormatReader> normalReader = new HiseLosslessAudioFormatReader(fin);
 
-	ScopedPointer<HlacMemoryMappedAudioFormatReader> reader = new HlacMemoryMappedAudioFormatReader(fin->getFile(), *normalReader, 0, normalReader->lengthInSamples, 1);
+    juce::ScopedPointer<HlacMemoryMappedAudioFormatReader> reader = new HlacMemoryMappedAudioFormatReader(fin->getFile(), *normalReader, 0, normalReader->lengthInSamples, 1);
 
 	return reader.release();
 #else
 
-	ignoreUnused(fin);
+    juce::ignoreUnused(fin);
 
 	// Memory mapped file support on 32bit is pretty useless so we don't bother at all...
 	jassertfalse;
@@ -132,14 +132,14 @@ MemoryMappedAudioFormatReader* HiseLosslessAudioFormat::createMemoryMappedReader
 #endif
 }
 
-MemoryMappedAudioFormatReader* HiseLosslessAudioFormat::createMemoryMappedReader(const File& file)
+juce::MemoryMappedAudioFormatReader* HiseLosslessAudioFormat::createMemoryMappedReader(const juce::File& file)
 {
-	FileInputStream* fis = new FileInputStream(file);
+    auto* fis = new juce::FileInputStream(file);
 
 	return createMemoryMappedReader(fis);
 }
 
-HiseLosslessHeader::HiseLosslessHeader(bool useEncryption, uint8 globalBitShiftAmount, double sampleRate, int numChannels, int bitsPerSample, bool useCompression, uint32 numBlocks)
+HiseLosslessHeader::HiseLosslessHeader(bool useEncryption, uint8_t globalBitShiftAmount, double sampleRate, int numChannels, int bitsPerSample, bool useCompression, uint32_t numBlocks)
 {
 	headerByte1 = HLAC_VERSION;
 
@@ -159,7 +159,7 @@ HiseLosslessHeader::HiseLosslessHeader(bool useEncryption, uint8 globalBitShiftA
 	blockOffsets.calloc(blockAmount);
 }
 
-HiseLosslessHeader::HiseLosslessHeader(InputStream* input)
+HiseLosslessHeader::HiseLosslessHeader(juce::InputStream* input)
 {
 	if (input == nullptr)
 	{
@@ -170,14 +170,14 @@ HiseLosslessHeader::HiseLosslessHeader(InputStream* input)
 	readMetadataFromStream(input);
 }
 
-HiseLosslessHeader::HiseLosslessHeader(const File& f)
+HiseLosslessHeader::HiseLosslessHeader(const juce::File& f)
 {
-	ScopedPointer<FileInputStream> fis = new FileInputStream(f);
+	auto fis = f.createInputStream();
 
-	readMetadataFromStream(fis);
+	readMetadataFromStream(fis.get());
 }
 
-void HiseLosslessHeader::readMetadataFromStream(InputStream* input)
+void HiseLosslessHeader::readMetadataFromStream (juce::InputStream* input)
 {
 	//metadata = input->readInt64();
 
@@ -196,7 +196,7 @@ void HiseLosslessHeader::readMetadataFromStream(InputStream* input)
 	}
 	else
 	{
-		const uint32 checkSum = (uint32)input->readInt();
+		const uint32_t checkSum = (uint32_t)input->readInt();
 		headerValid = CompressionHelpers::Misc::validateChecksum(checkSum);
 
 		if (!headerValid)
@@ -211,18 +211,18 @@ void HiseLosslessHeader::readMetadataFromStream(InputStream* input)
 		{
 			headerByte2 = input->readByte();
 			sampleDataByte = input->readByte();
-			blockAmount = (uint32)input->readInt();
+			blockAmount = (uint32_t)input->readInt();
 
 			blockOffsets.malloc(blockAmount);
 
-			for (uint32 i = 0; i < blockAmount; i++)
+			for (uint32_t i = 0; i < blockAmount; i++)
 			{
-				blockOffsets[i] = (uint32)input->readInt();
+				blockOffsets[i] = (uint32_t)input->readInt();
 			}
 		}
 	}
 
-	headerSize = (uint32)input->getPosition();
+	headerSize = (uint32_t)input->getPosition();
 }
 
 
@@ -282,17 +282,17 @@ double HiseLosslessHeader::getSampleRate() const
 	else
 	{
 		const static double sampleRates[4] = { 44100.0, 48000.0, 88200.0, 96000.0 };
-		const uint8 srIndex = (sampleDataByte & 0xC0) >> 6;
+		const uint8_t srIndex = (sampleDataByte & 0xC0) >> 6;
 		return sampleRates[srIndex];
 	}
 }
 
-uint32 HiseLosslessHeader::getBlockAmount() const 
+uint32_t HiseLosslessHeader::getBlockAmount() const
 {
 	return blockAmount;
 }
 
-bool HiseLosslessHeader::write(OutputStream* output)
+bool HiseLosslessHeader::write (juce::OutputStream* output)
 {
 	output->writeByte(headerByte1);
 
@@ -308,7 +308,7 @@ bool HiseLosslessHeader::write(OutputStream* output)
 
 	output->writeInt((int)blockAmount);
 	
-	for (uint32 i = 0; i < blockAmount; i++)
+	for (uint32_t i = 0; i < blockAmount; i++)
 	{
 		if (!output->writeInt(blockOffsets[i]))
 			return false;
@@ -317,9 +317,9 @@ bool HiseLosslessHeader::write(OutputStream* output)
 	return true;
 }
 
-void HiseLosslessHeader::storeOffsets(uint32* offsets, int numOffsets)
+void HiseLosslessHeader::storeOffsets(uint32_t* offsets, int numOffsets)
 {
-	memcpy(blockOffsets, offsets, sizeof(uint32)*numOffsets);
+	memcpy(blockOffsets, offsets, sizeof(uint32_t)*numOffsets);
 }
 
 } // namespace hlac

--- a/hi_lac/hlac/HiseLosslessAudioFormat.h
+++ b/hi_lac/hlac/HiseLosslessAudioFormat.h
@@ -34,10 +34,10 @@
 #ifndef HISELOSSLESSAUDIOFORMAT_H_INCLUDED
 #define HISELOSSLESSAUDIOFORMAT_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 
-class HiseLosslessAudioFormat : public AudioFormat
+class HiseLosslessAudioFormat : public juce::AudioFormat
 {
 public:
 
@@ -47,10 +47,10 @@ public:
 
 	~HiseLosslessAudioFormat() {}
 
-	bool canHandleFile(const File& fileToTest) override;
+	bool canHandleFile(const juce::File& fileToTest) override;
 
-	Array<int> getPossibleSampleRates() override;
-	Array<int> getPossibleBitDepths() override;
+    juce::Array<int> getPossibleSampleRates() override;
+    juce::Array<int> getPossibleBitDepths() override;
 
 	bool canDoMono() override;
 	bool canDoStereo() override;
@@ -58,16 +58,16 @@ public:
 
 	
 
-	StringArray getQualityOptions() override;
+    juce::StringArray getQualityOptions() override;
 
-	AudioFormatReader* createReaderFor(InputStream* sourceStream, bool deleteStreamIfOpeningFails) override;
-	AudioFormatWriter* createWriterFor(OutputStream* streamToWriteTo, double sampleRateToUse, unsigned int numberOfChannels, int /*bitsPerSample*/, const StringPairArray& metadataValues, int /*qualityOptionIndex*/) override;
+    juce::AudioFormatReader* createReaderFor (juce::InputStream* sourceStream, bool deleteStreamIfOpeningFails) override;
+    juce::AudioFormatWriter* createWriterFor (juce::OutputStream* streamToWriteTo, double sampleRateToUse, unsigned int numberOfChannels, int /*bitsPerSample*/, const juce::StringPairArray& metadataValues, int /*qualityOptionIndex*/) override;
 
-	MemoryMappedAudioFormatReader* createMemoryMappedReader(FileInputStream* fin) override;
+    juce::MemoryMappedAudioFormatReader* createMemoryMappedReader (juce::FileInputStream* fin) override;
 
-	MemoryMappedAudioFormatReader* createMemoryMappedReader(const File& file) override;
+    juce::MemoryMappedAudioFormatReader* createMemoryMappedReader (const juce::File& file) override;
 
-	HeapBlock<uint32> blockOffsets;
+    juce::HeapBlock<uint32_t> blockOffsets;
 };
 
 } // namespace hlac

--- a/hi_lac/hlac/HlacAudioFormatReader.cpp
+++ b/hi_lac/hlac/HlacAudioFormatReader.cpp
@@ -30,11 +30,11 @@
  *   ===========================================================================
  */
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
-HiseLosslessAudioFormatReader::HiseLosslessAudioFormatReader(InputStream* input_) :
-	AudioFormatReader(input_, "HLAC"),
-	internalReader(input_)
+HiseLosslessAudioFormatReader::HiseLosslessAudioFormatReader(juce::InputStream* input_) :
+    juce::AudioFormatReader(input_, "HLAC"),
+    internalReader(input_)
 {
 	numChannels = internalReader.header.getNumChannels();
 	sampleRate = internalReader.header.getSampleRate();
@@ -45,11 +45,11 @@ HiseLosslessAudioFormatReader::HiseLosslessAudioFormatReader(InputStream* input_
 
 	if (isMonolith)
 	{
-		lengthInSamples = (input_->getTotalLength() - 1) / numChannels / sizeof(int16);
+		lengthInSamples = (input_->getTotalLength() - 1) / numChannels / sizeof(int16_t);
 	}
 }
 
-bool HiseLosslessAudioFormatReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples)
+bool HiseLosslessAudioFormatReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples)
 {
 	if (isMonolith)
 	{
@@ -59,7 +59,7 @@ bool HiseLosslessAudioFormatReader::readSamples(int** destSamples, int numDestCh
 		if (numSamples <= 0)
 			return true;
 
-		const int bytesPerFrame = sizeof(int16) * numChannels;
+		const int bytesPerFrame = sizeof(int16_t) * numChannels;
 
 		input->setPosition(1 + startSampleInFile * bytesPerFrame);
 
@@ -68,13 +68,13 @@ bool HiseLosslessAudioFormatReader::readSamples(int** destSamples, int numDestCh
 			const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
 			char tempBuffer[tempBufSize];
 
-			const int numThisTime = jmin(tempBufSize / bytesPerFrame, numSamples);
+			const int numThisTime = juce::jmin(tempBufSize / bytesPerFrame, numSamples);
 			const int bytesRead = input->read(tempBuffer, numThisTime * bytesPerFrame);
 
 			if (bytesRead < numThisTime * bytesPerFrame)
 			{
 				jassert(bytesRead >= 0);
-				zeromem(tempBuffer + bytesRead, (size_t)(numThisTime * bytesPerFrame - bytesRead));
+                juce::zeromem(tempBuffer + bytesRead, (size_t)(numThisTime * bytesPerFrame - bytesRead));
 			}
 
 			copySampleData(destSamples, startOffsetInDestBuffer, numDestChannels,
@@ -93,20 +93,20 @@ bool HiseLosslessAudioFormatReader::readSamples(int** destSamples, int numDestCh
 }
 
 
-void HiseLosslessAudioFormatReader::setTargetAudioDataType(AudioDataConverters::DataFormat dataType)
+void HiseLosslessAudioFormatReader::setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType)
 {
-	usesFloatingPointData = (dataType == AudioDataConverters::DataFormat::float32BE) ||
-		(dataType == AudioDataConverters::DataFormat::float32LE);
+	usesFloatingPointData = (dataType == juce::AudioDataConverters::DataFormat::float32BE) ||
+		(dataType == juce::AudioDataConverters::DataFormat::float32LE);
 
 	internalReader.setTargetAudioDataType(dataType);
 }
 
 
-uint32 HiseLosslessHeader::getOffsetForReadPosition(int64 samplePosition, bool addHeaderOffset)
+uint32_t HiseLosslessHeader::getOffsetForReadPosition(int64_t samplePosition, bool addHeaderOffset)
 {
 	if (samplePosition % COMPRESSION_BLOCK_SIZE == 0)
 	{
-		uint32 blockIndex = (uint32)samplePosition / COMPRESSION_BLOCK_SIZE;
+		auto blockIndex = (uint32_t)samplePosition / COMPRESSION_BLOCK_SIZE;
 
 		if (blockIndex < blockAmount)
 		{
@@ -120,7 +120,7 @@ uint32 HiseLosslessHeader::getOffsetForReadPosition(int64 samplePosition, bool a
 	}
 	else
 	{
-		auto blockIndex = (uint32)samplePosition / COMPRESSION_BLOCK_SIZE;
+		auto blockIndex = (uint32_t)samplePosition / COMPRESSION_BLOCK_SIZE;
 
 		if (blockIndex < blockAmount)
 		{
@@ -134,11 +134,11 @@ uint32 HiseLosslessHeader::getOffsetForReadPosition(int64 samplePosition, bool a
 	}
 }
 
-uint32 HiseLosslessHeader::getOffsetForNextBlock(int64 samplePosition, bool addHeaderOffset)
+uint32_t HiseLosslessHeader::getOffsetForNextBlock(int64_t samplePosition, bool addHeaderOffset)
 {
 	if (samplePosition % COMPRESSION_BLOCK_SIZE == 0)
 	{
-		uint32 blockIndex = (uint32)samplePosition / COMPRESSION_BLOCK_SIZE;
+		auto blockIndex = (uint32_t)samplePosition / COMPRESSION_BLOCK_SIZE;
 
 		if (blockIndex < blockAmount-1)
 		{
@@ -152,7 +152,7 @@ uint32 HiseLosslessHeader::getOffsetForNextBlock(int64 samplePosition, bool addH
 	}
 	else
 	{
-		auto blockIndex = (uint32)samplePosition / COMPRESSION_BLOCK_SIZE;
+		auto blockIndex = (uint32_t)samplePosition / COMPRESSION_BLOCK_SIZE;
 
 		if (blockIndex < blockAmount-1)
 		{
@@ -178,16 +178,16 @@ HiseLosslessHeader HiseLosslessHeader::createMonolithHeader(int numChannels, dou
 	return monoHeader;
 }
 
-void HlacReaderCommon::setTargetAudioDataType(AudioDataConverters::DataFormat dataType)
+void HlacReaderCommon::setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType)
 {
-	usesFloatingPointData = (dataType == AudioDataConverters::DataFormat::float32BE) ||
-		(dataType == AudioDataConverters::DataFormat::float32LE);
+	usesFloatingPointData = (dataType == juce::AudioDataConverters::DataFormat::float32BE) ||
+		(dataType == juce::AudioDataConverters::DataFormat::float32LE);
 }
 
-bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples)
+bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples)
 {
-	ignoreUnused(startSampleInFile);
-	ignoreUnused(numDestChannels);
+    juce::ignoreUnused(startSampleInFile);
+    juce::ignoreUnused(numDestChannels);
 
 	decoder.setHlacVersion(header.getVersion());
 
@@ -197,7 +197,7 @@ bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, 
 	{
 		auto byteOffset = header.getOffsetForReadPosition(startSampleInFile, useHeaderOffsetWhenSeeking);
 
-		decoder.seekToPosition(*input, (uint32)startSampleInFile, byteOffset);
+		decoder.seekToPosition(*input, (uint32_t)startSampleInFile, byteOffset);
 	}
 
 	if (isStereo)
@@ -219,14 +219,14 @@ bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, 
 				}
 			}
 
-			AudioSampleBuffer b(destinationFloat, 2, numSamples);
+            juce::AudioSampleBuffer b(destinationFloat, 2, numSamples);
 			HiseSampleBuffer hsb(b);
 
 			decoder.decode(hsb, true, *input, (int)startSampleInFile, numSamples);
 		}
 		else
 		{
-			int16** destinationFixed = reinterpret_cast<int16**>(destSamples);
+			auto** destinationFixed = reinterpret_cast<int16_t**>(destSamples);
 
 			if (isStereo)
 			{
@@ -249,7 +249,7 @@ bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, 
 		{
 			float* destinationFloat = reinterpret_cast<float*>(destSamples[0]);
 
-			AudioSampleBuffer b(&destinationFloat, 1, numSamples);
+            juce::AudioSampleBuffer b(&destinationFloat, 1, numSamples);
 			HiseSampleBuffer hsb(b);
 			hsb.allocateNormalisationTables((int)startSampleInFile);
 
@@ -257,7 +257,7 @@ bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, 
 		}
 		else
 		{
-			int16** destinationFixed = reinterpret_cast<int16**>(destSamples);
+			auto** destinationFixed = reinterpret_cast<int16_t**>(destSamples);
 
 			HiseSampleBuffer hsb(destinationFixed, 1, numSamples);
 			hsb.allocateNormalisationTables((int)startSampleInFile);
@@ -269,15 +269,15 @@ bool HlacReaderCommon::internalHlacRead(int** destSamples, int numDestChannels, 
 	return true;
 }
 
-bool HlacReaderCommon::fixedBufferRead(HiseSampleBuffer& buffer, int numDestChannels, int startOffsetInBuffer, int64 startSampleInFile, int numSamples)
+bool HlacReaderCommon::fixedBufferRead(HiseSampleBuffer& buffer, int numDestChannels, int startOffsetInBuffer, int64_t startSampleInFile, int numSamples)
 {
 	bool isStereo = numDestChannels == 2;
 
 	if (startSampleInFile < 0)
 	{
-		auto silence = (int)jmin(-startSampleInFile, (int64)numSamples);
+		auto silence = (int)juce::jmin(-startSampleInFile, (int64_t)numSamples);
 
-		auto numToClear = jmin(silence, buffer.getNumSamples() - startOffsetInBuffer);
+		auto numToClear = juce::jmin(silence, buffer.getNumSamples() - startOffsetInBuffer);
 
 		buffer.clear(startOffsetInBuffer, numToClear);
 
@@ -293,7 +293,7 @@ bool HlacReaderCommon::fixedBufferRead(HiseSampleBuffer& buffer, int numDestChan
 	{
 		auto byteOffset = header.getOffsetForReadPosition(startSampleInFile, useHeaderOffsetWhenSeeking);
 
-		decoder.seekToPosition(*input, (uint32)startSampleInFile, byteOffset);
+		decoder.seekToPosition(*input, (uint32_t)startSampleInFile, byteOffset);
 	}
 
 	decoder.setHlacVersion(header.getVersion());
@@ -316,20 +316,20 @@ void HiseLosslessAudioFormatReader::copySampleData(int* const* destSamples, int 
 
 	if (numChannels == 1)
 	{
-		ReadHelper<AudioData::Float32, AudioData::Int16, AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, 1, sourceData, 1, numSamples);
+		ReadHelper<juce::AudioData::Float32, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, 1, sourceData, 1, numSamples);
 	}
 	else
 	{
-		ReadHelper<AudioData::Float32, AudioData::Int16, AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, numDestChannels, sourceData, 2, numSamples);
+		ReadHelper<juce::AudioData::Float32, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, numDestChannels, sourceData, 2, numSamples);
 	}
 }
 
-bool HiseLosslessAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64 offsetInFile, int numChannelsToCopy, int numSamples)
+bool HiseLosslessAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64_t offsetInFile, int numChannelsToCopy, int numSamples)
 {
 	if (numSamples <= 0)
 		return true;
 
-	const int bytesPerFrame = sizeof(int16) * numChannelsToCopy;
+	const int bytesPerFrame = sizeof(int16_t) * numChannelsToCopy;
 
 	input->setPosition(1 + offsetInFile * bytesPerFrame);
 
@@ -338,13 +338,13 @@ bool HiseLosslessAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destinati
 		const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
 		char tempBuffer[tempBufSize];
 
-		const int numThisTime = jmin(tempBufSize / bytesPerFrame, numSamples);
+		const int numThisTime = juce::jmin(tempBufSize / bytesPerFrame, numSamples);
 		const int bytesRead = input->read(tempBuffer, numThisTime * bytesPerFrame);
 
 		if (bytesRead < numThisTime * bytesPerFrame)
 		{
 			jassert(bytesRead >= 0);
-			zeromem(tempBuffer + bytesRead, (size_t)(numThisTime * bytesPerFrame - bytesRead));
+            juce::zeromem(tempBuffer + bytesRead, (size_t)(numThisTime * bytesPerFrame - bytesRead));
 		}
 
 
@@ -354,20 +354,20 @@ bool HiseLosslessAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destinati
 
 		if (numChannelsToCopy == 1)
 		{
-			memcpy(destination.getWritePointer(0, startOffsetInBuffer), tempBuffer, numThisTime * sizeof(int16));
+			memcpy(destination.getWritePointer(0, startOffsetInBuffer), tempBuffer, numThisTime * sizeof(int16_t));
 
 			if (numDestChannels == 2)
 			{
-				memcpy(destination.getWritePointer(1, startOffsetInBuffer), tempBuffer, numThisTime * sizeof(int16));
+				memcpy(destination.getWritePointer(1, startOffsetInBuffer), tempBuffer, numThisTime * sizeof(int16_t));
 			}
 		}
 		else
 		{
 			jassert(destination.getNumChannels() == 2);
 
-			int16* channels[2] = { static_cast<int16*>(destination.getWritePointer(0, 0)), static_cast<int16*>(destination.getWritePointer(1, 0)) };
+			int16_t* channels[2] = { static_cast<int16_t*>(destination.getWritePointer(0, 0)), static_cast<int16_t*>(destination.getWritePointer(1, 0)) };
 
-			ReadHelper<AudioData::Int16, AudioData::Int16, AudioData::LittleEndian>::read(channels, startOffsetInBuffer, numDestChannels, tempBuffer, 2, numThisTime);
+			ReadHelper<juce::AudioData::Int16, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(channels, startOffsetInBuffer, numDestChannels, tempBuffer, 2, numThisTime);
 		}
 
 		startOffsetInBuffer += numThisTime;
@@ -377,14 +377,14 @@ bool HiseLosslessAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destinati
 	return true;
 }
 
-bool HlacMemoryMappedAudioFormatReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples)
+bool HlacMemoryMappedAudioFormatReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples)
 {
 	if (isMonolith)
 	{
 		clearSamplesBeyondAvailableLength(destSamples, numDestChannels, startOffsetInDestBuffer,
 			startSampleInFile, numSamples, lengthInSamples);
 
-		if (map == nullptr || !mappedSection.contains(Range<int64>(startSampleInFile, startSampleInFile + numSamples)))
+		if (map == nullptr || !mappedSection.contains(juce::Range<int64_t>(startSampleInFile, startSampleInFile + numSamples)))
 		{
 			jassertfalse; // you must make sure that the window contains all the samples you're going to attempt to read.
 			return false;
@@ -408,7 +408,7 @@ bool HlacMemoryMappedAudioFormatReader::readSamples(int** destSamples, int numDe
 }
 
 
-bool HlacMemoryMappedAudioFormatReader::mapSectionOfFile(Range<int64> samplesToMap)
+bool HlacMemoryMappedAudioFormatReader::mapSectionOfFile(juce::Range<int64_t> samplesToMap)
 {
 	if (isMonolith)
 	{
@@ -419,11 +419,11 @@ bool HlacMemoryMappedAudioFormatReader::mapSectionOfFile(Range<int64> samplesToM
 	}
 	else
 	{
-		dataChunkStart = (int64)internalReader.header.getOffsetForReadPosition(0, true);
+		dataChunkStart = (int64_t)internalReader.header.getOffsetForReadPosition(0, true);
 		dataLength = getFile().getSize() - dataChunkStart;
 
-		int64 start = (int64)internalReader.header.getOffsetForReadPosition(samplesToMap.getStart(), true);
-		int64 end = 0;
+		int64_t start = (int64_t)internalReader.header.getOffsetForReadPosition(samplesToMap.getStart(), true);
+		int64_t end = 0;
 
 		if (samplesToMap.getEnd() >= lengthInSamples)
 		{
@@ -434,25 +434,25 @@ bool HlacMemoryMappedAudioFormatReader::mapSectionOfFile(Range<int64> samplesToM
 			end = internalReader.header.getOffsetForNextBlock(samplesToMap.getEnd(), true);
 		}
 
-		auto fileRange = Range<int64>(start, end);
+		auto fileRange = juce::Range<int64_t>(start, end);
 
-		map.reset(new MemoryMappedFile(getFile(), fileRange, MemoryMappedFile::readOnly, false));
+		map.reset(new juce::MemoryMappedFile(getFile(), fileRange, juce::MemoryMappedFile::readOnly, false));
 
 		if (map != nullptr && !map->getRange().isEmpty())
 		{
-			int64 mappedStart = samplesToMap.getStart() / COMPRESSION_BLOCK_SIZE;
+			int64_t mappedStart = samplesToMap.getStart() / COMPRESSION_BLOCK_SIZE;
 
-			int64 mappedEnd = jmin<int64>(lengthInSamples, samplesToMap.getEnd() - (samplesToMap.getEnd() % COMPRESSION_BLOCK_SIZE) + 1);
-			mappedSection = Range<int64>(mappedStart, mappedEnd);
+			int64_t mappedEnd = juce::jmin<int64_t>(lengthInSamples, samplesToMap.getEnd() - (samplesToMap.getEnd() % COMPRESSION_BLOCK_SIZE) + 1);
+			mappedSection = juce::Range<int64_t>(mappedStart, mappedEnd);
 
 			auto actualMappedRange = map->getRange();
 
 			int offset = (int)(fileRange.getStart() - actualMappedRange.getStart());
 			int length = (int)(actualMappedRange.getLength() - offset);
 
-			mis = new MemoryInputStream((uint8*)map->getData() + offset, length, false);
+			mis = std::make_unique<juce::MemoryInputStream>((uint8_t*)map->getData() + offset, length, false);
 
-			internalReader.input = mis;
+			internalReader.input = mis.get();
 
 			internalReader.setUseHeaderOffsetWhenSeeking(false);
 
@@ -464,10 +464,10 @@ bool HlacMemoryMappedAudioFormatReader::mapSectionOfFile(Range<int64> samplesToM
 	}
 }
 
-void HlacMemoryMappedAudioFormatReader::setTargetAudioDataType(AudioDataConverters::DataFormat dataType)
+void HlacMemoryMappedAudioFormatReader::setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType)
 {
-	usesFloatingPointData = (dataType == AudioDataConverters::DataFormat::float32BE) ||
-		(dataType == AudioDataConverters::DataFormat::float32LE);
+	usesFloatingPointData = (dataType == juce::AudioDataConverters::DataFormat::float32BE) ||
+		(dataType == juce::AudioDataConverters::DataFormat::float32LE);
 
 	internalReader.setTargetAudioDataType(dataType);
 }
@@ -478,44 +478,44 @@ void HlacMemoryMappedAudioFormatReader::copySampleData(int* const* destSamples, 
 
 	if (numChannels == 1)
 	{
-		ReadHelper<AudioData::Float32, AudioData::Int16, AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, 1, sourceData, 1, numSamples);
+		ReadHelper<juce::AudioData::Float32, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, 1, sourceData, 1, numSamples);
 	}
 	else
 	{
-		ReadHelper<AudioData::Float32, AudioData::Int16, AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, numDestChannels, sourceData, 2, numSamples);
+		ReadHelper<juce::AudioData::Float32, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(destSamples, startOffsetInDestBuffer, numDestChannels, sourceData, 2, numSamples);
 	}
 }
 
-bool HlacMemoryMappedAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64 offsetInFile, int numSrcChannels, int numSamples)
+bool HlacMemoryMappedAudioFormatReader::copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64_t offsetInFile, int numSrcChannels, int numSamples)
 {
 	auto sourceData = sampleToPointer(offsetInFile);
 
 	if (numSrcChannels == 1)
 	{
-		memcpy(destination.getWritePointer(0, startOffsetInBuffer), sourceData, numSamples * sizeof(int16));
+		memcpy(destination.getWritePointer(0, startOffsetInBuffer), sourceData, numSamples * sizeof(int16_t));
 
 		if (numDestChannels == 2)
 		{
-			memcpy(destination.getWritePointer(1, startOffsetInBuffer), sourceData, numSamples * sizeof(int16));
+			memcpy(destination.getWritePointer(1, startOffsetInBuffer), sourceData, numSamples * sizeof(int16_t));
 		}
 	}
 	else
 	{
 		jassert(destination.getNumChannels() == 2);
 
-		int16* channels[2] = { static_cast<int16*>(destination.getWritePointer(0, 0)), static_cast<int16*>(destination.getWritePointer(1, 0)) };
+		int16_t* channels[2] = { static_cast<int16_t*>(destination.getWritePointer(0, 0)), static_cast<int16_t*>(destination.getWritePointer(1, 0)) };
 
-		ReadHelper<AudioData::Int16, AudioData::Int16, AudioData::LittleEndian>::read(channels, startOffsetInBuffer, numDestChannels, sourceData, 2, numSamples);
+		ReadHelper<juce::AudioData::Int16, juce::AudioData::Int16, juce::AudioData::LittleEndian>::read(channels, startOffsetInBuffer, numDestChannels, sourceData, 2, numSamples);
 	}
 
 	return true;
 }
 
-HlacSubSectionReader::HlacSubSectionReader(AudioFormatReader* sourceReader, int64 subsectionStartSample, int64 subsectionLength) :
+HlacSubSectionReader::HlacSubSectionReader(AudioFormatReader* sourceReader, int64_t subsectionStartSample, int64_t subsectionLength) :
 	AudioFormatReader(0, sourceReader->getFormatName()),
 	start(subsectionStartSample)
 {
-	length = jmin(jmax((int64)0, sourceReader->lengthInSamples - subsectionStartSample), subsectionLength);
+	length = juce::jmin (juce::jmax ((int64_t)0, sourceReader->lengthInSamples - subsectionStartSample), subsectionLength);
 
 	sampleRate = sourceReader->sampleRate;
 	bitsPerSample = sourceReader->bitsPerSample;
@@ -544,7 +544,7 @@ HlacSubSectionReader::HlacSubSectionReader(AudioFormatReader* sourceReader, int6
 	}
 }
 
-bool HlacSubSectionReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples)
+bool HlacSubSectionReader::readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples)
 {
 	clearSamplesBeyondAvailableLength(destSamples, numDestChannels, startOffsetInDestBuffer,
 		startSampleInFile, numSamples, length);
@@ -555,10 +555,10 @@ bool HlacSubSectionReader::readSamples(int** destSamples, int numDestChannels, i
 		return normalReader->readSamples(destSamples, numDestChannels, startOffsetInDestBuffer, startSampleInFile + start, numSamples);
 }
 
-void HlacSubSectionReader::readMaxLevels(int64 startSampleInFile, int64 numSamples, Range<float>* results, int numChannelsToRead)
+void HlacSubSectionReader::readMaxLevels(int64_t startSampleInFile, int64_t numSamples, juce::Range<float>* results, int numChannelsToRead)
 {
-	startSampleInFile = jmax((int64)0, startSampleInFile);
-	numSamples = jmax((int64)0, jmin(numSamples, length - startSampleInFile));
+	startSampleInFile = juce::jmax((int64_t)0, startSampleInFile);
+	numSamples = juce::jmax((int64_t)0, juce::jmin(numSamples, length - startSampleInFile));
 
 	if(memoryReader != nullptr)
 		memoryReader->readMaxLevels(startSampleInFile + start, numSamples, results, numChannelsToRead);
@@ -566,7 +566,7 @@ void HlacSubSectionReader::readMaxLevels(int64 startSampleInFile, int64 numSampl
 		normalReader->readMaxLevels(startSampleInFile + start, numSamples, results, numChannelsToRead);
 }
 
-void HlacSubSectionReader::readIntoFixedBuffer(HiseSampleBuffer& buffer, int startSample, int numSamples, int64 readerStartSample)
+void HlacSubSectionReader::readIntoFixedBuffer(HiseSampleBuffer& buffer, int startSample, int numSamples, int64_t readerStartSample)
 {
 	if (isMonolith)
 	{

--- a/hi_lac/hlac/HlacAudioFormatReader.h
+++ b/hi_lac/hlac/HlacAudioFormatReader.h
@@ -33,54 +33,54 @@
 #ifndef HLACAUDIOFORMATREADER_H_INCLUDED
 #define HLACAUDIOFORMATREADER_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 struct HiseLosslessHeader
 {
-	HiseLosslessHeader(InputStream* input);
+	HiseLosslessHeader(juce::InputStream* input);
 
-	HiseLosslessHeader(const File& f);
+	HiseLosslessHeader(const juce::File& f);
 
-	HiseLosslessHeader(bool useEncryption, uint8 globalBitShiftAmount, double sampleRate, int numChannels, int bitsPerSample, bool useCompression, uint32 numBlocks);
+	HiseLosslessHeader(bool useEncryption, uint8_t globalBitShiftAmount, double sampleRate, int numChannels, int bitsPerSample, bool useCompression, uint32_t numBlocks);
 
 	int getVersion() const;
 	bool isEncrypted() const;
 	int getBitShiftAmount() const;
-	uint32 getNumChannels() const;
-	uint32 getBitsPerSample() const;
+	uint32_t getNumChannels() const;
+	uint32_t getBitsPerSample() const;
 	bool usesCompression() const;
 	double getSampleRate() const;
-	uint32 getBlockAmount() const;
+	uint32_t getBlockAmount() const;
 
-	uint32 getOffsetForReadPosition(int64 samplePosition, bool addHeaderOffset);
+	uint32_t getOffsetForReadPosition(int64_t samplePosition, bool addHeaderOffset);
 
-	uint32 getOffsetForNextBlock(int64 samplePosition, bool addHeaderOffset);
+	uint32_t getOffsetForNextBlock(int64_t samplePosition, bool addHeaderOffset);
 
-	bool write(OutputStream* output);
+	bool write(juce::OutputStream* output);
 
-	void storeOffsets(uint32* offsets, int numOffsets);
+	void storeOffsets(uint32_t* offsets, int numOffsets);
 
-	void readMetadataFromStream(InputStream* stream);
+	void readMetadataFromStream(juce::InputStream* stream);
 
 	static HiseLosslessHeader createMonolithHeader(int numChannels, double sampleRate);
 
 private:
 
-	uint8 headerByte1 = 0;
-	uint8 headerByte2 = 0;
-	uint8 sampleDataByte = 0;
-	uint32 blockAmount = 0;
-	HeapBlock<uint32> blockOffsets;
+	uint8_t headerByte1 = 0;
+	uint8_t headerByte2 = 0;
+	uint8_t sampleDataByte = 0;
+	uint32_t blockAmount = 0;
+    juce::HeapBlock<uint32_t> blockOffsets;
 	bool headerValid = false;
 	bool isOldMonolith = false;
-	uint32 headerSize;
+	uint32_t headerSize;
 };
 
 class HlacReaderCommon
 {
 public:
 
-	HlacReaderCommon(InputStream* input_):
+	HlacReaderCommon(juce::InputStream* input_):
 		input(input_),
 		header(input)
 	{
@@ -88,7 +88,7 @@ public:
 		decoder.setHlacVersion(header.getVersion());
 	}
 
-	HlacReaderCommon(const File& f) :
+	HlacReaderCommon(const juce::File& f) :
 		input(nullptr),
 		header(f)
 	{
@@ -98,7 +98,7 @@ public:
 
 	/** You can choose what the target data type should be. If you read into integer AudioSampleBuffers, you might want to call this method
 	*	in order to save unnecessary conversions between float and integer numbers. */
-	void setTargetAudioDataType(AudioDataConverters::DataFormat dataType);
+	void setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType);
 
 	/** When seeking, add the length of the header as offset. */
 	void setUseHeaderOffsetWhenSeeking(bool shouldUseHeaderOffset)
@@ -110,16 +110,16 @@ private:
 
 	friend class HlacSubSectionReader;
 
-	bool internalHlacRead(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples);
+	bool internalHlacRead(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples);
 
-	bool fixedBufferRead(HiseSampleBuffer& buffer, int numDestChannels, int startOffsetInBuffer, int64 startSampleInFile, int numSamples);
+	bool fixedBufferRead(HiseSampleBuffer& buffer, int numDestChannels, int startOffsetInBuffer, int64_t startSampleInFile, int numSamples);
 
 	
 
 	friend class HiseLosslessAudioFormatReader;
 	friend class HlacMemoryMappedAudioFormatReader;
 
-	InputStream* input;
+    juce::InputStream* input;
 
 	HlacDecoder decoder;
 	HiseLosslessHeader header;
@@ -130,16 +130,16 @@ private:
 
 };
 
-class HiseLosslessAudioFormatReader : public AudioFormatReader
+class HiseLosslessAudioFormatReader : public juce::AudioFormatReader
 {
 public:
-	HiseLosslessAudioFormatReader(InputStream* input_);
+	HiseLosslessAudioFormatReader(juce::InputStream* input_);
 
-	bool readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples) override;
+	bool readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples) override;
 
 	double getDecompressionPerformanceForLastFile() { return internalReader.decoder.getDecompressionPerformance(); }
 
-	void setTargetAudioDataType(AudioDataConverters::DataFormat dataType);
+	void setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType);
 
 private:
 
@@ -148,7 +148,7 @@ private:
 
 	static void copySampleData(int* const* destSamples, int startOffsetInDestBuffer, int numDestChannels, const void* sourceData, int numChannels, int numSamples) noexcept;
 
-	bool copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64 offsetInFile, int numChannels, int numSamples);
+	bool copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64_t offsetInFile, int numChannels, int numSamples);
 
 	HlacReaderCommon internalReader;
 
@@ -157,11 +157,11 @@ private:
 };
 
 
-class HlacMemoryMappedAudioFormatReader : public MemoryMappedAudioFormatReader
+class HlacMemoryMappedAudioFormatReader : public juce::MemoryMappedAudioFormatReader
 {
 public:
 
-	HlacMemoryMappedAudioFormatReader(const File& f, const AudioFormatReader& details, int64 start, int64 length, int frameSize) :
+	HlacMemoryMappedAudioFormatReader(const juce::File& f, const AudioFormatReader& details, int64_t start, int64_t length, int frameSize) :
 		MemoryMappedAudioFormatReader(f, details, start, length, frameSize),
 		internalReader(f)
 	{
@@ -169,24 +169,24 @@ public:
 
 		if (isMonolith)
 		{
-			bytesPerFrame = internalReader.header.getNumChannels() * sizeof(int16);
+			bytesPerFrame = internalReader.header.getNumChannels() * sizeof(int16_t);
 			dataChunkStart = 1;
 			dataLength = f.getSize() - 1;
 		}
 	}
 
-	bool readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64 startSampleInFile, int numSamples) override;
+	bool readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples) override;
 
-	bool mapSectionOfFile(Range<int64> samplesToMap) override;
+	bool mapSectionOfFile(juce::Range<int64_t> samplesToMap) override;
 
-	void getSample(int64 /*sampleIndex*/, float* result) const noexcept override
+	void getSample(int64_t /*sampleIndex*/, float* result) const noexcept override
 	{
 		// this should never be used
 		jassertfalse;
 		*result = 0.0f;
 	}
 
-	void setTargetAudioDataType(AudioDataConverters::DataFormat dataType);
+	void setTargetAudioDataType(juce::AudioDataConverters::DataFormat dataType);
 
 private:
 	
@@ -194,38 +194,38 @@ private:
 
 	static void copySampleData(int* const* destSamples, int startOffsetInDestBuffer, int numDestChannels, const void* sourceData, int numChannels, int numSamples) noexcept;
 
-	bool copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64 offsetInFile, int numChannels, int numSamples);
+	bool copyFromMonolith(HiseSampleBuffer& destination, int startOffsetInBuffer, int numDestChannels, int64_t offsetInFile, int numChannels, int numSamples);
 
-	ScopedPointer<MemoryInputStream> mis;
+	std::unique_ptr<juce::MemoryInputStream> mis;
 	HlacReaderCommon internalReader;
 
 	bool isMonolith = false;
 };
 
-class HlacSubSectionReader: public AudioFormatReader
+class HlacSubSectionReader: public juce::AudioFormatReader
 {
 public:
 
-	HlacSubSectionReader(AudioFormatReader* sourceReader, int64 subsectionStartSample, int64 subsectionLength);
+	HlacSubSectionReader(AudioFormatReader* sourceReader, int64_t subsectionStartSample, int64_t subsectionLength);
 
 	bool readSamples(int** destSamples, int numDestChannels, int startOffsetInDestBuffer,
-		int64 startSampleInFile, int numSamples);
+		int64_t startSampleInFile, int numSamples);
 
-	void readMaxLevels(int64 startSampleInFile, int64 numSamples, Range<float>* results, int numChannelsToRead);
+	void readMaxLevels(int64_t startSampleInFile, int64_t numSamples, juce::Range<float>* results, int numChannelsToRead);
 
-	void readIntoFixedBuffer(HiseSampleBuffer& buffer, int startSample, int numSamples, int64 readerStartSample);
+	void readIntoFixedBuffer(HiseSampleBuffer& buffer, int startSample, int numSamples, int64_t readerStartSample);
 
 private:
 
 	bool isMonolith = false;
 
-	HlacMemoryMappedAudioFormatReader* memoryReader;
-	HiseLosslessAudioFormatReader* normalReader;
+	HlacMemoryMappedAudioFormatReader* memoryReader = nullptr;
+	HiseLosslessAudioFormatReader* normalReader     = nullptr;
 
-	HlacReaderCommon* internalReader;
+	HlacReaderCommon* internalReader = nullptr;
 
-	int64 start;
-	int64 length;
+	int64_t start  = 0;
+	int64_t length = 0;
 };
 
 } // namespace hlac

--- a/hi_lac/hlac/HlacAudioFormatWriter.h
+++ b/hi_lac/hlac/HlacAudioFormatWriter.h
@@ -33,9 +33,9 @@
 #ifndef HLACAUDIOFORMATWRITER_H_INCLUDED
 #define HLACAUDIOFORMATWRITER_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
-class HiseLosslessAudioFormatWriter : public AudioFormatWriter
+class HiseLosslessAudioFormatWriter : public juce::AudioFormatWriter
 {
 public:
 
@@ -47,7 +47,7 @@ public:
 		numEncodeModes
 	};
 
-	HiseLosslessAudioFormatWriter(EncodeMode mode_, OutputStream* output, double sampleRate, int numChannels, uint32* blockOffsetBuffer);
+	HiseLosslessAudioFormatWriter(EncodeMode mode_, juce::OutputStream* output, double sampleRate, int numChannels, uint32_t* blockOffsetBuffer);
 
 	~HiseLosslessAudioFormatWriter();
 
@@ -66,27 +66,27 @@ public:
 	void setTemporaryBufferType(bool shouldUseTemporaryFile);
 
 	/** Call this to preallocate the amount of memory approximately required for the extraction. */
-	void preallocateMemory(int64 numSamplesToWrite, int numChannels);
+	void preallocateMemory(int64_t numSamplesToWrite, int numChannels);
 
 	/** Returns the number of written bytes for this reader. */
-	int64 getNumBytesWritten() const;
+	int64_t getNumBytesWritten() const;
 
 private:
 
 	bool writeHeader();
 	bool writeDataFromTemp();
 
-	int64 numBytesWritten = 0;
+	int64_t numBytesWritten = 0;
 
 	void deleteTemp();
 
-	ScopedPointer<TemporaryFile> tempFile;
-	ScopedPointer<OutputStream> tempOutputStream;
+	std::unique_ptr<juce::TemporaryFile> tempFile;
+    std::unique_ptr<juce::OutputStream> tempOutputStream;
 
 	bool tempWasFlushed = true;
 	bool usesTempFile = false;
 
-	uint32* blockOffsets;
+	uint32_t* blockOffsets;
 
 	HlacEncoder encoder;
 
@@ -96,7 +96,7 @@ private:
 	bool useEncryption = false;
 	bool useCompression = true;
 
-	uint8 globalBitShiftAmount = 0;
+	uint8_t globalBitShiftAmount = 0;
 };
 
 } // namespace hlac

--- a/hi_lac/hlac/HlacDecoder.h
+++ b/hi_lac/hlac/HlacDecoder.h
@@ -34,7 +34,7 @@
 #ifndef HLACDECODER_H_INCLUDED
 #define HLACDECODER_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 class HlacDecoder
 {
@@ -51,49 +51,49 @@ public:
 		hlacVersion = version;
 	}
 
-	void decode(HiseSampleBuffer& destination, bool decodeStereo, InputStream& input, int offsetInSource=0, int numSamples=-1);
+	void decode(HiseSampleBuffer& destination, bool decodeStereo, juce::InputStream& input, int offsetInSource=0, int numSamples=-1);
 
 	void setupForDecompression();
 
 	double getDecompressionPerformance() const;
 
-	uint32 getCurrentReadPosition() const
+	uint32_t getCurrentReadPosition() const
 	{
 		return readOffset;
 	}
 
-	void seekToPosition(InputStream& input, uint32 samplePosition, uint32 byteOffset);
+	void seekToPosition(juce::InputStream& input, uint32_t samplePosition, uint32_t byteOffset);
 
 private:
 
 	struct CycleHeader
 	{
-		CycleHeader(uint8 headerInfo_, uint16 numSamples_) :
+		CycleHeader(uint8_t headerInfo_, uint16_t numSamples_) :
 			headerInfo(headerInfo_),
 			numSamples(numSamples_)
 		{}
 
 		bool isTemplate() const;
-		uint8 getBitRate(bool getFullBitRate = true) const;
+		uint8_t getBitRate(bool getFullBitRate = true) const;
 		bool isDiff() const;
 
-		uint16 getNumSamples() const;
+		uint16_t getNumSamples() const;
 
 	private:
 
-		uint8 headerInfo;
-		uint16 numSamples;
+		uint8_t headerInfo;
+		uint16_t numSamples;
 	};
 
 	void reset();
 	
 	
 
-	bool decodeBlock(HiseSampleBuffer& destination, bool decodeStereo, InputStream& input, int channelIndex);
+	bool decodeBlock(HiseSampleBuffer& destination, bool decodeStereo, juce::InputStream& input, int channelIndex);
 
-	void decodeDiff(const CycleHeader& header, bool decodeStereo, HiseSampleBuffer& destination, InputStream& input, int channelIndex);
+	void decodeDiff(const CycleHeader& header, bool decodeStereo, HiseSampleBuffer& destination, juce::InputStream& input, int channelIndex);
 
-	void decodeCycle(const CycleHeader& header, bool decodeStereo, HiseSampleBuffer& destination, InputStream& input, int channelIndex);
+	void decodeCycle(const CycleHeader& header, bool decodeStereo, HiseSampleBuffer& destination, juce::InputStream& input, int channelIndex);
 
 	enum class FloatWriteMode
 	{
@@ -105,7 +105,7 @@ private:
 
 	void writeToFloatArray(bool shouldCopy, bool useTempBuffer, HiseSampleBuffer& destination, int channelIndex, int numSamples);
 
-	CycleHeader readCycleHeader(InputStream& input);
+	CycleHeader readCycleHeader(juce::InputStream& input);
 
 	BitCompressors::Collection collection;
 
@@ -113,20 +113,20 @@ private:
 
 	CompressionHelpers::AudioBufferInt16 workBuffer;
 
-	uint16 indexInBlock = 0;
+	uint16_t indexInBlock = 0;
 	int leftFloatIndex = 0;
 	int rightFloatIndex = 0;
 	
 	int leftNumToSkip = 0;
 	int rightNumToSkip = 0;
 	
-	uint32 blockOffset = 0;
+	uint32_t blockOffset = 0;
 
-	uint8 bitRateForCurrentCycle;
+	uint8_t bitRateForCurrentCycle;
 
-	int16 firstCycleLength = -1;
+	int16_t firstCycleLength = -1;
 
-	MemoryBlock readBuffer;
+    juce::MemoryBlock readBuffer;
 
 	float ratio = 0.0f;
 
@@ -134,7 +134,7 @@ private:
 
 	int readIndex = 0;
 
-	Array<double> decompressionSpeeds;
+    juce::Array<double> decompressionSpeeds;
 
 	double decompressionSpeed = 0.0;
 

--- a/hi_lac/hlac/HlacEncoder.h
+++ b/hi_lac/hlac/HlacEncoder.h
@@ -34,7 +34,7 @@
 #ifndef HLACENCODER_H_INCLUDED
 #define HLACENCODER_H_INCLUDED
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 class HlacEncoder
 {
@@ -60,28 +60,28 @@ public:
 		};
 
 		bool useCompression = true;
-		int16 fixedBlockWidth = -1;
+		int16_t fixedBlockWidth = -1;
 		bool removeDcOffset = true;
 		bool applyDithering = false;
-		uint8 normalisationMode = 0;
-		uint8 normalisationThreshold = 4;
+		uint8_t normalisationMode = 0;
+		uint8_t normalisationThreshold = 4;
 		int bitRateForWholeBlock = 6;
 		bool useDiffEncodingWithFixedBlocks = false;
 
-		static String getBoolString(bool b)
+		static juce::String getBoolString(bool b)
 		{
 			return b ? "true" : "false";
 		}
 
-		String toString() const
+        juce::String toString() const
 		{
-			String s;
-			NewLine nl;
+            juce::String s;
+            juce::NewLine nl;
 
 			s << "useCompression: " << getBoolString(useCompression) << nl;
-			s << "fixedBlockWidth: " << String(fixedBlockWidth) << nl;
+			s << "fixedBlockWidth: " << juce::String(fixedBlockWidth) << nl;
 			s << "removeDCOffset: " << getBoolString(removeDcOffset) << nl;
-			s << "bitRateForWholeBlock: " << String(bitRateForWholeBlock) << nl;
+			s << "bitRateForWholeBlock: " << juce::String(bitRateForWholeBlock) << nl;
 			s << "useDiffEncodingWithFixedBlocks: " << getBoolString(useDiffEncodingWithFixedBlocks) << nl;
 
 			return s;
@@ -128,7 +128,7 @@ public:
 	};
 
 
-	void compress(AudioSampleBuffer& source, OutputStream& output, uint32* blockOffsetData);
+	void compress(juce::AudioSampleBuffer& source, juce::OutputStream& output, uint32_t* blockOffsetData);
 	
 	void reset();
 
@@ -139,38 +139,38 @@ public:
 
 	float getCompressionRatio() const;
 
-	uint32 getNumBlocksWritten() const { return blockIndex; }
+	uint32_t getNumBlocksWritten() const { return blockIndex; }
 
 private:
 
-	bool encodeBlock(AudioSampleBuffer& block, OutputStream& output);
+	bool encodeBlock (juce::AudioSampleBuffer& block, juce::OutputStream& output);
 
-	bool encodeBlock(CompressionHelpers::AudioBufferInt16& block, OutputStream& output);
+	bool encodeBlock(CompressionHelpers::AudioBufferInt16& block, juce::OutputStream& output);
 
-	bool normaliseBlockAndAddHeader(CompressionHelpers::AudioBufferInt16& block16, OutputStream& output);
+	bool normaliseBlockAndAddHeader(CompressionHelpers::AudioBufferInt16& block16, juce::OutputStream& output);
 
-	MemoryBlock createCompressedBlock(CompressionHelpers::AudioBufferInt16& block);
+    juce::MemoryBlock createCompressedBlock(CompressionHelpers::AudioBufferInt16& block);
 
-	uint8 getBitReductionAmountForMSEncoding(AudioSampleBuffer& block);
+	uint8_t getBitReductionAmountForMSEncoding (juce::AudioSampleBuffer& block);
 
 	bool isBlockExhausted() const
 	{
 		return indexInBlock >= COMPRESSION_BLOCK_SIZE;
 	}
 
-	bool writeChecksumBytesForBlock(OutputStream& output);
+	bool writeChecksumBytesForBlock (juce::OutputStream& output);
 
-	bool writeNormalisationAmount(OutputStream& output);
+	bool writeNormalisationAmount (juce::OutputStream& output);
 
-	bool writeUncompressed(CompressionHelpers::AudioBufferInt16& block, OutputStream& output);
+	bool writeUncompressed (CompressionHelpers::AudioBufferInt16& block, juce::OutputStream& output);
 
-	bool encodeCycle(CompressionHelpers::AudioBufferInt16& cycle, OutputStream& output);
-	bool encodeDiff(CompressionHelpers::AudioBufferInt16& cycle, OutputStream& output);
-	bool encodeCycleDelta(CompressionHelpers::AudioBufferInt16& nextCycle, OutputStream& output);
-	void  encodeLastBlock(AudioSampleBuffer& block, OutputStream& output);
+	bool encodeCycle (CompressionHelpers::AudioBufferInt16& cycle, juce::OutputStream& output);
+	bool encodeDiff (CompressionHelpers::AudioBufferInt16& cycle, juce::OutputStream& output);
+	bool encodeCycleDelta(CompressionHelpers::AudioBufferInt16& nextCycle, juce::OutputStream& output);
+	void  encodeLastBlock (juce::AudioSampleBuffer& block, juce::OutputStream& output);
 
-	bool writeCycleHeader(bool isTemplate, int bitDepth, int numSamples, OutputStream& output);
-	bool writeDiffHeader(int fullBitRate, int errorBitRate, int blockSize, OutputStream& output);
+	bool writeCycleHeader(bool isTemplate, int bitDepth, int numSamples, juce::OutputStream& output);
+	bool writeDiffHeader(int fullBitRate, int errorBitRate, int blockSize, juce::OutputStream& output);
 
 	int getCycleLength(CompressionHelpers::AudioBufferInt16& block);
 	int getCycleLengthFromTemplate(CompressionHelpers::AudioBufferInt16& newCycle, CompressionHelpers::AudioBufferInt16& rest);
@@ -183,20 +183,20 @@ private:
 
 	int indexInBlock = 0;
 
-	uint32 numBytesWritten = 0;
-	uint32 numBytesUncompressed = 0;
+	uint32_t numBytesWritten = 0;
+	uint32_t numBytesUncompressed = 0;
 
-	uint32 numTemplates = 0;
-	uint32 numDeltas = 0;
+	uint32_t numTemplates = 0;
+	uint32_t numDeltas = 0;
 
-	uint32 blockOffset = 0;
-	uint32 blockIndex = 0;
+	uint32_t blockOffset = 0;
+	uint32_t blockIndex = 0;
 
-	uint8 bitRateForCurrentCycle = 0;
+	uint8_t bitRateForCurrentCycle = 0;
 
 	int firstCycleLength = -1;
 
-	MemoryBlock readBuffer;
+    juce::MemoryBlock readBuffer;
 
 	CompressorOptions options;
 
@@ -204,7 +204,7 @@ private:
 
 	float ratio = 0.0f;
 
-	uint64 readIndex = 0;
+	uint64_t readIndex = 0;
 
 	double decompressionSpeed = 0.0;
 };

--- a/hi_lac/hlac/SampleBuffer.cpp
+++ b/hi_lac/hlac/SampleBuffer.cpp
@@ -30,7 +30,7 @@
 *   ===========================================================================
 */
 
-namespace hlac { using namespace juce; 
+namespace hlac {
 
 HiseSampleBuffer::HiseSampleBuffer(HiseSampleBuffer& otherBuffer, int offset)
 {
@@ -59,7 +59,7 @@ void HiseSampleBuffer::reverse(int startSample, int numSamples)
 	{
 		floatBuffer.reverse(startSample, numSamples);
 
-		int fadeLength = jmin<int>(500, numSamples);
+		int fadeLength = juce::jmin<int>(500, numSamples);
 
 		floatBuffer.applyGainRamp(numSamples - fadeLength, fadeLength, 1.0f, 0.0f);
 
@@ -80,7 +80,7 @@ void HiseSampleBuffer::reverse(int startSample, int numSamples)
 
 void HiseSampleBuffer::setSize(int numChannels_, int numSamples)
 {
-	jassert(isPositiveAndBelow(numChannels, 3));
+	jassert(juce::isPositiveAndBelow(numChannels, 3));
 
 
 
@@ -149,7 +149,7 @@ void HiseSampleBuffer::allocateNormalisationTables(int offsetToUse)
 }
 
 
-void HiseSampleBuffer::flushNormalisationInfo(Range<int> rangeToFlush)
+void HiseSampleBuffer::flushNormalisationInfo(juce::Range<int> rangeToFlush)
 {
 	//DBG("-- FLUSHING {" + String(rangeToFlush.getStart()) + ", " + String(rangeToFlush.getEnd()) + "}");
 
@@ -158,10 +158,10 @@ void HiseSampleBuffer::flushNormalisationInfo(Range<int> rangeToFlush)
 
 	auto offset = getNormaliseMap(0).getOffset();
 
-	int numToFlush = jmin<int>(size, rangeToFlush.getLength());
+	int numToFlush = juce::jmin<int>(size, rangeToFlush.getLength());
 
-	uint8 lastL = 128;
-	uint8 lastR = 128;
+	uint8_t lastL = 128;
+	uint8_t lastR = 128;
 
 	int currentStart = 0;
 	int currentEnd = 0;
@@ -170,14 +170,14 @@ void HiseSampleBuffer::flushNormalisationInfo(Range<int> rangeToFlush)
 
 	while (numToFlush > 0)
 	{
-		int numThisTime = jmin<int>(numToFlush, 1024 - (thisIndex % 1024));
+		int numThisTime = juce::jmin<int>(numToFlush, 1024 - (thisIndex % 1024));
 
 		//DBG("--- READING " + String(numThisTime) + " / " + String(numToFlush) + " at " + String(thisIndex));
 
 		auto pos = lMap.getIndexForSamplePosition(thisIndex);
 
-		uint8 nextL = lMap.getTableData()[pos];
-		uint8 nextR = rMap.getTableData()[pos];
+		uint8_t nextL = lMap.getTableData()[pos];
+		uint8_t nextR = rMap.getTableData()[pos];
 
 		currentEnd += numThisTime;
 		numToFlush -= numThisTime;
@@ -241,12 +241,12 @@ hlac::FixedSampleBuffer& HiseSampleBuffer::getFixedBuffer(int channelIndex)
 
 void HiseSampleBuffer::convertToFloatWithNormalisation(float** data, int numTargetChannels, int startSampleInSource, int numSamples) const
 {
-	Range<int> rangeInBuffer({ startSampleInSource, startSampleInSource + numSamples });
+    juce::Range<int> rangeInBuffer({ startSampleInSource, startSampleInSource + numSamples });
 
 	if (useOneMap)
 	{
 		float* ptr = data[0];
-		auto int_ptr = static_cast<const int16*>(getReadPointer(0, startSampleInSource));
+		auto int_ptr = static_cast<const int16_t*>(getReadPointer(0, startSampleInSource));
 
 		CompressionHelpers::fastInt16ToFloat(int_ptr, ptr, numSamples);
 
@@ -254,7 +254,7 @@ void HiseSampleBuffer::convertToFloatWithNormalisation(float** data, int numTarg
 
 		if (numTargetChannels == 2)
 		{
-			FloatVectorOperations::copy(data[1], data[0], numSamples);
+            juce::FloatVectorOperations::copy(data[1], data[0], numSamples);
 		}
 	}
 	else
@@ -262,8 +262,8 @@ void HiseSampleBuffer::convertToFloatWithNormalisation(float** data, int numTarg
 		float* l_ptr = data[0];
 		float* r_ptr = numTargetChannels == 2 ? data[1] : nullptr;
 
-		auto int_l_ptr = static_cast<const int16*>(getReadPointer(0, startSampleInSource));
-		auto int_r_ptr = static_cast<const int16*>(getReadPointer(1, startSampleInSource));
+		auto int_l_ptr = static_cast<const int16_t*>(getReadPointer(0, startSampleInSource));
+		auto int_r_ptr = static_cast<const int16_t*>(getReadPointer(1, startSampleInSource));
 		
 		CompressionHelpers::fastInt16ToFloat(int_l_ptr, l_ptr, numSamples);
 		
@@ -275,7 +275,7 @@ void HiseSampleBuffer::convertToFloatWithNormalisation(float** data, int numTarg
 }
 
 
-void HiseSampleBuffer::clearNormalisation(Range<int> r)
+void HiseSampleBuffer::clearNormalisation(juce::Range<int> r)
 {
 	if (r.getStart() == 0 && r.getLength() == size)
 		normaliser.clear();
@@ -297,7 +297,7 @@ void HiseSampleBuffer::burnNormalisation()
 	if (getNumSamples() == 0)
 		return;
 
-	AudioSampleBuffer fb(getNumChannels(), getNumSamples());
+    juce::AudioSampleBuffer fb(getNumChannels(), getNumSamples());
 	convertToFloatWithNormalisation(fb.getArrayOfWritePointers(), getNumChannels(), 0, getNumSamples());
 
 	auto l = leftIntBuffer.getWritePointer(0);
@@ -308,10 +308,10 @@ void HiseSampleBuffer::burnNormalisation()
 
 	for (int i = 0; i < fb.getNumSamples(); i++)
 	{
-		l[i] = (int16)(int)(lr[i] * INT16_MAX);
+		l[i] = (int16_t)(int)(lr[i] * INT16_MAX);
 
 		if(r != nullptr)
-			r[i] = (int16)(int)(rr[i] * INT16_MAX);
+			r[i] = (int16_t)(int)(rr[i] * INT16_MAX);
 	}
 
 	normaliser.clear();
@@ -319,7 +319,7 @@ void HiseSampleBuffer::burnNormalisation()
 
 void HiseSampleBuffer::copyNormalisationRanges(const HiseSampleBuffer& otherBuffer, int startOffsetInBuffer)
 {
-	Range<int> rangeToClear({ startOffsetInBuffer, startOffsetInBuffer + otherBuffer.size });
+    juce::Range<int> rangeToClear({ startOffsetInBuffer, startOffsetInBuffer + otherBuffer.size });
 
 	clearNormalisation(rangeToClear);
 
@@ -341,8 +341,8 @@ void HiseSampleBuffer::copy(HiseSampleBuffer& dst, const HiseSampleBuffer& sourc
 	if (numSamples <= 0)
 		return;
 
-    jassert(isPositiveAndBelow(startSampleDst + numSamples, dst.getNumSamples()+1));
-    jassert(isPositiveAndBelow(startSampleSource + numSamples, source.getNumSamples()+1));
+    jassert(juce::isPositiveAndBelow(startSampleDst + numSamples, dst.getNumSamples()+1));
+    jassert(juce::isPositiveAndBelow(startSampleSource + numSamples, source.getNumSamples()+1));
     
 	if (source.isFloatingPoint() == dst.isFloatingPoint())
 	{
@@ -362,7 +362,7 @@ void HiseSampleBuffer::copy(HiseSampleBuffer& dst, const HiseSampleBuffer& sourc
 		}
 		else
 		{
-			auto byteToCopy = sizeof(int16) * numSamples;
+			auto byteToCopy = sizeof(int16_t) * numSamples;
 
 			memcpy(dst.getWritePointer(0, startSampleDst), source.getReadPointer(0, startSampleSource), byteToCopy);
 
@@ -374,8 +374,8 @@ void HiseSampleBuffer::copy(HiseSampleBuffer& dst, const HiseSampleBuffer& sourc
 					memcpy(dst.getWritePointer(1, startSampleDst), source.getReadPointer(0, startSampleSource), byteToCopy);
 			}
 
-			Range<int> srcRange({ startSampleSource, startSampleSource + numSamples });
-			Range<int> dstRange({ startSampleDst, startSampleDst + numSamples });
+            juce::Range<int> srcRange({ startSampleSource, startSampleSource + numSamples });
+            juce::Range<int> dstRange({ startSampleDst, startSampleDst + numSamples });
 
 			dst.normaliser.copyFrom(source.normaliser, srcRange, dstRange);
 		}
@@ -438,7 +438,7 @@ void HiseSampleBuffer::add(HiseSampleBuffer& dst, const HiseSampleBuffer& source
 
 void* HiseSampleBuffer::getWritePointer(int channel, int startSample)
 {
-    jassert(isPositiveAndBelow(startSample, size));
+    jassert(juce::isPositiveAndBelow(startSample, size));
     
 	if (isFloatingPoint())
 	{
@@ -498,7 +498,7 @@ void HiseSampleBuffer::applyGainRamp(int channelIndex, int startOffset, int ramp
 	}
 }
 
-AudioSampleBuffer* HiseSampleBuffer::getFloatBufferForFileReader()
+juce::AudioSampleBuffer* HiseSampleBuffer::getFloatBufferForFileReader()
 {
 	jassert(isFloatingPoint());
 
@@ -536,7 +536,7 @@ void HiseSampleBuffer::minimizeNormalisationInfo()
 	}
 }
 
-void HiseSampleBuffer::Normaliser::clear(Range<int> rangeToClear /*= Range<int>()*/)
+void HiseSampleBuffer::Normaliser::clear(juce::Range<int> rangeToClear /*= Range<int>()*/)
 {
 	if (rangeToClear.isEmpty())
 		infos.clearQuick();
@@ -572,7 +572,7 @@ void HiseSampleBuffer::Normaliser::clear(Range<int> rangeToClear /*= Range<int>(
 	}
 }
 
-void HiseSampleBuffer::Normaliser::apply(float* dataLWithoutOffset, float* dataRWithoutOffset, Range<int> rangeInData) const
+void HiseSampleBuffer::Normaliser::apply(float* dataLWithoutOffset, float* dataRWithoutOffset, juce::Range<int> rangeInData) const
 {
 	for (const auto& i : infos)
 	{
@@ -580,7 +580,7 @@ void HiseSampleBuffer::Normaliser::apply(float* dataLWithoutOffset, float* dataR
 	}
 }
 
-void HiseSampleBuffer::Normaliser::copyFrom(const Normaliser& source, Range<int> srcRange, Range<int> dstRange)
+void HiseSampleBuffer::Normaliser::copyFrom(const Normaliser& source, juce::Range<int> srcRange, juce::Range<int> dstRange)
 {
 	int offset = dstRange.getStart() - srcRange.getStart();
 	
@@ -661,11 +661,11 @@ bool HiseSampleBuffer::Normaliser::NormalisationInfo::canBeJoined(const Normalis
 
 void HiseSampleBuffer::Normaliser::NormalisationInfo::join(NormalisationInfo&& other)
 {
-	range = { jmin<int>(range.getStart(), other.range.getStart()),
-			 jmax<int>(range.getEnd(), other.range.getEnd()) };
+	range = { juce::jmin<int>(range.getStart(), other.range.getStart()),
+        juce::jmax<int>(range.getEnd(), other.range.getEnd()) };
 }
 
-void HiseSampleBuffer::Normaliser::NormalisationInfo::apply(float* dataLWithoutOffset, float* dataRWithoutOffset, Range<int> rangeInData) const
+void HiseSampleBuffer::Normaliser::NormalisationInfo::apply(float* dataLWithoutOffset, float* dataRWithoutOffset, juce::Range<int> rangeInData) const
 {
 	auto intersection = range.getIntersectionWith(rangeInData);
 
@@ -678,11 +678,11 @@ void HiseSampleBuffer::Normaliser::NormalisationInfo::apply(float* dataLWithoutO
 
 		int offsetInFloatArray = intersection.getStart() - rangeInData.getStart();
 
-		FloatVectorOperations::multiply(dataLWithoutOffset + offsetInFloatArray, lGain, l);
+        juce::FloatVectorOperations::multiply(dataLWithoutOffset + offsetInFloatArray, lGain, l);
 
 		if (dataRWithoutOffset != nullptr)
 		{
-			FloatVectorOperations::multiply(dataRWithoutOffset + offsetInFloatArray, rGain, l);
+            juce::FloatVectorOperations::multiply(dataRWithoutOffset + offsetInFloatArray, rGain, l);
 		}
 	}
 }

--- a/hi_streaming/hi_streaming.h
+++ b/hi_streaming/hi_streaming.h
@@ -58,11 +58,11 @@ END_JUCE_MODULE_DECLARATION
 
 #include <atomic>
 
-#include "../JUCE/modules/juce_core/juce_core.h"
-#include "../JUCE/modules/juce_audio_basics/juce_audio_basics.h"
-#include "../JUCE/modules/juce_data_structures/juce_data_structures.h"
-#include "../JUCE/modules/juce_dsp/juce_dsp.h"
-#include "../hi_lac/hi_lac.h"
+#include "juce_core/juce_core.h"
+#include "juce_audio_basics/juce_audio_basics.h"
+#include "juce_data_structures/juce_data_structures.h"
+#include "juce_dsp/juce_dsp.h"
+#include "hi_lac/hi_lac.h"
 
 
 #if USE_IPP

--- a/hi_streaming/hi_streaming/MonolithAudioFormat.cpp
+++ b/hi_streaming/hi_streaming/MonolithAudioFormat.cpp
@@ -30,11 +30,11 @@
 *   ===========================================================================
 */
 
-namespace hise { using namespace juce;
+namespace hise {
 
 #if USE_OLD_MONOLITH_FORMAT
 
-void HiseMonolithAudioFormat::fillMetadataInfo(const ValueTree &sampleMap)
+void HiseMonolithAudioFormat::fillMetadataInfo(const juce::ValueTree &sampleMap)
 {
 	int numChannels = sampleMap.getChild(0).getNumChildren();
 	if (numChannels == 0) numChannels = 1;
@@ -107,14 +107,14 @@ void HiseMonolithAudioFormat::fillMetadataInfo(const ValueTree &sampleMap)
 
 #else
 
-void HlacMonolithInfo::fillMetadataInfo(const ValueTree& sampleMap)
+void HlacMonolithInfo::fillMetadataInfo(const juce::ValueTree& sampleMap)
 {
 	int numChannels = sampleMap.getChild(0).getNumChildren();
 	if (numChannels == 0) numChannels = 1;
 
 	int numSplitFiles = (int)sampleMap.getProperty("MonolithSplitAmount", 0);
 
-	numChannels = jmax(numSplitFiles, numChannels);
+	numChannels = std::max(numSplitFiles, numChannels);
 
 	multiChannelSampleInformation.reserve(numChannels);
 
@@ -128,7 +128,7 @@ void HlacMonolithInfo::fillMetadataInfo(const ValueTree& sampleMap)
 
 	for (int i = 0; i < sampleMap.getNumChildren(); i++)
 	{
-		ValueTree sample = sampleMap.getChild(i);
+        auto sample = sampleMap.getChild(i);
 
 		if (!sample.hasProperty("MonolithLength") || !sample.hasProperty("MonolithOffset"))
 		{
@@ -181,8 +181,8 @@ void HlacMonolithInfo::fillMetadataInfo(const ValueTree& sampleMap)
         else
             dummyReader.sampleRate = multiChannelSampleInformation[i][0].sampleRate;
 
-		const int bytesPerFrame = sizeof(int16) * dummyReader.numChannels;
-		FileInputStream fis(monolithicFiles[i]);
+		const int bytesPerFrame = sizeof(int16_t) * dummyReader.numChannels;
+        juce::FileInputStream fis(monolithicFiles[i]);
         
         if(fis.getTotalLength() == 0)
         {
@@ -193,7 +193,7 @@ void HlacMonolithInfo::fillMetadataInfo(const ValueTree& sampleMap)
         
 		dummyReader.lengthInSamples = (fis.getTotalLength() - 1) / bytesPerFrame;
 
-		ScopedPointer<MemoryMappedAudioFormatReader> reader = hlaf.createMemoryMappedReader(monolithicFiles[i]);
+        juce::ScopedPointer<juce::MemoryMappedAudioFormatReader> reader = hlaf.createMemoryMappedReader(monolithicFiles[i]);
 
 		
 
@@ -202,7 +202,7 @@ void HlacMonolithInfo::fillMetadataInfo(const ValueTree& sampleMap)
 
 		memoryReaders.add(dynamic_cast<hlac::HlacMemoryMappedAudioFormatReader*>(reader.release()));
 
-		memoryReaders.getLast()->setTargetAudioDataType(AudioDataConverters::DataFormat::int16BE);
+		memoryReaders.getLast()->setTargetAudioDataType(juce::AudioDataConverters::DataFormat::int16BE);
 
 		if (memoryReaders.getLast()->getMappedSection().isEmpty())
 		{

--- a/hi_streaming/hi_streaming/SampleThreadPool.cpp
+++ b/hi_streaming/hi_streaming/SampleThreadPool.cpp
@@ -30,16 +30,12 @@
 *   ===========================================================================
 */
 
-namespace hise { using namespace juce;
+namespace hise {
 
 
 struct SampleThreadPool::Pimpl
 {
-	Pimpl() :
-		jobQueue(8192),
-		currentlyExecutedJob(nullptr),
-		diskUsage(0.0)
-	{};
+    Pimpl() = default;
 
 	~Pimpl()
 	{
@@ -49,13 +45,13 @@ struct SampleThreadPool::Pimpl
 		}
 	}
 
-	CriticalSection clearLock;
+    juce::CriticalSection clearLock;
 
-	std::atomic<double> diskUsage;
-	int64 startTime, endTime;
-	moodycamel::ReaderWriterQueue<WeakReference<Job>> jobQueue;
-	std::atomic<Job*> currentlyExecutedJob;
-	static const String errorMessage;
+    std::atomic<double> diskUsage { 0.0 };
+	int64_t startTime, endTime;
+    moodycamel::ReaderWriterQueue<juce::WeakReference<Job>> jobQueue { 8192 };
+    std::atomic<Job*> currentlyExecutedJob { nullptr };
+	static const juce::String errorMessage;
 };
 
 SampleThreadPool::SampleThreadPool() :
@@ -80,9 +76,9 @@ double SampleThreadPool::getDiskUsage() const noexcept
 
 void SampleThreadPool::clearPendingTasks()
 {
-	ScopedLock sl(pimpl->clearLock);
+    juce::ScopedLock sl(pimpl->clearLock);
 		
-	WeakReference<Job> next;
+    juce::WeakReference<Job> next;
 
 	while (pimpl->jobQueue.try_dequeue(next))
 	{
@@ -93,7 +89,7 @@ void SampleThreadPool::clearPendingTasks()
 
 void SampleThreadPool::addJob(Job* jobToAdd, bool unused)
 {
-	ignoreUnused(unused);
+    juce::ignoreUnused(unused);
 
 #if ENABLE_CONSOLE_OUTPUT
 	if (jobToAdd->isQueued())
@@ -113,11 +109,11 @@ void SampleThreadPool::run()
 {
 	while (!threadShouldExit())
 	{
-		WeakReference<Job> next;
+        juce::WeakReference<Job> next;
 
 		if (pimpl->jobQueue.try_dequeue(next))
 		{
-			ScopedLock sl(pimpl->clearLock);
+            juce::ScopedLock sl(pimpl->clearLock);
 
 			Job* j = next.get();
 
@@ -178,7 +174,7 @@ void SampleThreadPool::run()
 	}
 }
 
-const String SampleThreadPool::Pimpl::errorMessage("HDD overflow");
+const juce::String SampleThreadPool::Pimpl::errorMessage("HDD overflow");
 
 
 void SampleThreadPool::Job::resetJob()

--- a/hi_streaming/hi_streaming/SampleThreadPool.h
+++ b/hi_streaming/hi_streaming/SampleThreadPool.h
@@ -33,9 +33,9 @@
 #ifndef SAMPLETHREADPOOL_H_INCLUDED
 #define SAMPLETHREADPOOL_H_INCLUDED
 
-namespace hise { using namespace juce;
+namespace hise {
 
-class SampleThreadPool : public Thread
+class SampleThreadPool : public juce::Thread
 {
 public:
 
@@ -48,13 +48,13 @@ public:
 	{
 	public:
 
-		Job(const String &name_) : 
-			name(name_),
-			queued(false),
-			running(false),
-			shouldStop(false)
-		{};
-        
+        Job(const juce::String &name_) :
+            queued(false),
+            running(false),
+            shouldStop(false),
+            name(name_)
+        {}
+
         virtual ~Job() { masterReference.clear(); }
 
 		enum JobStatus
@@ -82,15 +82,15 @@ public:
 	private:
 
 		friend class SampleThreadPool;
-        friend class WeakReference<Job>;
-        WeakReference<Job>::Master masterReference;
 
 		std::atomic<bool> queued;
 		std::atomic<bool> running;
 		std::atomic<bool> shouldStop;
 		std::atomic<Thread*> currentThread;
 
-		const String name;
+		const juce::String name;
+        
+        JUCE_DECLARE_WEAK_REFERENCEABLE (Job)
 	};
 
 	double getDiskUsage() const noexcept;
@@ -104,7 +104,7 @@ public:
 	struct Pimpl;
 
 	
-	ScopedPointer<Pimpl> pimpl;
+	std::unique_ptr<Pimpl> pimpl;
 
 };
 

--- a/hi_streaming/hi_streaming/StreamingSampler.cpp
+++ b/hi_streaming/hi_streaming/StreamingSampler.cpp
@@ -30,7 +30,7 @@
 *   ===========================================================================
 */
 
-namespace hise { using namespace juce;
+namespace hise {
 
 #define LOG_SAMPLE_RENDERING 0
 
@@ -46,7 +46,7 @@ void StreamingHelpers::increaseBufferIfNeeded(hlac::HiseSampleBuffer& b, int num
 	}
 }
 
-bool StreamingHelpers::preloadSample(StreamingSamplerSound * s, const int preloadSize, String& errorMessage)
+bool StreamingHelpers::preloadSample(StreamingSamplerSound * s, const int preloadSize, juce::String& errorMessage)
 {
 	try
 	{
@@ -62,21 +62,21 @@ bool StreamingHelpers::preloadSample(StreamingSamplerSound * s, const int preloa
 	}
 }
 
-hise::StreamingHelpers::BasicMappingData StreamingHelpers::getBasicMappingDataFromSample(const ValueTree& sampleData)
+hise::StreamingHelpers::BasicMappingData StreamingHelpers::getBasicMappingDataFromSample(const juce::ValueTree& sampleData)
 {
 	BasicMappingData data;
 
-	static const Identifier hiKey("HiKey");
-	static const Identifier loKey("LoKey");
-	static const Identifier loVel("LoVel");
-	static const Identifier hiVel("HiVel");
-	static const Identifier root("Root");
+	static const juce::Identifier hiKey("HiKey");
+	static const juce::Identifier loKey("LoKey");
+	static const juce::Identifier loVel("LoVel");
+	static const juce::Identifier hiVel("HiVel");
+	static const juce::Identifier root("Root");
 
-	data.highKey = (int8)(int)sampleData.getProperty(hiKey);
-	data.lowKey = (int8)(int)sampleData.getProperty(loKey);
-	data.lowVelocity = (int8)(int)sampleData.getProperty(loVel);
-	data.highVelocity = (int8)(int)sampleData.getProperty(hiVel);
-	data.rootNote = (int8)(int)sampleData.getProperty(root);
+	data.highKey = (int8_t)(int)sampleData.getProperty(hiKey);
+	data.lowKey = (int8_t)(int)sampleData.getProperty(loKey);
+	data.lowVelocity = (int8_t)(int)sampleData.getProperty(loVel);
+	data.highVelocity = (int8_t)(int)sampleData.getProperty(hiVel);
+	data.rootNote = (int8_t)(int)sampleData.getProperty(root);
 
 	return data;
 }

--- a/hi_streaming/hi_streaming/StreamingSampler.h
+++ b/hi_streaming/hi_streaming/StreamingSampler.h
@@ -33,7 +33,7 @@
 #ifndef STREAMINGSAMPLER_H_INCLUDED
 #define STREAMINGSAMPLER_H_INCLUDED
 
-namespace hise { using namespace juce;
+namespace hise {
 
 class ModulatorSampler;
 
@@ -44,19 +44,19 @@ struct StreamingHelpers
 	/** This contains the minimal MIDI information that can be extracted from a SampleMap. */
 	struct BasicMappingData
 	{
-		int8 lowKey = -1;
-		int8 highKey = -1;
-		int8 lowVelocity = -1;
-		int8 highVelocity = -1;
-		int8 rootNote = -1;
+		int8_t lowKey = -1;
+		int8_t highKey = -1;
+		int8_t lowVelocity = -1;
+		int8_t highVelocity = -1;
+		int8_t rootNote = -1;
 	};
 
 	static void increaseBufferIfNeeded(hlac::HiseSampleBuffer& b, int numSamplesNeeded);
 
-	static bool preloadSample(StreamingSamplerSound * s, const int preloadSize, String& errorMessage);
+	static bool preloadSample(StreamingSamplerSound * s, const int preloadSize, juce::String& errorMessage);
 
 	/** Creates a BasicMappingData object from the given samplemap entry. */
-	static BasicMappingData getBasicMappingDataFromSample(const ValueTree& sampleData);
+	static BasicMappingData getBasicMappingDataFromSample(const juce::ValueTree& sampleData);
 };
 
 
@@ -89,7 +89,7 @@ public:
 		if (numOpenFileHandles < 0) numOpenFileHandles = 0;
 	}
 
-	AudioFormatManager afm;
+    juce::AudioFormatManager afm;
 
 	int getNumOpenFileHandles() const { return numOpenFileHandles; }
 

--- a/hi_streaming/hi_streaming/StreamingSamplerSound.h
+++ b/hi_streaming/hi_streaming/StreamingSamplerSound.h
@@ -34,7 +34,7 @@
 #ifndef STREAMINGSAMPLERSOUND_H_INCLUDED
 #define STREAMINGSAMPLERSOUND_H_INCLUDED
 
-namespace hise { using namespace juce;
+namespace hise {
 
 // ==================================================================================================================================================
 
@@ -44,7 +44,7 @@ namespace hise { using namespace juce;
 	This class is not directly used in HISE, but wrapped into a ModulatorSamplerSound which provides extra functionality.
 	However, if you roll your own sampler class and just need to reuse the streaming facilities, you can tinker around with this class.
 */
-class StreamingSamplerSound : public SynthesiserSound
+class StreamingSamplerSound : public juce::SynthesiserSound
 {
 public:
 
@@ -65,13 +65,13 @@ public:
 		*	@param fileName the file that caused the error.
 		*	@param errorDescription a description of what went wrong.
 		*/
-		LoadingError(const String &fileName_, const String &errorDescription_) :
+		LoadingError(const juce::String &fileName_, const juce::String &errorDescription_) :
 			fileName(fileName_),
 			errorDescription(errorDescription_)
 		{};
 
-		String fileName;
-		String errorDescription;
+        juce::String fileName;
+        juce::String errorDescription;
 	};
 
 	// ==============================================================================================================================================
@@ -82,7 +82,7 @@ public:
 	*	@param midiNotes the note map
 	*	@param midiNoteForNormalPitch the root note
 	*/
-	StreamingSamplerSound(const String &fileNameToLoad, StreamingSamplerSoundPool *pool);
+	StreamingSamplerSound(const juce::String &fileNameToLoad, StreamingSamplerSoundPool *pool);
 
 	/** Creates a new StreamingSamplerSound from a monolithic file. */
 	StreamingSamplerSound(MonolithInfoToUse *info, int channelIndex, int sampleIndex);
@@ -205,32 +205,32 @@ public:
 
 	int getBitRate() const;
 
-	bool replaceAudioFile(const AudioSampleBuffer& b);
+	bool replaceAudioFile(const juce::AudioSampleBuffer& b);
 
 	bool isMonolithic() const;
-	AudioFormatReader* createReaderForPreview();
+    juce::AudioFormatReader* createReaderForPreview();
 
-	AudioFormatReader* createReaderForAnalysis();
+    juce::AudioFormatReader* createReaderForAnalysis();
 
-	int64 getMonolithOffset() const { return fileReader.getMonolithOffset(); }
-	int64 getMonolithLength() const { return fileReader.getMonolithLength(); }
+	int64_t getMonolithOffset() const { return fileReader.getMonolithOffset(); }
+	int64_t getMonolithLength() const { return fileReader.getMonolithLength(); }
 	double getMonolithSampleRate() const { return fileReader.getMonolithSampleRate(); }
 
 	// ==============================================================================================================================================
 
-	String getFileName(bool getFullPath = false) const;
+    juce::String getFileName(bool getFullPath = false) const;
 
-	int64 getHashCode();
+	int64_t getHashCode();
 
 
 	void refreshFileInformation();
 	void checkFileReference();
-	void replaceFileReference(const String &newFileName);
+	void replaceFileReference(const juce::String &newFileName);
 
 	bool isMissing() const noexcept;
 	bool hasActiveState() const noexcept;
 
-	String getSampleStateAsString() const;;
+    juce::String getSampleStateAsString() const;;
 
 	// ==============================================================================================================================================
 
@@ -243,7 +243,7 @@ public:
 	};
 
 	/** Returns the length of the loaded audio file in samples. */
-	int64 getLengthInSamples() const noexcept { return fileReader.getSampleLength(); };
+	int64_t getLengthInSamples() const noexcept { return fileReader.getSampleLength(); };
 
 	/** Gets the sound into active memory.
 	*
@@ -280,9 +280,9 @@ public:
 
 	// ==============================================================================================================================================
 
-	typedef ReferenceCountedObjectPtr<StreamingSamplerSound> Ptr;
+	typedef juce::ReferenceCountedObjectPtr<StreamingSamplerSound> Ptr;
 
-	const CriticalSection& getSampleLock() const { return lock; };
+	const juce::CriticalSection& getSampleLock() const { return lock; };
 
     /** Use this in order to skip the preloading before all properties have been set. */
     void setDelayPreloadInitialisation(bool shouldDelay);
@@ -303,12 +303,12 @@ private:
 
 		// ==============================================================================================================================================
 
-		void setFile(const String &fileName);
+		void setFile(const juce::String &fileName);
 		void setMonolithicInfo(MonolithInfoToUse* info, int channelIndex, int sampleIndex);
 
-		String getFileName(bool getFullPath);
+        juce::String getFileName(bool getFullPath);
 		void checkFileReference();
-		int64 getHashCode() { return hashCode; };
+		int64_t getHashCode() { return hashCode; };
 
 		/** Refreshes the information about the file (if it is missing, if it supports memory-mapping). */
 		void refreshFileInformation();
@@ -316,25 +316,25 @@ private:
 		// ==============================================================================================================================================
 
 		/** Returns the best reader for the file. If a memorymapped reader can be used, it will return a MemoryMappedAudioFormatReader. */
-		AudioFormatReader *getReader();
+        juce::AudioFormatReader *getReader();
 
 		/** Encapsulates all reading operations. It will use the best available reader type and opens the file handle if it is not open yet. */
 		void readFromDisk(hlac::HiseSampleBuffer &buffer, int startSample, int numSamples, int readerPosition, bool useMemoryMappedReader);
 
 		/** Call this method if you want to close the file handle. If voices are playing, it won't close it. */
-		void closeFileHandles(NotificationType notifyPool = sendNotification);
+		void closeFileHandles(juce::NotificationType notifyPool = juce::sendNotification);
 
 		/** Call this method if you want to open the file handles. If you just want to read the file, you don't need to call it. */
-		void openFileHandles(NotificationType notifyPool = sendNotification);
+		void openFileHandles(juce::NotificationType notifyPool = juce::sendNotification);
 
 		// ==============================================================================================================================================
 
 		void increaseVoiceCount() { ++voiceCount; };
-		void decreaseVoiceCount() { --voiceCount; voiceCount.compareAndSetBool(0, -1); }
+        void decreaseVoiceCount() { --voiceCount; }
 
 		// ==============================================================================================================================================
 
-		bool isUsed() const noexcept { return voiceCount.get() != 0; }
+		bool isUsed() const noexcept { return voiceCount.load() != 0; }
 		bool isOpened() const noexcept { return fileHandlesOpen; }
 		bool isMonolithic() const noexcept { return monolithicInfo != nullptr; }
 
@@ -343,7 +343,7 @@ private:
 		bool isMissing() const { return missing; }
 		void setMissing() { missing = true; }
 
-		int64 getMonolithOffset() const
+		int64_t getMonolithOffset() const
 		{
 			if (monolithicInfo != nullptr)
 				return monolithicInfo->getMonolithOffset(monolithicIndex);
@@ -351,7 +351,7 @@ private:
 			return 0;
 		}
 
-		int64 getMonolithLength() const
+		int64_t getMonolithLength() const
 		{
 			if (monolithicInfo != nullptr)
 				return monolithicInfo->getMonolithLength(monolithicIndex);
@@ -359,7 +359,7 @@ private:
 			return 0;
 		}
 
-		int64 getSampleLength() const
+		int64_t getSampleLength() const
 		{
 			return sampleLength;
 		}
@@ -380,9 +380,9 @@ private:
 
 		float calculatePeakValue();
 
-		AudioFormatReader* createMonolithicReaderForPreview();
+        juce::AudioFormatReader* createMonolithicReaderForPreview();
 
-		AudioFormatWriter* createWriterWithSameFormat(OutputStream* out);
+        juce::AudioFormatWriter* createWriterWithSameFormat(juce::OutputStream* out);
 
 		// ==============================================================================================================================================
 
@@ -390,34 +390,34 @@ private:
 
 		StreamingSamplerSoundPool *pool;
 
-		ReferenceCountedObjectPtr<MonolithInfoToUse> monolithicInfo = nullptr;
+        juce::ReferenceCountedObjectPtr<MonolithInfoToUse> monolithicInfo = nullptr;
 		int monolithicIndex = -1;
 		int monolithicChannelIndex = -1;
-		String monolithicName;
+        juce::String monolithicName;
 
-		CriticalSection readLock2;
+        juce::CriticalSection readLock2;
 
-		ReadWriteLock fileAccessLock;
+        juce::ReadWriteLock fileAccessLock;
 
 		bool stereo = true;
 
 		bool isReading;
 
-		int64 sampleLength;
+		int64_t sampleLength;
 
-		File loadedFile;
+        juce::File loadedFile;
 
-		String faultyFileName;
+        juce::String faultyFileName;
 
-		int64 hashCode;
+		int64_t hashCode;
 
 		StreamingSamplerSound *sound;
 
-		ScopedPointer<MemoryMappedAudioFormatReader> memoryReader;
-		ScopedPointer<AudioFormatReader> normalReader;
+		std::unique_ptr<juce::MemoryMappedAudioFormatReader> memoryReader;
+        std::unique_ptr<juce::AudioFormatReader> normalReader;
 		bool fileHandlesOpen;
 
-		Atomic<int> voiceCount;
+        std::atomic<int> voiceCount {0};
 
         bool fileFormatSupportsMemoryReading = true;
 
@@ -429,9 +429,9 @@ private:
 
 	struct ScopedFileHandler
 	{
-		ScopedFileHandler(StreamingSamplerSound* s, NotificationType notifyPool_ = NotificationType::sendNotification) :
-			reader(s->fileReader),
-			notifyPool(notifyPool_)
+		ScopedFileHandler(StreamingSamplerSound* s, juce::NotificationType notifyPool_ = juce::NotificationType::sendNotification) :
+            notifyPool(notifyPool_),
+            reader(s->fileReader)
 		{
 			reader.openFileHandles(notifyPool);
 		}
@@ -441,7 +441,7 @@ private:
 			reader.closeFileHandles(notifyPool);
 		}
 
-		NotificationType notifyPool;
+        juce::NotificationType notifyPool;
 		FileReader& reader;
 	};
 
@@ -467,7 +467,7 @@ private:
 	// ==============================================================================================================================================
 
 
-	CriticalSection lock;
+    juce::CriticalSection lock;
 
 	mutable FileReader fileReader;
 
@@ -503,12 +503,12 @@ private:
 	int loopLength;
 	int crossfadeLength;
 
-	Range<int> crossfadeArea;
+    juce::Range<int> crossfadeArea;
 
-	int8 rootNote = 0;
+	int8_t rootNote = 0;
 	
-	BigInteger midiNotes = 0;
-	BigInteger velocityRange = 0;
+    juce::BigInteger midiNotes = 0;
+    juce::BigInteger velocityRange = 0;
 	
 	// contains the precalculated crossfade
 	hlac::HiseSampleBuffer loopBuffer;
@@ -517,10 +517,8 @@ private:
 
 	// ==============================================================================================================================================
 
-	friend class WeakReference < StreamingSamplerSound >;
-	WeakReference<StreamingSamplerSound>::Master masterReference;
-
-	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(StreamingSamplerSound)
+    JUCE_DECLARE_WEAK_REFERENCEABLE (StreamingSamplerSound)
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (StreamingSamplerSound)
 };
 
 } // namespace hise

--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.h
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.h
@@ -33,7 +33,7 @@
 #ifndef STREAMINGSAMPLERVOICE_H_INCLUDED
 #define STREAMINGSAMPLERVOICE_H_INCLUDED
 
-namespace hise { using namespace juce;
+namespace hise {
 
 
 /** This is a utility class that handles buffered sample streaming in a background thread.
@@ -67,7 +67,7 @@ public:
 	*
 	*	The write buffer will be locked for the time of the read operation. Also it measures the time for getDiskUsage();
 	*/
-	JobStatus runJob() override;
+    JobStatus runJob() override;
 
 	size_t getActualStreamingBufferSize() const;
 
@@ -123,7 +123,7 @@ public:
 
 
 	void setLogger(DebugLogger* l) { logger = l; }
-	const CriticalSection &getLock() const { return lock; }
+	const juce::CriticalSection &getLock() const { return lock; }
 
 	/** Sets a function that checks whether the streaming engine should work asynchronously or fetch the data directly
 	    in the caller thread. 
@@ -160,45 +160,45 @@ private:
 	*	during the read operation, but I have to lock everything for a few calls, so that's why
 	*	there is a critical section.
 	*/
-	CriticalSection lock;
+	juce::CriticalSection lock;
 
 	/** A mutex for the buffer that is being used for loading. */
-	bool writeBufferIsBeingFilled;
+	bool writeBufferIsBeingFilled = false;
 
 	// variables for handling of the internal buffers
 
-	double readIndexDouble;
+	double readIndexDouble = 0.0;
 
 	double lastSwapPosition = 0.0;
 
-	Atomic<StreamingSamplerSound const *> sound;
+    juce::Atomic<StreamingSamplerSound const *> sound { nullptr };
 
-	int readIndex;
-	int idealBufferSize;
-	int minimumBufferSizeForSamplesPerBlock;
+	int readIndex   = 0;
+	int idealBufferSize = 0;
+	int minimumBufferSizeForSamplesPerBlock = 0;
 
-	int positionInSampleFile;
+	int positionInSampleFile = 0;
 
-	bool isReadingFromPreloadBuffer;
+	bool isReadingFromPreloadBuffer = true;
 
-	bool entireSampleIsLoaded;
+	bool entireSampleIsLoaded = false;
 
-	bool voiceCounterWasIncreased;
+	bool voiceCounterWasIncreased = false;
 
-	int sampleStartModValue;
+	int sampleStartModValue = 0;
 
-	DebugLogger* logger;
+	DebugLogger* logger = nullptr;
 
-	Atomic<hlac::HiseSampleBuffer const *> readBuffer;
-	Atomic<hlac::HiseSampleBuffer *> writeBuffer;
+    juce::Atomic<hlac::HiseSampleBuffer const *> readBuffer { nullptr };
+    juce::Atomic<hlac::HiseSampleBuffer *> writeBuffer      { nullptr };
 
 	// variables for disk usage measurement
 
-	Atomic<float> diskUsage;
-	double lastCallToRequestData;
+    juce::Atomic<float> diskUsage { 0.0 };
+	double lastCallToRequestData = 0.0;
 
 	// just a pointer to the used pool
-	SampleThreadPool *backgroundPool;
+	SampleThreadPool *backgroundPool = nullptr;
 
 	// the internal buffers
 
@@ -213,7 +213,7 @@ private:
 *	It uses a SampleLoader object to fetch the data and copies the values into an internal buffer, so you
 *	don't have to bother with the SampleLoader's internals.
 */
-class StreamingSamplerVoice : public SynthesiserVoice
+class StreamingSamplerVoice : public juce::SynthesiserVoice
 {
 public:
 	StreamingSamplerVoice(SampleThreadPool *backgroundThreadPool);
@@ -221,22 +221,22 @@ public:
 	~StreamingSamplerVoice() {};
 
 	/** Always returns true. */
-	bool canPlaySound(SynthesiserSound*) { return true; };
+	bool canPlaySound(juce::SynthesiserSound*) override { return true; }
 
 	/** starts the streaming of the sound. */
-	void startNote(int midiNoteNumber, float velocity, SynthesiserSound* s, int /*currentPitchWheelPosition*/) override;
+	void startNote(int midiNoteNumber, float velocity, juce::SynthesiserSound* s, int /*currentPitchWheelPosition*/) override;
 
 	const StreamingSamplerSound *getLoadedSound();
 
 	void setLoaderBufferSize(int newBufferSize);;
 
 	/** Clears the note data and resets the loader. */
-	void stopNote(float, bool /*allowTailOff*/);;
+	void stopNote(float, bool /*allowTailOff*/) override;
 
 	void setDebugLogger(DebugLogger* newLogger);
 
 	/** Adds it's output to the outputBuffer. */
-	void renderNextBlock(AudioSampleBuffer &outputBuffer, int startSample, int numSamples) override;
+	void renderNextBlock(juce::AudioSampleBuffer &outputBuffer, int startSample, int numSamples) override;
 
 	/** You can pass a pointer with float values containing pitch information for each sample and the delta pitch value for each sample.
 	*
@@ -315,7 +315,7 @@ private:
 	// will be calculated at note on
 	double constUptimeDelta = 1.0;
 
-	int sampleStartModValue;
+	int sampleStartModValue = 0;
 
 	DebugLogger* logger = nullptr;
 


### PR DESCRIPTION
This commit allows to compile the streaming_example with the current JUCE master (6.1.2)

- Replaced most ScopedPointer with std::unique_ptr
- Removed using namespace juce and added juce:: prefixes/use the std types e.g. uint8_t
- Unified include to juce standard
- Fixed several initialisation order problems
- Moved default initialisations to header
- Fixed some uninitialised variables

Hope that you like it, would love to see this in the repo