### PR TITLE
Added File.getVersion.

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.cpp
@@ -187,6 +187,7 @@ struct ScriptingObjects::ScriptFile::Wrapper
 	API_METHOD_WRAPPER_1(ScriptFile, getChildFile);
 	API_METHOD_WRAPPER_1(ScriptFile, createDirectory);
 	API_METHOD_WRAPPER_0(ScriptFile, getSize);
+	API_METHOD_WRAPPER_0(ScriptFile, getVersion);
 	API_METHOD_WRAPPER_0(ScriptFile, getBytesFreeOnVolume);
 	API_METHOD_WRAPPER_1(ScriptFile, setExecutePermission);
 	API_METHOD_WRAPPER_1(ScriptFile, startAsProcess);
@@ -239,6 +240,7 @@ ScriptingObjects::ScriptFile::ScriptFile(ProcessorWithScriptingContent* p, const
 	ADD_API_METHOD_1(getChildFile);
 	ADD_API_METHOD_1(createDirectory);
 	ADD_API_METHOD_0(getSize);
+	ADD_API_METHOD_0(getVersion);
 	ADD_API_METHOD_0(getHash);
 	ADD_API_METHOD_1(toString);
 	ADD_API_METHOD_0(isFile);
@@ -287,6 +289,16 @@ var ScriptingObjects::ScriptFile::createDirectory(String directoryName)
 int64 ScriptingObjects::ScriptFile::getSize()
 {	
 	return f.getSize();
+}
+
+String ScriptingObjects::ScriptFile::getVersion()
+{	
+	#if JUCE_LINUX
+		auto matches = RegexFunctions::getFirstMatch(R"((\d+)(.\d+)*)", f.getFileName());
+		return matches[0];
+	#else
+		return f.getVersion();
+	#endif	
 }
 
 int64 ScriptingObjects::ScriptFile::getBytesFreeOnVolume()

--- a/hi_scripting/scripting/api/ScriptingApiObjects.h
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.h
@@ -287,6 +287,9 @@ namespace ScriptingObjects
 		/** Returns the size of the file in bytes. */
 		int64 getSize();
 		
+		/** If possible, this will try to create a version string for the given file. */
+		String getVersion();
+		
 		/** Returns the number of bytes free on the drive that this file lives on. */
 		int64 getBytesFreeOnVolume();
 


### PR DESCRIPTION
JUCE doesn't include an implementation for retrieving a version number from a binary on GNU/Linux so I had to roll my own for that platform. 

There doesn't appear to be a universal way to do this but as my purpose is for getting the version of plugins (.so) and the standard way to add a version number to a .so on Linux is to append it to the end of the file, I'm using some simple regex to retrieve that part of the file name.

If anyone has a more generic method that doesn't rely on the version being part of the file name that would be great :)

Oh and I appear to have added a superfluous `else` in there, so feel free to remove it.