### PR TITLE
Added function to get expansion properties directly from info.hxi

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -513,6 +513,24 @@ juce::File ExpansionHandler::getExpansionTargetFolder(const File& resourceFile)
 	return File();
 }
 
+var ExpansionHandler::getPropertiesFromHxi(const File& hxiFile)
+{
+	FileInputStream fis(hxiFile);
+	auto hxiData = ValueTree::readFromStream(fis);
+	
+	auto hxiTree = hxiData.getChildWithName(ExpansionIds::ExpansionInfo);
+	
+	auto obj = new DynamicObject();
+
+	for (int i = 0; i < hxiTree.getNumProperties(); ++i)
+	{
+		Identifier propertyName = hxiTree.getPropertyName(i);
+		obj->setProperty(propertyName, hxiTree.getProperty(propertyName).toString());
+	}
+
+	return obj;
+}
+
 PooledAudioFile ExpansionHandler::loadAudioFileReference(const PoolReference& sampleId)
 {
 	AudioSampleBufferPool* pool = nullptr;

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -315,6 +315,8 @@ public:
 
 	void removeListener(Listener* l);
 
+	var getPropertiesFromHxi(const File& hxiFile);
+
 	bool installFromResourceFile(const File& f, const File& sampleDirectoryToUse);
 
 	File getExpansionTargetFolder(const File& resourceFile);

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -955,7 +955,8 @@ struct ScriptExpansionHandler::Wrapper
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, encodeWithCredentials);
 	API_METHOD_WRAPPER_0(ScriptExpansionHandler, refreshExpansions);
 	API_VOID_METHOD_WRAPPER_1(ScriptExpansionHandler, setAllowedExpansionTypes);
-	API_METHOD_WRAPPER_2(ScriptExpansionHandler, installExpansionFromPackage);
+	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getPropertiesFromHxi);
+		API_METHOD_WRAPPER_2(ScriptExpansionHandler, installExpansionFromPackage);
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getExpansionForInstallPackage);
 };
 
@@ -980,6 +981,7 @@ ScriptExpansionHandler::ScriptExpansionHandler(JavascriptProcessor* jp_) :
 	ADD_API_METHOD_1(setInstallFullDynamics);
 	ADD_API_METHOD_1(encodeWithCredentials);
 	ADD_API_METHOD_0(refreshExpansions);
+	ADD_API_METHOD_1(getPropertiesFromHxi);
 	ADD_API_METHOD_2(installExpansionFromPackage);
 	ADD_API_METHOD_1(setAllowedExpansionTypes);
 	ADD_API_METHOD_0(getCurrentExpansion);
@@ -1133,6 +1135,24 @@ bool ScriptExpansionHandler::encodeWithCredentials(var hxiFile)
 	{
 		reportScriptError("argument is not a file");
 		RETURN_IF_NO_THROW(false);
+	}
+}
+
+var ScriptExpansionHandler::getPropertiesFromHxi(var hxiFile)
+{
+	if (auto f = dynamic_cast<ScriptingObjects::ScriptFile*>(hxiFile.getObject()))
+	{
+		if (!f->f.existsAsFile())
+			reportScriptError(f->toString(0) + " doesn't exist");
+
+		auto result = getMainController()->getExpansionHandler().getPropertiesFromHxi(f->f);
+
+		return var(result);
+	}
+	else
+	{
+		reportScriptError("argument is not a file");
+		return var();
 	}
 }
 

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -245,6 +245,9 @@ public:
 	/** Encrypts the given hxi file. */
 	bool encodeWithCredentials(var hxiFile);
 
+	/** Get the Expansion properties directly from an info.hxi file */
+	var getPropertiesFromHxi(var hxiFile);
+
 	/** Decompresses the samples and installs the .hxi / .hxp file. */
 	bool installExpansionFromPackage(var packageFile, var sampleDirectory);
 


### PR DESCRIPTION
As part of my install process I want to check if the hxi belongs to an expansion that is already installed, so that if it is I can use its existing samples and data folders rather than creating new ones.

This function allows us to access the properties (Name, Company, Version, etc.) of the expansion from the hxi before it's installed and loaded as an expansion.