### PR TITLE
Excape spaces in sample paths when opening in external editor

### DIFF
--- a/hi_dsp/modules/Modulators.cpp
+++ b/hi_dsp/modules/Modulators.cpp
@@ -712,9 +712,7 @@ void Modulation::PitchConverters::normalisedRangeToPitchFactor(float* rangeValue
 #endif
 
 		if (hasDeltaSignChange)
-		{
-			DBG("USE RANGE");
-			
+		{			
 			for (int i = 0; i < numValues; i++)
 				rangeValues[i] = normalisedRangeToPitchFactor(rangeValues[i]);
 		}

--- a/hi_sampler/sampler/components/SampleEditor.cpp
+++ b/hi_sampler/sampler/components/SampleEditor.cpp
@@ -1730,10 +1730,10 @@ void SampleEditor::perform(SampleMapCommands c)
 
 #if JUCE_WINDOWS
         for(auto& f: editedFiles)
-            args << "\"" << f.getFullPathName() << "\" ";
+            args << "\"" << f.getFullPathName().replace(" ", "\\ ") << "\" ";
 #else
         for(auto& f: editedFiles)
-            args << f.getFullPathName() << " ";
+            args << f.getFullPathName().replace(" ", "\\ ") << " ";
 #endif
 
         externalWatcher = new ExternalFileChangeWatcher(sampler, editedFiles);


### PR DESCRIPTION
Not sure if there is a more elegant solution, but this fixes #341