### PR TITLE
Linux: Reduce compiler warnings

### DIFF
--- a/JUCE/modules/juce_gui_basics/juce_gui_basics.h
+++ b/JUCE/modules/juce_gui_basics/juce_gui_basics.h
@@ -54,6 +54,8 @@
 #pragma once
 #define JUCE_GUI_BASICS_H_INCLUDED
 
+#include <utility>
+
 #include <juce_graphics/juce_graphics.h>
 #include <juce_data_structures/juce_data_structures.h>
 

--- a/hi_components/floating_layout/BackendPanelTypes.h
+++ b/hi_components/floating_layout/BackendPanelTypes.h
@@ -368,7 +368,7 @@ public:
 
 	void resized() override
 	{
-		auto area = getParentShell()->getContentBounds();
+		auto area = getParentContentBounds();
 
 		auto top = area.removeFromTop(32).reduced(4);
 
@@ -384,7 +384,7 @@ public:
 
 	void paint(Graphics& g)
 	{
-		auto area = getParentShell()->getContentBounds();
+		auto area = getParentContentBounds();
 
 		g.setColour(Colours::white.withAlpha(0.7f));
 		g.setFont(GLOBAL_BOLD_FONT());
@@ -553,11 +553,6 @@ struct PoolTableSubTypes
 	using SampleMapPoolTable = ExternalFileTableBase<ValueTree>;
 	using MidiFilePoolTable = ExternalFileTableBase<MidiFileReference>;
 };
-
-
-
-
-
 
 } // namespace hise
 

--- a/hi_components/floating_layout/FloatingTile.cpp
+++ b/hi_components/floating_layout/FloatingTile.cpp
@@ -2185,4 +2185,10 @@ juce::Path FloatingTilePopup::Factory::createPath(const String& url) const
 	return path;
 }
 
+
+const Identifier FloatingTileHelpers::getTileID(FloatingTile* parent)
+{
+	return parent->getLayoutData().getID();
+}
+
 } // namespace hise

--- a/hi_components/floating_layout/FloatingTile.h
+++ b/hi_components/floating_layout/FloatingTile.h
@@ -898,13 +898,15 @@ private:
 
 struct FloatingTileHelpers
 {
+	static const Identifier getTileID(FloatingTile* parent);
 	template <class ContentType> static ContentType* findTileWithId(FloatingTile* root, const Identifier& id)
 	{
 		FloatingTile::Iterator<ContentType> iter(root);
 
 		while (auto t = iter.getNextPanel())
 		{
-			if (t->getParentShell()->getLayoutData().getID() == id || id.isNull())
+			auto tid = getTileID(t->getParentShell());
+			if (tid == id || id.isNull())
 				return t;
 		}
 

--- a/hi_components/floating_layout/FloatingTileContent.cpp
+++ b/hi_components/floating_layout/FloatingTileContent.cpp
@@ -93,6 +93,10 @@ const BackendRootWindow* FloatingTileContent::getRootWindow() const
 	return getParentShell()->getBackendRootWindow();
 }
 
+Rectangle<int> FloatingTileContent::getParentContentBounds() {
+    return getParentShell()->getContentBounds();
+}
+
 var FloatingTileContent::toDynamicObject() const
 {
 	auto o = new DynamicObject();

--- a/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_components/floating_layout/FloatingTileContent.h
@@ -540,6 +540,8 @@ public:
 		return parent; 
 	}
 
+	Rectangle<int> getParentContentBounds();
+
 	virtual String getTitle() const { return getIdentifierForBaseClass().toString(); };
 	virtual Identifier getIdentifierForBaseClass() const = 0;
 

--- a/hi_components/floating_layout/MiscFloatingPanelTypes.h
+++ b/hi_components/floating_layout/MiscFloatingPanelTypes.h
@@ -650,7 +650,7 @@ public:
 #if USE_FRONTEND
 		component->setBounds(getLocalBounds());
 #else
-		component->setBounds(getParentShell()->getContentBounds());
+		component->setBounds(getParentContentBounds());
 #endif
 	}
 

--- a/hi_components/floating_layout/SnexFloatingTiles.h
+++ b/hi_components/floating_layout/SnexFloatingTiles.h
@@ -176,7 +176,7 @@ template <typename C> struct SnexWorkbenchPanel : public FloatingTileContent,
 	void resized() override
 	{
 		if(content != nullptr)
-			content->setBounds(getParentShell()->getContentBounds());
+			content->setBounds(getParentContentBounds());
 	}
 
 	bool forceShowTitle = true;
