### PR TITLE
browseInternally now returns an empty file if no valid file is selected.

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -7358,10 +7358,13 @@ void ScriptingApi::FileSystem::browseInternally(File f, bool forSaving, bool isD
 				a = var(new ScriptingObjects::ScriptFile(p_, fc.getResult()));
 		}
 
-		if (a.isObject())
+		if (!a.isObject())
 		{
-			wc.call(&a, 1);
+			File emptyFile;
+			a = var(new ScriptingObjects::ScriptFile(p_, emptyFile));
 		}
+			
+		wc.call(&a, 1);
 		
 		fileChooserIsOpen = false;
 	};


### PR DESCRIPTION
This is potentially a breaking change if users aren't checking that the file/directory returned is valid, so perhaps it should be put behind a preprocessor definition?