### PR TITLE
Support compiling DSP networks from command line for Linux

### DIFF
--- a/hi_backend/backend/CompileExporter.cpp
+++ b/hi_backend/backend/CompileExporter.cpp
@@ -267,19 +267,6 @@ CompileExporter::ErrorCodes CompileExporter::compileFromCommandLine(const String
 
 		ScopedPointer<StandaloneProcessor> processor = new StandaloneProcessor();
 		ScopedPointer<BackendRootWindow> editor = dynamic_cast<BackendRootWindow*>(processor->createEditor());
-
-		if (args.contains("-dsp"))
-		{
-			auto s = new DspNetworkCompileExporter(editor, editor->getBackendProcessor());
-			s->setModalBaseWindowComponent(editor);
-			s->run();
-			s->threadFinished();
-			editor = nullptr;
-			processor = nullptr;
-
-			return ErrorCodes::OK;
-		}
-
 		ModulatorSynthChain* mainSynthChain = editor->getBackendProcessor()->getMainSynthChain();
         
         dynamic_cast<GlobalSettingManager*>(mainSynthChain->getMainController())->getSettingsObject().addTemporaryDefinitions(getTemporaryDefinitions(commandLine));

--- a/hi_backend/backend/CompileExporter.cpp
+++ b/hi_backend/backend/CompileExporter.cpp
@@ -329,7 +329,6 @@ CompileExporter::ErrorCodes CompileExporter::compileFromCommandLine(const String
 
 		std::cout << "DONE" << std::endl << std::endl;
 
-
 		BuildOption b = exporter.getBuildOptionFromCommandLine(args);
 
 		

--- a/projects/standalone/Source/Main.cpp
+++ b/projects/standalone/Source/Main.cpp
@@ -352,6 +352,7 @@ public:
 		jsfx->getOrCreate("dsp");
 
 		CompileExporter::setExportingFromCommandLine();
+		CompileExporter::setExportUsingCI(true);
 
 		hise::DspNetworkCompileExporter exporter(nullptr, dynamic_cast<BackendProcessor*>(mc));
 

--- a/projects/standalone/Source/Main.cpp
+++ b/projects/standalone/Source/Main.cpp
@@ -133,7 +133,6 @@ public:
         print("          but the build time is much shorter");
         print("-D:NAME=VALUE Adds a temporary preprocessor definition to the extra definitions.");
         print("              You can use multiple definitions by using this flag multiple times.");
-		print("-dsp      Compile DSP networks only." );
 		print("--test [PLUGIN_FILE]" );
 		print("Tests the given plugin" );
 		print("");
@@ -359,6 +358,7 @@ public:
 		exporter.getComboBoxComponent("build")->setText(config, dontSendNotification);
 
 		exporter.run();
+		exporter.threadFinished();
 	}
 
 	static void setProjectFolder(const String& commandLine, bool exitOnSuccess=true)


### PR DESCRIPTION
Hello,

I need a way to use the "Compile DSP networks as DLL" function from the command line for [my project to build VST plugins inside a CI environment](https://github.com/spezifisch/hise-builder). ([Usage example](https://github.com/spezifisch/Reach/blob/17b1d68caa766776c2329f213a05194b1599455b/Packaging/GNU/compileAndBuild.sh#L41))

I admit my proposed way in this PR is a bit of a hack by adding the `-dsp` flag to the `export_ci` command which seems to also need the `-t:instrument` flag to just generate the DSP code.

Is this a feature that you would want to integrate and what would be a more proper way to implement this?

Regards,
spezifisch