### PR TITLE
Prevent table envelope jumping to 1 after sustain phase

### DIFF
--- a/hi_core/hi_modules/modulators/mods/TableEnvelope.cpp
+++ b/hi_core/hi_modules/modulators/mods/TableEnvelope.cpp
@@ -321,7 +321,6 @@ float TableEnvelope::calculateNewValue(int voiceIndex)
 			else
 			{
 				state->current_state = TableEnvelopeState::SUSTAIN;
-				state->current_value = 1.0f;
 			}
 		}
 		break;


### PR DESCRIPTION
Fixes #471 