### PR TITLE
Fix FileSystem.Samples when using full instrument expansion

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -6917,7 +6917,18 @@ juce::File ScriptingApi::FileSystem::getFile(SpecialLocations l)
 
 	switch (l)
 	{
-	case Samples:	f = getMainController()->getCurrentFileHandler().getSubDirectory(FileHandlerBase::Samples);
+	case Samples:
+	
+		if(FullInstrumentExpansion::isEnabled(getMainController()))
+		{
+		  if (auto e = getMainController()->getExpansionHandler().getCurrentExpansion())
+		    f = e->getSubDirectory(FileHandlerBase::Samples);
+		}
+		else 
+		{
+			f = getMainController()->getCurrentFileHandler().getSubDirectory(FileHandlerBase::Samples);	
+		}
+		
 		break;
 	case Expansions: return getMainController()->getExpansionHandler().getExpansionFolder();
 #if USE_BACKEND


### PR DESCRIPTION
Using `FileSystem.getFolder(FileSystem.Samples);` returns the wrong path when using full instrument expansions. This PR fixes it. Might need doing for user presets and audio files too but I haven't tested that yet.