### PR TITLE
 Wave editor Timeline beats 

### DIFF
--- a/hi_core/hi_components/audio_components/SampleComponents.cpp
+++ b/hi_core/hi_components/audio_components/SampleComponents.cpp
@@ -1233,7 +1233,7 @@ juce::Identifier SamplerSoundWaveform::getSampleIdToChange(AreaTypes a, const Mo
 
 SamplerDisplayWithTimeline::SamplerDisplayWithTimeline(ModulatorSampler* sampler)
 {
-	
+	sampler->getMainController()->addTempoListener(this);
 }
 
 hise::SamplerSoundWaveform* SamplerDisplayWithTimeline::getWaveform()
@@ -1272,11 +1272,15 @@ void SamplerDisplayWithTimeline::mouseDown(const MouseEvent& e)
 	m.addItem(1, "Samples", true, props.currentDomain == TimeDomain::Samples);
 	m.addItem(2, "Milliseconds", true, props.currentDomain == TimeDomain::Milliseconds);
 	m.addItem(3, "Seconds", true, props.currentDomain == TimeDomain::Seconds);
+	m.addItem(4, "Beats", true, props.currentDomain == TimeDomain::Beats);
 
 	if (auto r = m.show())
 	{
 		props.currentDomain = (TimeDomain)(r - 1);
 		getWaveform()->timeProperties.currentDomain = props.currentDomain;
+		getWaveform()->timeProperties.bpm = props.bpm;
+		getWaveform()->timeProperties.nominator = props.nominator;
+		getWaveform()->timeProperties.denominator = props.denominator;
 		repaint();
 	}
 }
@@ -1295,6 +1299,18 @@ String SamplerDisplayWithTimeline::getText(const Properties& p, float normalised
 		if (p.currentDomain == TimeDomain::Milliseconds)
 			return String(roundToInt(msValue)) + " ms";
 
+		if (p.currentDomain == TimeDomain::Beats && p.nominator > 0)
+		{
+			int position = roundToInt(getNumBeats(sampleValue, p.sampleRate, p.bpm) + 1);
+			int bar = floor((position - 1) / p.nominator) + 1;
+			int beat = ((position - 1) % p.nominator) + 1;
+
+			if (beat != 1)
+				return String(bar) + "." + String(beat);
+
+			return String(bar);
+		}
+
 		String sec;
 		sec << Time((int64)msValue).formatted("%M:%S:");
 
@@ -1308,6 +1324,11 @@ String SamplerDisplayWithTimeline::getText(const Properties& p, float normalised
 	}
 
 	return {};
+}
+
+double SamplerDisplayWithTimeline::getNumBeats(double positionInSamples, double sampleRate, double bpm)
+{
+		return positionInSamples / sampleRate * bpm * 1 / 60;
 }
 
 juce::Colour SamplerDisplayWithTimeline::getColourForEnvelope(Modulation::Mode m)
@@ -1328,11 +1349,14 @@ void SamplerDisplayWithTimeline::paint(Graphics& g)
 	g.setFont(GLOBAL_FONT());
 
 	int delta = 200;
-
+			
 	if (auto s = getWaveform()->getCurrentSound())
 	{
 		props.sampleLength = s->getReferenceToSound(0)->getLengthInSamples();
 		props.sampleRate = s->getReferenceToSound(0)->getSampleRate();
+
+		if (props.currentDomain == TimeDomain::Beats)
+			delta = roundToInt(getWidth() / getNumBeats(props.sampleLength, props.sampleRate, props.bpm));
 	}
 
 	for (int i = 0; i < getWidth(); i += delta)

