### PR TITLE
Added Engine.isCtrlDown

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -873,6 +873,7 @@ struct ScriptingApi::Engine::Wrapper
 	API_METHOD_WRAPPER_2(Engine, matchesRegex);
 	API_METHOD_WRAPPER_2(Engine, getRegexMatches);
 	API_METHOD_WRAPPER_2(Engine, doubleToString);
+	API_METHOD_WRAPPER_0(Engine, isCtrlDown);
 	API_METHOD_WRAPPER_0(Engine, getOS);
 	API_METHOD_WRAPPER_0(Engine, getSystemStats);
 	API_METHOD_WRAPPER_0(Engine, isPlugin);
@@ -994,6 +995,7 @@ parentMidiProcessor(dynamic_cast<ScriptBaseMidiProcessor*>(p))
 	ADD_API_METHOD_2(matchesRegex);
 	ADD_API_METHOD_2(getRegexMatches);
 	ADD_API_METHOD_2(doubleToString);
+	ADD_API_METHOD_0(isCtrlDown);
 	ADD_API_METHOD_1(getMasterPeakLevel);
 	ADD_API_METHOD_0(getOS);
 	ADD_API_METHOD_0(getSystemStats);
@@ -2532,6 +2534,10 @@ String ScriptingApi::Engine::doubleToString(double value, int digits)
     return String(value, digits);
 }
 
+bool ScriptingApi::Engine::isCtrlDown()
+{
+	return juce::ModifierKeys::currentModifiers.isCommandDown() || juce::ModifierKeys::currentModifiers.isCtrlDown();
+}
 void ScriptingApi::Engine::undo()
 {
 	WeakReference<Processor> p = getProcessor();

--- a/hi_scripting/scripting/api/ScriptingApi.h
+++ b/hi_scripting/scripting/api/ScriptingApi.h
@@ -544,7 +544,9 @@ public:
     var getRegexMatches(String stringToMatch, String regex);
 
     /** Returns a string of the value with the supplied number of digits. */
-    String doubleToString(double value, int digits);
+    String doubleToString(double value, int digits);	
+		/** Checks whether the CTRL key's flag is set. */
+		bool isCtrlDown();
 
 		/** Reverts the last controller change. */
 		void undo();


### PR DESCRIPTION
I'd like to add a similar check for alt and shift but I'm not sure if a) individual functions for each key is the best approach and b) if the Engine class is where this should live. What do you think?