@@ -234,7 +234,7 @@ struct SnexEditorPanel : public Component,
 
 	void resized() override
 	{
-		auto b = FloatingTileContent::getParentShell()->getContentBounds();
+		auto b = FloatingTileContent::getParentContentBounds();
 		if (playground != nullptr)
 			playground->setBounds(b);
 	}

--- a/hi_core/hi_core/ExternalFilePool.h
+++ b/hi_core/hi_core/ExternalFilePool.h
@@ -673,7 +673,7 @@ private:
 
 
 /** Implementations of the data pool. */
-template <class DataType> class SharedPoolBase : public PoolBase
+template <class DataType> class SharedPoolBase : public PoolBase, public InternalLogger
 {
 public:
 
@@ -1084,7 +1084,7 @@ public:
 					}
 					else
 					{
-						getMainController()->getDebugLogger().logMessage(r.getReferenceString() + " wasn't found.");
+						logMessage(getMainController(), r.getReferenceString() + " wasn't found.");
 
 						jassertfalse; // This shouldn't happen...
 						return ManagedPtr();
@@ -1169,7 +1169,7 @@ public:
 			}
 			else
 			{
-				getMainController()->getDebugLogger().logMessage(r.getReferenceString() + " wasn't found.");
+				logMessage(getMainController(), r.getReferenceString() + " wasn't found.");
 				return ManagedPtr();
 			}
 		}

--- a/hi_core/hi_core/MainControllerShell.cpp
+++ b/hi_core/hi_core/MainControllerShell.cpp
@@ -1,0 +1,9 @@
+#include "JuceHeader.h"
+
+namespace hise {
+using namespace juce;
+void InternalLogger::logMessage(MainController* mc, const String& errorMessage) {
+    mc->getDebugLogger().logMessage(errorMessage);
+}
+
+} // namespace hise

--- a/hi_core/hi_core/MainControllerShell.h
+++ b/hi_core/hi_core/MainControllerShell.h
@@ -1,0 +1,19 @@
+#ifndef MAINCONTROLLERSHELL_H_INCLUDED
+#define MAINCONTROLLERSHELL_H_INCLUDED
+// Derive from this class if you want to log in a class which MainController
+// depends on.
+
+namespace hise {
+// forward declaration of MainController
+class MainController;
+
+// derive from these classes if you need access to various methods of
+// MainController before it is actually defined and MainController
+// depends on your class.
+
+class InternalLogger {
+public:
+    void logMessage(MainController* mc, const String& errorMessage);
+};
+} // namespace hise
+#endif // MAINCONTROLLERSHELL_H_INCLUDED

--- a/hi_core/hi_core/hi_core.cpp
+++ b/hi_core/hi_core/hi_core.cpp
@@ -53,6 +53,7 @@
 
 #include "UtilityClasses.cpp"
 #include "DebugLogger.cpp"
+#include "MainControllerShell.cpp" // provides encapsulated access to MainController functions
 #include "ThreadWithQuasiModalProgressWindow.cpp"
 #include "ExternalFilePool.cpp"
 #include "ExpansionHandler.cpp"

--- a/hi_core/hi_core/hi_core.h
+++ b/hi_core/hi_core/hi_core.h
@@ -78,6 +78,7 @@
 #include "UtilityClasses.h"
 
 #include "DebugLogger.h"
+#include "MainControllerShell.h" // provides encapsulated access to MainController functions
 #include "ThreadWithQuasiModalProgressWindow.h"
 #include "Popup.h"
 #include "BackgroundThreads.h"

--- a/hi_dsp_library/node_api/helpers/parameter.h
+++ b/hi_dsp_library/node_api/helpers/parameter.h
@@ -336,7 +336,7 @@ template <class T, int P, class Expression> struct expression : public single_ba
 		Expression e;
 		v = e.op(v);
 
-		ObjectType::setParameterStatic<P>(this->obj, v);
+		ObjectType:: template setParameterStatic<P>(this->obj, v);
 	}
 
 	void operator()(double v)

--- a/hi_dsp_library/node_api/nodes/duplicate.h
+++ b/hi_dsp_library/node_api/nodes/duplicate.h
@@ -238,8 +238,8 @@ template <typename DataType, CloneProcessType ProcessType>
     constexpr auto& getObject() { return *this; }
 	constexpr const auto& getObject() const { return *this; }
 
-	constexpr auto& getWrappedObject() { return *DataType::Iterator<false>(cloneData).begin(); }
-	constexpr const auto& getWrappedObject() const { return *DataType::Iterator<false>(cloneData).begin(); }
+	constexpr auto& getWrappedObject() { return *DataType:: template Iterator<false>(cloneData).begin(); }
+	constexpr const auto& getWrappedObject() const { return *DataType:: template Iterator<false>(cloneData).begin(); }
 
     static constexpr int NumChannels = DataType::ObjectType::NumChannels;
     

