### PR TITLE
Fixing pitch envelope export and improving auto pitch envelope

### DIFF
--- a/hi_backend/backend/BackendApplicationCommandWindows.cpp
+++ b/hi_backend/backend/BackendApplicationCommandWindows.cpp
@@ -2196,6 +2196,14 @@ public:
 			int numChannels = ob.getNumChannels();
 			int numSamples = ob.getNumSamples();
 
+			AudioFormatManager afm;
+	    afm.registerBasicFormats(); // Register basic audio formats
+
+	    std::unique_ptr<AudioFormatReader> reader(afm.createReaderFor(fileToUse));
+
+			double sampleRate = reader->sampleRate;
+			int bitDepth = reader->bitsPerSample;
+
 			fileToUse.deleteFile();
 
 			AudioSampleBuffer lut;
@@ -2370,8 +2378,8 @@ public:
 				CascadedEnvelopeLowPass lp(true);
 
 				PrepareSpecs ps;
-				ps.blockSize = 16;
-				ps.sampleRate = 44100.0;
+				ps.blockSize = bitDepth;
+				ps.sampleRate = sampleRate;
 				ps.numChannels = numChannels;
 
 				lp.prepare(ps);
@@ -2388,7 +2396,7 @@ public:
 			}
 
 			propertyData.removeProperty(id, nullptr);
-			hlac::CompressionHelpers::dump(ob, fileToUse.getFullPathName());
+			hlac::CompressionHelpers::dump(ob, fileToUse.getFullPathName(), sampleRate, bitDepth);
 		}
 
 		ValueTree propertyData;

--- a/hi_core/hi_sampler/sampler/components/SampleEditor.cpp
+++ b/hi_core/hi_sampler/sampler/components/SampleEditor.cpp
@@ -403,22 +403,29 @@ struct EnvelopePopup : public Component
 							y += 0.5;
 
 							y = 0.5 * (1.0 - intensity) + intensity * y;
-
+							
 							list.add({ x, y });
 						}
 						
 						numToDo -= numSamplesToUse;
 						offset += numSamplesToUse;
 					}
-
+					
 					if (!list.isEmpty())
 					{
 						auto f = [list](Table& t)
 						{
 							t.reset();
+							t.setTablePoint(0, 0.0f, 0.5f, 0.5f);
+							t.setTablePoint(1, 0.0f, 0.5f, 0.5f);
 
 							for (auto p : list)
-								t.addTablePoint(p.x, p.y);
+							{
+								if (p.y != 0.0 && p.y != 1.0)
+									t.addTablePoint(p.x, p.y);
+							}
+							
+							t.setTablePoint(0, 0.0f, t.getGraphPoint(1).y, 0.5f);
 
 							return true;
 						};

--- a/hi_lac/hlac/CompressionHelpers.cpp
+++ b/hi_lac/hlac/CompressionHelpers.cpp
@@ -488,7 +488,7 @@ void CompressionHelpers::dump(const AudioBufferInt16& b, String fileName)
 }
 
 
-void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
+void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName, double sampleRate, int bitDepth)
 {
 	WavAudioFormat afm;
     
@@ -498,7 +498,7 @@ void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
 
 	if (File::isAbsolutePath(fileName))
 	{
-		dumpFile = File(fileName);
+		dumpFile = File(fileName);	
 	}
 	else
 	{
@@ -523,7 +523,7 @@ void CompressionHelpers::dump(const AudioSampleBuffer& b, String fileName)
 
 	FileOutputStream* fis = new FileOutputStream(dumpFile);
 	StringPairArray metadata;
-	ScopedPointer<AudioFormatWriter> writer = afm.createWriterFor(fis, 44100, b.getNumChannels(), 16, metadata, 5);
+	ScopedPointer<AudioFormatWriter> writer = afm.createWriterFor(fis, sampleRate, b.getNumChannels(), bitDepth, metadata, 5);
 
 	if (writer != nullptr)
 		writer->writeFromAudioSampleBuffer(b, 0, b.getNumSamples());

--- a/hi_lac/hlac/CompressionHelpers.h
+++ b/hi_lac/hlac/CompressionHelpers.h
@@ -307,7 +307,7 @@ struct CompressionHelpers
 
 	static void dump(const AudioBufferInt16& b, String fileName=String());
 
-	static void dump(const AudioSampleBuffer& b, String fileName = String());
+	static void dump(const AudioSampleBuffer& b, String fileName = String(), double sampleRate = 44100, int bitDepth = 16);
 
 	static void fastInt16ToFloat(const void* source, float* destination, int numSamples);
 


### PR DESCRIPTION
I've made it so the first and last node of the auto generated pitch envelope is set to 0.5 after the table is reset.

After the table is generated the first node is set to be the same as the second node. I've found in practice that it works out well, rather than leaving it at 0.5.

I've also set it to remove any nodes that are 0.0 or 1.0 because otherwise I've found that the envelope always includes a few random 0s and 1s at the start and end which I was getting RSI from removing :)

I've added optional arguments to set the sample rate and bit depth for the CompressionHelpers::dump function so that when using the `Apply sample map properties to sample files` tool we can use the sample rate and bit depth of the original samples. When no sample rate or bit depth is provided to the function it will default to 44100/16 which were the previously hardcoded values.

