### PR TITLE
Fixed slow download on MacOS

### DIFF
--- a/JUCE/modules/juce_core/native/juce_mac_Network.mm
+++ b/JUCE/modules/juce_core/native/juce_mac_Network.mm
@@ -1143,10 +1143,10 @@ private:
                     // Workaround for an Apple bug. See https://github.com/AFNetworking/AFNetworking/issues/2334
                     [req HTTPBody];
 
-                    if (@available (macOS 10.10, *))
-                        connection = std::make_unique<URLConnectionState> (req, numRedirectsToFollow);
+                    //if (@available (macOS 10.10, *))
+                    //    connection = std::make_unique<URLConnectionState> (req, numRedirectsToFollow);
                    #if JUCE_MAC
-                    else
+                    //else
                         connection = std::make_unique<URLConnectionStatePreYosemite> (req, numRedirectsToFollow);
                    #endif
                 }


### PR DESCRIPTION
So this is caused by an issue in JUCE. It was reported on the JUCE forum and the fix was simple, I just copied it from here:- https://forum.juce.com/t/requests-take-2x-time-inside-juce-on-mac/54083

It seems a proper fix was incorporated into a more recent version of JUCE, so when HISE is updated to a newer JUCE version we shouldn't have an issue - https://forum.juce.com/t/memory-corruption-in-listenerlist-class/60739/10