### PR TITLE
Use pkg-config to detect WebKitGTK version dynamically on Linux

### DIFF
--- a/JUCE/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
+++ b/JUCE/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
@@ -512,10 +512,15 @@ static bool isLoadCurlSymbolsLazilyEnabled (Project& project)
             && project.isConfigFlagEnabled ("JUCE_LOAD_CURL_SYMBOLS_LAZILY", false));
 }
 
+bool isPackageAvailable (const juce::String& package)
+{
+    juce::String cmd = "pkg-config --exists " + package;
+    return std::system (cmd.toRawUTF8()) == 0;
+}
+
 StringArray ProjectExporter::getLinuxPackages (PackageDependencyType type) const
 {
     auto packages = linuxPackages;
-    juce::DynamicLibrary library;
 
     // don't add libcurl if curl symbols are loaded at runtime
     if (isCurlEnabled (project) && ! isLoadCurlSymbolsLazilyEnabled (project))
@@ -523,10 +528,10 @@ StringArray ProjectExporter::getLinuxPackages (PackageDependencyType type) const
 
     if (isWebBrowserComponentEnabled (project) && type == PackageDependencyType::compile)
     {
-		if (library.open ("libwebkit2gtk-4.1.so"))
-			packages.add ("webkit2gtk-4.1");
-        else
-			packages.add ("webkit2gtk-4.0");
+      if (isPackageAvailable ("webkit2gtk-4.1"))
+          packages.add ("webkit2gtk-4.1");
+      else if (isPackageAvailable ("webkit2gtk-4.0"))
+          packages.add ("webkit2gtk-4.0");
 			
         packages.add ("gtk+-x11-3.0");
     }


### PR DESCRIPTION
Projucer began segfaulting on me recently when resaving the HISE standalone project. I tracked it down to the commit I made for detecting which version of libwebkit2gtk was installed.

The method I was using was a bit flaky so I've swapped it out to use pkg-config instead and that seems to have resolved the segfaulting issue I was having.