--- a/hi_dsp_library/node_api/nodes/processors.h
+++ b/hi_dsp_library/node_api/nodes/processors.h
@@ -734,6 +734,8 @@ template <class T> class default_data
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 
 /** A wrapper that extends the wrap::init class with the possibility of handling external data.

--- a/hi_dsp_library/snex_basics/snex_DynamicType.h
+++ b/hi_dsp_library/snex_basics/snex_DynamicType.h
@@ -54,6 +54,7 @@ namespace snex
 			data.p.type = Types::ID::Pointer;
 			data.p.data = ptr;
 			data.p.size = sizeof(T);
+			return *this;
 		}
 
 		VariableStorage(void* objectPointer, int objectSize);

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -2218,7 +2218,7 @@ public:
 	};
 
 
-	using ScreenshotListener = ScreenshotListener;
+	using ScreenshotListener = hise::ScreenshotListener;
 
 	struct VisualGuide
 	{

--- a/hi_scripting/scripting/scriptnode/api/NodeBase.h
+++ b/hi_scripting/scripting/scriptnode/api/NodeBase.h
@@ -205,7 +205,7 @@ class NodeBase : public ConstScriptingObject
 {
 public:
 
-	using Parameter = Parameter;
+	using Parameter = scriptnode::Parameter;
 
 	using FrameType = snex::Types::dyn<float>;
 	using MonoFrameType = snex::Types::span<float, 1>;

--- a/hi_scripting/scripting/scriptnode/snex_nodes/SnexMidi.h
+++ b/hi_scripting/scripting/scriptnode/snex_nodes/SnexMidi.h
@@ -73,7 +73,7 @@ struct dynamic : public OptionalSnexSource
 
 		Result runTest(snex::ui::WorkbenchData::CompileResult& lastResult) override
 		{
-			auto wb = static_cast<snex::ui::WorkbenchManager*>(parent.getParentNode()->getScriptProcessor()->getMainController_()->getWorkbenchManager());
+			auto wb = static_cast<snex::ui::WorkbenchManager*>(getNodeWorkbench(parent.getParentNode()));
 			
 			if (auto rwb = wb->getRootWorkbench())
 			{

--- a/hi_scripting/scripting/scriptnode/snex_nodes/SnexNode.h
+++ b/hi_scripting/scripting/scriptnode/snex_nodes/SnexNode.h
@@ -157,7 +157,7 @@ struct snex_node : public SnexSource
 #if 0
 		Result runTest(snex::ui::WorkbenchData::CompileResult& lastResult) override
 		{
-			auto wb = static_cast<snex::ui::WorkbenchManager*>(parent.getParentNode()->getScriptProcessor()->getMainController_()->getWorkbenchManager());
+			auto wb = static_cast<snex::ui::WorkbenchManager*>(getNodeWorkbench(parent.getParentNode()));
 
 			if (auto rwb = wb->getRootWorkbench())
 			{

--- a/hi_scripting/scripting/scriptnode/snex_nodes/SnexOscillator.h
+++ b/hi_scripting/scripting/scriptnode/snex_nodes/SnexOscillator.h
@@ -66,7 +66,7 @@ struct SnexOscillator : public SnexSource
 				OscProcessData d;
 			};
 
-			auto wb = static_cast<snex::ui::WorkbenchManager*>(parent.getParentNode()->getScriptProcessor()->getMainController_()->getWorkbenchManager());
+			auto wb = static_cast<snex::ui::WorkbenchManager*>(getNodeWorkbench(parent.getParentNode()));
 
 			ScopedPointer<OscTestData> td = new OscTestData(wb->getRootWorkbench());
 

--- a/hi_scripting/scripting/scriptnode/snex_nodes/SnexSource.cpp
+++ b/hi_scripting/scripting/scriptnode/snex_nodes/SnexSource.cpp
@@ -40,6 +40,11 @@ using namespace juce;
 using namespace hise;
 using namespace snex;
 
+void* SnexSource::SnexTestBaseHelper::getNodeWorkbench(NodeBase* node)
+{
+    return node->getScriptProcessor()->getMainController_()->getWorkbenchManager();
+
+}
 
 void SnexSource::recompiled(WorkbenchData::Ptr wb)
 {

--- a/hi_scripting/scripting/scriptnode/snex_nodes/SnexSource.h
+++ b/hi_scripting/scripting/scriptnode/snex_nodes/SnexSource.h
@@ -44,6 +44,12 @@ struct SnexSource : public WorkbenchData::Listener,
 {
 	using SnexTestBase = snex::ui::WorkbenchData::TestRunnerBase;
 
+	struct SnexTestBaseHelper
+	{
+	    static void *getNodeWorkbench(NodeBase* node);
+	};
+
+
     enum class ErrorLevel
     {
         Uncompiled,
@@ -328,7 +334,8 @@ struct SnexSource : public WorkbenchData::Listener,
 		OwnedArray<snex::ExternalDataHolder> audioFiles;
 	};
 
-	struct CallbackHandlerBase : public HandlerBase
+	struct CallbackHandlerBase : public HandlerBase,
+	                             public SnexTestBaseHelper
 	{
 		CallbackHandlerBase(SnexSource& p, ObjectStorageType& o) :
 			HandlerBase(p, o)
@@ -410,7 +417,8 @@ struct SnexSource : public WorkbenchData::Listener,
 		std::atomic<bool> ok = { false };
 	};
 
-	template <class T, bool UseRootTest=false> struct Tester: public SnexTestBase
+	template <class T, bool UseRootTest=false> struct Tester: public SnexTestBase,
+	                                                          public SnexTestBaseHelper
 	{
 		Tester(SnexSource& s) :
 			dataHandler(s, obj),
@@ -487,7 +495,7 @@ struct SnexSource : public WorkbenchData::Listener,
 
 			if (callbacks.runRootTest())
 			{
-				auto wb = static_cast<snex::ui::WorkbenchManager*>(original.getParentNode()->getScriptProcessor()->getMainController_()->getWorkbenchManager());
+				auto wb = static_cast<snex::ui::WorkbenchManager*>(getNodeWorkbench(original.getParentNode()));
 
 				if (auto rwb = wb->getRootWorkbench())
 				{

--- a/hi_snex/hi_snex.cpp
+++ b/hi_snex/hi_snex.cpp
@@ -56,7 +56,7 @@ using String = juce::String;
 #include "snex_jit/snex_jit_TemplateClassBuilder.h"
 #include "snex_library/snex_jit_ContainerTypeLibrary.h"
 #include "snex_library/snex_jit_ParameterTypeLibrary.h"
-#include "snex_library/snex_jit_WrapperTypeLibrary.h";
+#include "snex_library/snex_jit_WrapperTypeLibrary.h"
 #include "snex_library/snex_jit_NodeLibrary.h"
 #include "snex_library/snex_jit_IndexLibrary.h"
 
@@ -114,7 +114,7 @@ using String = juce::String;
 #include "snex_library/snex_jit_ExternalComplexTypeLibrary.cpp"
 #include "snex_library/snex_jit_ContainerTypeLibrary.cpp"
 #include "snex_library/snex_jit_ParameterTypeLibrary.cpp"
-#include "snex_library/snex_jit_WrapperTypeLibrary.cpp";
+#include "snex_library/snex_jit_WrapperTypeLibrary.cpp"
 #include "snex_library/snex_jit_NodeLibrary.cpp"
 #include "snex_library/snex_jit_IndexLibrary.cpp"
 #include "snex_library/snex_ExternalObjects.cpp"

--- a/hi_snex/snex_core/snex_jit_ComplexTypeLibrary.cpp
+++ b/hi_snex/snex_core/snex_jit_ComplexTypeLibrary.cpp
@@ -1379,7 +1379,7 @@ bool StructType::createDefaultConstructor()
 	if (hasConstructor())
 		return false;
 
-
+	return true;
 }
 
 void StructType::registerExternalAtNamespaceHandler(NamespaceHandler* handler, const String& description)

--- a/hi_snex/snex_jit/snex_jit_TemplateClassBuilder.cpp
+++ b/hi_snex/snex_jit/snex_jit_TemplateClassBuilder.cpp
@@ -222,6 +222,7 @@ int TemplateClassBuilder::Helpers::getTemplateConstant(StructType* st, int index
 		return tp.constant;
 
 	r = Result::fail("Expected template constant at index " + String(index));
+	return -1;
 }
 
 snex::jit::TemplateClassBuilder::StatementPtr TemplateClassBuilder::Helpers::createFunctionCall(ComplexType::Ptr converterType, SyntaxTreeInlineData* d, const Identifier& functionId, StatementList originalArgs)

--- a/hi_snex/snex_library/snex_CallbackCollection.cpp
+++ b/hi_snex/snex_library/snex_CallbackCollection.cpp
@@ -237,6 +237,8 @@ float JitExpression::getFloatValueWithInput(float input, float value)
 
 	if (f)
 		return getFloatValueWithInputUnchecked(input, value);
+
+	return nanf("");
 }
 
 float JitExpression::getFloatValueWithInputUnchecked(float input, float value)

--- a/hi_snex/snex_library/snex_jit_IndexLibrary.cpp
+++ b/hi_snex/snex_library/snex_jit_IndexLibrary.cpp
@@ -124,6 +124,8 @@ bool IndexBuilder::MetaDataExtractor::isLoopType() const
 
 	if (indexStruct != nullptr && indexStruct->id.getIdentifier() == IndexIds::looped)
 		return true;
+
+	return false;
 }
 
 String IndexBuilder::MetaDataExtractor::getWithLimit(const String& v, const String& l, Types::ID dataType/*=Types::ID::Void*/) const

