### PR TITLE
Added panel.isImageLoaded

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -3065,6 +3065,7 @@ struct ScriptingApi::Content::ScriptPanel::Wrapper
 	API_VOID_METHOD_WRAPPER_0(ScriptPanel, changed);
 	API_VOID_METHOD_WRAPPER_2(ScriptPanel, loadImage);
 	API_VOID_METHOD_WRAPPER_0(ScriptPanel, unloadAllImages);
+	API_METHOD_WRAPPER_1(ScriptPanel, isImageLoaded);
 	API_VOID_METHOD_WRAPPER_1(ScriptPanel, setDraggingBounds);
 	API_VOID_METHOD_WRAPPER_2(ScriptPanel, setPopupData);
   API_VOID_METHOD_WRAPPER_3(ScriptPanel, setValueWithUndo);
@@ -3168,6 +3169,7 @@ void ScriptingApi::Content::ScriptPanel::init()
 	ADD_API_METHOD_0(stopTimer);
 	ADD_API_METHOD_2(loadImage);
 	ADD_API_METHOD_0(unloadAllImages);
+	ADD_API_METHOD_1(isImageLoaded);
 	ADD_API_METHOD_1(setDraggingBounds);
 	ADD_API_METHOD_2(setPopupData);
 	ADD_API_METHOD_3(setValueWithUndo);
@@ -3447,6 +3449,17 @@ void ScriptingApi::Content::ScriptPanel::loadImage(String imageName, String pret
 void ScriptingApi::Content::ScriptPanel::unloadAllImages()
 {
 	loadedImages.clear();
+}
+
+bool ScriptingApi::Content::ScriptPanel::isImageLoaded(String prettyName)
+{
+	for (auto& img : loadedImages)
+	{
+		if (img.prettyName == prettyName)
+			return true;
+	}
+	
+	return false;
 }
 
 StringArray ScriptingApi::Content::ScriptPanel::getItemList() const

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -1728,6 +1728,9 @@ public:
 
 		/** Unload all images from the panel. */
 		void unloadAllImages();
+		
+		/** Checks if the image has been loaded into the panel */
+		bool isImageLoaded(String prettyName);
 
 		/** If `allowedDragging` is enabled, it will define the boundaries where the panel can be dragged. */
 		void setDraggingBounds(var area);


### PR DESCRIPTION
I had a situation where a paint routine was being assigned before an image had finished loading and it was causing an image not found error in the paint routine. Using this function I'm able to skip that part of the paint routine until the image has finished loading.