--- a/hi_core/hi_components/audio_components/SampleComponents.cpp
+++ b/hi_core/hi_components/audio_components/SampleComponents.cpp
@@ -914,6 +914,7 @@ void SamplerSoundWaveform::setSoundToDisplay(const ModulatorSamplerSound *s, int
 			preview->setReader(afr, numSamplesInCurrentSample);
 
 			timeProperties.sampleLength = (double)currentSound->getReferenceToSound(0)->getLengthInSamples();
+			timeProperties.sampleStart = (double)currentSound->getReferenceToSound(0)->getSampleStart();
 			timeProperties.sampleRate = (double)currentSound->getReferenceToSound(0)->getSampleRate();
 
 			updateRanges();
@@ -1289,7 +1290,7 @@ String SamplerDisplayWithTimeline::getText(const Properties& p, float normalised
 {
 	if (p.sampleRate > 0.0)
 	{
-		auto sampleValue = roundToInt(normalisedX * p.sampleLength);
+		auto sampleValue = roundToInt(normalisedX * p.sampleLength - p.sampleStart);
 
 		if (p.currentDomain == TimeDomain::Samples)
 			return String(roundToInt(sampleValue));
@@ -1348,20 +1349,26 @@ void SamplerDisplayWithTimeline::paint(Graphics& g)
 
 	g.setFont(GLOBAL_FONT());
 
+	int xOffset = 0;
 	int delta = 200;
-			
+		
 	if (auto s = getWaveform()->getCurrentSound())
 	{
 		props.sampleLength = s->getReferenceToSound(0)->getLengthInSamples();
 		props.sampleRate = s->getReferenceToSound(0)->getSampleRate();
+		props.sampleStart = s->getReferenceToSound(0)->getSampleStart();
+
+		xOffset = roundToInt(getWidth() / props.sampleLength * props.sampleStart);
 
 		if (props.currentDomain == TimeDomain::Beats)
 			delta = roundToInt(getWidth() / getNumBeats(props.sampleLength, props.sampleRate, props.bpm));
 	}
 
-	for (int i = 0; i < getWidth(); i += delta)
+	for (int i = xOffset; i < getWidth(); i += delta)
 	{
 		auto textArea = b.removeFromLeft(delta).toFloat();
+
+		textArea.setX(textArea.getX() + xOffset);
 
 		g.setColour(Colours::white.withAlpha(0.1f));
 		g.drawVerticalLine(i, 3.0f, (float)TimelineHeight);
@@ -1373,7 +1380,6 @@ void SamplerDisplayWithTimeline::paint(Graphics& g)
 		g.drawText(getText(props, normalisedX), textArea.reduced(5.0f, 0.0f), Justification::centredLeft);
 	}
 }
-
 
 struct EnvelopeLaf : public TableEditor::LookAndFeelMethods,
 			 public LookAndFeel_V3

--- a/hi_core/hi_components/audio_components/SampleComponents.h
+++ b/hi_core/hi_components/audio_components/SampleComponents.h
@@ -185,7 +185,7 @@ class SamplerSoundWaveform;
 
 
 
-struct SamplerDisplayWithTimeline : public Component
+struct SamplerDisplayWithTimeline : public Component, public TempoListener
 {
 	static constexpr int TimelineHeight = 24;
 
@@ -193,23 +193,33 @@ struct SamplerDisplayWithTimeline : public Component
 	{
 		Samples,
 		Milliseconds,
-		Seconds
+		Seconds,
+		Beats
 	};
 
 	struct Properties
 	{
 		double sampleLength;
 		double sampleRate;
+		double bpm;
+		int nominator;
+		int denominator;
 		TimeDomain currentDomain = TimeDomain::Seconds;
 	};
 
 	SamplerDisplayWithTimeline(ModulatorSampler* sampler);
+
+	~SamplerDisplayWithTimeline()
+	{
+		//Remove tempo listener here
+	}
 
 	SamplerSoundWaveform* getWaveform();
 	const SamplerSoundWaveform* getWaveform() const;
 	void resized() override;
 	void mouseDown(const MouseEvent& e) override;
 	static String getText(const Properties& p, float normalisedX);
+	static double getNumBeats(double positionInSamples, double sampleRate, double bpm);
 
 	static Colour getColourForEnvelope(Modulation::Mode m);
 
@@ -224,6 +234,25 @@ struct SamplerDisplayWithTimeline : public Component
 	Modulation::Mode envelope = Modulation::Mode::numModes;
 
 	JUCE_DECLARE_WEAK_REFERENCEABLE(SamplerDisplayWithTimeline);
+	
+	void tempoChanged(double newTempo) override
+	{
+		props.bpm = newTempo;
+		
+		MessageManager::callAsync([this]() {
+			this->repaint();
+		});
+	}
+	
+	void onSignatureChange(int newNominator, int newDenominator) override
+	{
+		props.nominator = newNominator;
+		props.denominator = newDenominator;
+		
+		MessageManager::callAsync([this]() {
+			this->repaint();
+		});
+	}
 };
 
 struct SamplerTools

--- a/hi_core/hi_components/audio_components/SampleComponents.h
+++ b/hi_core/hi_components/audio_components/SampleComponents.h
@@ -199,6 +199,7 @@ struct SamplerDisplayWithTimeline : public Component, public TempoListener
 
 	struct Properties
 	{
+		double sampleStart;
 		double sampleLength;
 		double sampleRate;
 		double bpm;


### PR DESCRIPTION


As discussed in this thread - https://forum.hise.audio/topic/11804/feature-request-click-track-overlay-in-wave-editor/8

This PR adds the option of showing beats on the wave editor timeline, based on the current host bpm.

It also shifts the start of the timeline to match the sample start - let me know if there is a problem with this but I can't see why I would want to count from before the sample start.

The only issue I ran into which I haven't found a solution for is when changing the host bpm it triggers a JUCE Assertion failure in MainController.cpp:1679. I believe this is related to the tempo listener.
