### PR TITLE
Slider getValueNormalized wasn't in the API list

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -874,6 +874,7 @@ public:
 		/** Set the value from a 0.0 to 1.0 range */
 		void setValueNormalized(double normalizedValue) override;
 
+		/** Returns the normalized value. */
 		double getValueNormalized() const override;
 
 		/** Sets the range and the step size of the knob. */


### PR DESCRIPTION
(API tree isn't rebuilt from a mac so it'll wait for next build)