### PR TITLE
projects/standalone: increase warning level to /W2

### DIFF
--- a/projects/standalone/HISE Standalone.jucer
+++ b/projects/standalone/HISE Standalone.jucer
@@ -152,7 +152,7 @@
     </XCODE_IPHONE>
     <VS2017 targetFolder="Builds/VisualStudio2017" smallIcon="ho3qQy" bigIcon="ho3qQy"
             useIPP="Sequential" IPPLibrary="" windowsTargetPlatformVersion="10.0.16299.0"
-            extraDefs="USE_IPP=1&#10;HISE_SCRIPT_SERVER_TIMEOUT=20000" extraCompilerFlags="/bigobj /W0"
+            extraDefs="USE_IPP=1&#10;HISE_SCRIPT_SERVER_TIMEOUT=20000" extraCompilerFlags="/bigobj /W2"
             IPP1ALibrary="Static_Library">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="2" generateManifest="1" winArchitecture="x64"


### PR DESCRIPTION
This commit increases the compile warning level on Windows from /W0, which suppresses all warnings to /W2.
I noticed that issue after pulling from the current develop, when there were several compiler warnings on Linux again, which should have triggered on Windows as well.