--- a/hi_snex/snex_library/snex_jit_IndexLibrary.h
+++ b/hi_snex/snex_library/snex_jit_IndexLibrary.h
@@ -50,7 +50,7 @@ namespace IndexIds
 	DECLARE_ID(lerp);
 	DECLARE_ID(hermite);
 	DECLARE_ID(looped);
-#undef DECLARE_ID;
+#undef DECLARE_ID
 }
 
 struct IndexBuilder : public TemplateClassBuilder

--- a/hi_snex/snex_library/snex_jit_ParameterTypeLibrary.cpp
+++ b/hi_snex/snex_library/snex_jit_ParameterTypeLibrary.cpp
@@ -154,11 +154,9 @@ snex::jit::FunctionData ParameterBuilder::Helpers::connectFunction(StructType* s
 				cc.mov(x86::ptr(PTR_REG_R(obj)), tmp);
 				return Result::ok();
 			});
-
-		return cFunc;
 	}
 
-	
+	return cFunc;
 }
 
 bool ParameterBuilder::Helpers::isParameterClass(const TypeInfo& type)

--- a/hi_snex/snex_library/snex_jit_WrapperTypeLibrary.cpp
+++ b/hi_snex/snex_library/snex_jit_WrapperTypeLibrary.cpp
@@ -303,8 +303,8 @@ snex::jit::FunctionData WrapBuilder::createGetWrappedObjectFunction(StructType* 
 				return Result::ok();
 			});
 
