### PR TITLE
Add DONT_CREATE_USER_PRESET_FOLDER and DONT_CREATE_EXPANSIONS_FOLDER

### DIFF
--- a/hi_core/hi_core.h
+++ b/hi_core/hi_core.h
@@ -115,6 +115,22 @@ If true, then this will use some additional features for the standalone app (pop
 #define IS_STANDALONE_APP 0
 #endif
 
+/** Config: DONT_CREATE_USER_PRESET_FOLDER
+
+Set this to 1 to disable the creation of the User Presets folder at init (i.e. for non-audio related app)
+*/
+#ifndef DONT_CREATE_USER_PRESET_FOLDER
+#define DONT_CREATE_USER_PRESET_FOLDER 0
+#endif
+
+/** Config: DONT_CREATE_EXPANSIONS_FOLDER
+
+Set this to 1 to disable the creation of the Expansions folder at init (i.e. for non-audio related app)
+*/
+#ifndef DONT_CREATE_EXPANSIONS_FOLDER
+#define DONT_CREATE_EXPANSIONS_FOLDER 0
+#endif
+
 /** Config: USE_COPY_PROTECTION
 
 If true, then the copy protection will be used

--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -183,8 +183,10 @@ juce::File ExpansionHandler::getExpansionFolder() const
 	{
 		auto f = getMainController()->getSampleManager().getProjectHandler().getRootFolder().getChildFile("Expansions");
 
+#if !DONT_CREATE_EXPANSIONS_FOLDER
 		if (!f.isDirectory())
 			f.createDirectory();
+#endif
 
 #if JUCE_WINDOWS
 		auto linkFile = f.getChildFile("LinkWindows");
@@ -196,9 +198,6 @@ juce::File ExpansionHandler::getExpansionFolder() const
 
 		if (linkFile.existsAsFile())
 			f = File(linkFile.loadFileAsString());
-		
-		if (!f.isDirectory())
-			f.createDirectory();
 
 		expansionFolder = f;
 	}

--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -471,7 +471,7 @@ juce::StringArray UserPresetHelpers::getExpansionsForUserPreset(const File& user
 
 void UserPresetHelpers::extractUserPresets(const char* userPresetData, size_t size)
 {
-#if USE_FRONTEND
+#if USE_FRONTEND && !DONT_CREATE_USER_PRESET_FOLDER
 	auto userPresetDirectory = FrontendHandler::getUserPresetDirectory();
 
 	if (userPresetDirectory.isDirectory())


### PR DESCRIPTION
This is useful when developing a non-audio related app, and prevents dirty deletion of the folders after they are created.
Also removed a redundant Expansions folder creation