### PR TITLE
Added reset, set, and add points functions for script tables

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -3106,6 +3106,9 @@ void ScriptingApi::Content::ScriptTable::handleDefaultDeactivatedProperties()
 
 struct ScriptingApi::Content::ScriptTable::Wrapper
 {
+	API_VOID_METHOD_WRAPPER_0(ScriptTable, reset);
+	API_VOID_METHOD_WRAPPER_2(ScriptTable, addTablePoint);
+	API_VOID_METHOD_WRAPPER_4(ScriptTable, setTablePoint);
 	API_METHOD_WRAPPER_1(ScriptTable, getTableValue);
 	API_VOID_METHOD_WRAPPER_1(ScriptTable, setTablePopupFunction);
 	API_VOID_METHOD_WRAPPER_2(ScriptTable, connectToOtherTable);
@@ -3135,6 +3138,9 @@ ComplexDataScriptComponent(base, name, snex::ExternalData::DataType::Table)
 
 	updateCachedObjectReference();
 
+	ADD_API_METHOD_0(reset);
+	ADD_API_METHOD_2(addTablePoint);
+	ADD_API_METHOD_4(setTablePoint);
 	ADD_API_METHOD_1(getTableValue);
 	ADD_API_METHOD_2(connectToOtherTable);
 	ADD_API_METHOD_1(setSnapValues);
@@ -3151,6 +3157,24 @@ ScriptCreatedComponentWrapper * ScriptingApi::Content::ScriptTable::createCompon
 {
 	return new ScriptCreatedComponentWrappers::TableWrapper(content, this, index);
 }
+
+void ScriptingApi::Content::ScriptTable::reset()
+{
+	if (auto t = getCachedTable())
+		t->reset();
+}
+
+void ScriptingApi::Content::ScriptTable::addTablePoint(float x, float y)
+{
+	if (auto t = getCachedTable())
+		t->addTablePoint(x, y);
+};
+
+void ScriptingApi::Content::ScriptTable::setTablePoint(int pointIndex, float x, float y, float curve)
+{
+	if (auto t = getCachedTable())
+		t->setTablePoint(pointIndex, x, y, curve);
+};
 
 float ScriptingApi::Content::ScriptTable::getTableValue(float inputValue)
 {

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -1335,6 +1335,15 @@ public:
 
 		void connectToOtherTable(String processorId, int index);
 
+		/** Resets the table with the given index to a 0..1 line. */
+		void reset();
+		
+		/** Adds a new table point (x and y are normalized coordinates). */
+		void addTablePoint(float x, float y);
+		
+		/** Sets the point with the given index to the values. */
+		void setTablePoint(int pointIndex, float x, float y, float curve);
+
 		/** Returns the table value from 0.0 to 1.0 according to the input value from 0.0 to 1.0. */
 		float getTableValue(float inputValue);
 


### PR DESCRIPTION
I need the ability to modify script tables without having them connected to a modulator's table.