### PR TITLE
Set first and last pitch envelope point to 0.5 when using pitch detector

### DIFF
--- a/hi_core/hi_sampler/sampler/components/SampleEditor.cpp
+++ b/hi_core/hi_sampler/sampler/components/SampleEditor.cpp
@@ -417,6 +417,9 @@ struct EnvelopePopup : public Component
 						{
 							t.reset();
 
+							t.addTablePoint(0.0, 0.5);
+							t.addTablePoint(1.0, 0.5);
+
 							for (auto p : list)
 								t.addTablePoint(p.x, p.y);
 


### PR DESCRIPTION
Currently when using the pitch detector to generate the envelope shape, the table is reset before the new points are applied. This causes the first point to always be 0 and the last to always be 1 which isn't desirable. This PR sets the first and last points to 0.5 by default.