### PR TITLE
Fix maxPeaks array typo in drawMatrixPeakMeter

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5058,7 +5058,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawMatrixPeakMeter(Graphics& g
             peaks.add(peakValues[i]);
             
             if(maxPeaks != nullptr)
-                maxPeakArray.add(maxPeaks[numChannels]);
+								maxPeakArray.add(maxPeaks[i]);
         }
 
 		writeId(obj, c);


### PR DESCRIPTION
Related forum thread - https://forum.hise.audio/topic/11190/matrix-peak-meter-laf-maxpeaks-always-0-0