-		return getObjectFunction;
 	}
+	return getObjectFunction;
 }
 
 snex::jit::FunctionData WrapBuilder::createGetSelfAsObjectFunction(StructType* st)

--- a/hi_snex/snex_parser/snex_jit_BlockParser.h
+++ b/hi_snex/snex_parser/snex_jit_BlockParser.h
@@ -104,6 +104,7 @@ public:
 	{
 		p->comment = lastComment;
 		lastComment = {};
+		return p;
 	}
 
 	struct ScopedTemplateArgParser

--- a/hi_snex/snex_parser/snex_jit_FunctionParser.cpp
+++ b/hi_snex/snex_parser/snex_jit_FunctionParser.cpp
@@ -606,10 +606,7 @@ snex::jit::BlockParser::ExprPtr SyntaxTreeInlineParser::parseUnary()
 		
 		l.throwError("Can't find external expression " + id.toString());
 	}
-	else
-	{
-		return BlockParser::parseUnary();
-	}
+	return BlockParser::parseUnary();
 }
 
 

--- a/hi_snex/snex_parser/snex_jit_PreProcessor.cpp
+++ b/hi_snex/snex_parser/snex_jit_PreProcessor.cpp
@@ -83,7 +83,7 @@ void Preprocessor::TextBlock::parseBlockStart()
 		MATCH_TOKEN(PreprocessorTokens::else_);
 		MATCH_TOKEN(PreprocessorTokens::endif_);
 		MATCH_TOKEN(PreprocessorTokens::undef_);
-#undef MATCH_TOKEN(x);
+#undef MATCH_TOKEN
 
 		auto tokenLength = String(blockType).length();
 


### PR DESCRIPTION
This PR fixes all warnings on Arch Linux with GCC 12.2.0 ~except `invalid offsetof` warnings in `hi_dsp_library/node_api/nodes/processors.h:758`. They are suppressed under clang already and it would be easy to do the same for GCC. But invalid use of offset of is undefined behaviour so I think we should think about other solutions here.~
Invalid offsetof will apparently be fixed in C++23. Before that no good alternative exists, but we can assume compilers not to reorder blocks all of a sudden.

@christoph-hart: In the case of missing return value fixes, you should have a look if the new behaviour is desirable or if there need to be further changes. The old behaviour would have resulted in pseudo-random return values if those paths were taken.