### PR TITLE
Use number of mics from sample map regardless of useStaticMatrix value

### DIFF
--- a/hi_sampler/sampler/ModulatorSamplerData.cpp
+++ b/hi_sampler/sampler/ModulatorSamplerData.cpp
@@ -330,17 +330,10 @@ void SampleMap::parseValueTree(const ValueTree &v)
 
 	micPositions.removeEmptyStrings(true);
 
-	if (!sampler->isUsingStaticMatrix())
-	{
-		if (micPositions.size() != 0)
-		{
-			sampler->setNumMicPositions(micPositions);
-		}
-		else
-		{
-			sampler->setNumChannels(numChannels);
-		}
-	}
+	if (micPositions.size() != 0)
+		sampler->setNumMicPositions(micPositions);
+	else
+		sampler->setNumChannels(numChannels);
 
 	auto& progress = getSampler()->getMainController()->getSampleManager().getPreloadProgress();
 


### PR DESCRIPTION
Discussion - https://forum.hise.audio/topic/5478/setusestaticmatrix-creates-false-mic-positions/