### PR TITLE
Set allValueChangeCausesCallback to false by defaul to preserve backw…

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -1457,7 +1457,7 @@ public:
 
 	private:
 
-		bool allValueChangeCausesCallback = true;
+		bool allValueChangeCausesCallback = false;
 
 		const SliderPackData* getCachedSliderPack() const { return static_cast<const SliderPackData*>(getCachedDataObject()); };
 		SliderPackData* getCachedSliderPack() { return static_cast<SliderPackData*>(getCachedDataObject()); };


### PR DESCRIPTION
Following up on this issue - https://github.com/christophhart/HISE/issues/646

The change you made there causes all sliderpack value changes to trigger the changed callback. 

This PR sets that to false by default to preserve backwards compatibility but perhaps the original issue needs revisiting. 

We picked up on this causing issues with an existing project that has a lot of sliderpacks.