### PR TITLE
gitignore: ignore emacs' temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ extras/demo_project/AdditionalSourceCode/nodes/
 extras/hball/
 extras/demo_project/UserPresets/
 hi_snex/xml/
+# emacs backup files:
+\#*\#
+.\#*
+*~


### PR DESCRIPTION
Add patterns to .gitignore for emacs' temporary files