### PR TITLE
Added favoriteIconOffset for preset column items

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -955,6 +955,7 @@ var PresetBrowserPanel::toDynamicObject() const
 	storePropertyInObject(obj, SpecialPanelIds::ShowRenameButton, options.showRenameButton);
 	storePropertyInObject(obj, SpecialPanelIds::ShowDeleteButton, options.showDeleteButton);
 	storePropertyInObject(obj, SpecialPanelIds::ShowSearchBar, options.showSearchBar);
+	storePropertyInObject(obj, SpecialPanelIds::FavoriteIconOffset, options.favoriteIconOffset);
 	storePropertyInObject(obj, SpecialPanelIds::ShowFavoriteIcon, options.showFavoriteIcons);
 	storePropertyInObject(obj, SpecialPanelIds::FullPathFavorites, options.fullPathFavorites);
 	storePropertyInObject(obj, SpecialPanelIds::ButtonsInsideBorder, options.buttonsInsideBorder);
@@ -982,6 +983,7 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.showRenameButton = getPropertyWithDefault(object, SpecialPanelIds::ShowRenameButton);
 	options.showDeleteButton = getPropertyWithDefault(object, SpecialPanelIds::ShowDeleteButton);
 	options.showSearchBar = getPropertyWithDefault(object, SpecialPanelIds::ShowSearchBar);
+	options.favoriteIconOffset = getPropertyWithDefault(object, SpecialPanelIds::FavoriteIconOffset);
 	options.fullPathFavorites = getPropertyWithDefault(object, SpecialPanelIds::FullPathFavorites);
 	options.buttonsInsideBorder = getPropertyWithDefault(object, SpecialPanelIds::ButtonsInsideBorder);
 	options.editButtonOffset = getPropertyWithDefault(object, SpecialPanelIds::EditButtonOffset);
@@ -1084,6 +1086,7 @@ juce::Identifier PresetBrowserPanel::getDefaultablePropertyId(int index) const
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnWidthRatio, "ColumnWidthRatio");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionsAsColumn, "ShowExpansionsAsColumn");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowFavoriteIcon, "ShowFavoriteIcon");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FavoriteIconOffset, "FavoriteIconOffset");
 
 	return Identifier();
 }
@@ -1105,6 +1108,7 @@ var PresetBrowserPanel::getDefaultProperty(int index) const
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowAddButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowRenameButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::FullPathFavorites, false);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::FavoriteIconOffset, 0);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowDeleteButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowSearchBar, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ButtonsInsideBorder, false);

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -504,6 +504,7 @@ public:
 		MoreButtonBounds,
 		FavoriteButtonBounds,
     FullPathFavorites,
+    FavoriteIconOffset,
 		numSpecialProperties
 	};
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1074,6 +1074,11 @@ void PresetBrowser::setShowFavorites(bool shouldShowFavorites)
 	showFavoritesButton = shouldShowFavorites;
 }
 
+void PresetBrowser::setFavoriteIconOffset(int xOffset)
+{
+	presetColumn->setFavoriteIconOffset(xOffset);
+}
+
 void PresetBrowser::setShowSearchBar(bool shouldBeShown)
 {
 	if (shouldBeShown != searchBar->isVisible())
@@ -1315,6 +1320,7 @@ void PresetBrowser::setOptions(const Options& newOptions)
 	setColumnRowPadding(newOptions.columnRowPadding);
 	setShowNotesLabel(newOptions.showNotesLabel);
 	setShowFavorites(newOptions.showFavoriteIcons);
+	setFavoriteIconOffset(newOptions.favoriteIconOffset);
 	setShowFullPathFavorites(newOptions.fullPathFavorites);
 	
 	if (expansionColumn != nullptr)

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -82,6 +82,7 @@ public:
 		bool showSearchBar = true;
 		bool buttonsInsideBorder = false;
 		int editButtonOffset = 10;
+		int favoriteIconOffset = 0;
 		Array<var> listAreaOffset;
 		Array<var> columnRowPadding;
 		Array<var> searchBarBounds;
@@ -251,6 +252,7 @@ private:
 	DefaultPresetBrowserLookAndFeel laf;
 
 	void setShowFavorites(bool shouldShowFavorites);
+	void setFavoriteIconOffset(int xOffset);
 	void setShowFullPathFavorites(bool shouldShowFullPathFavorites);
 	void setHighlightColourAndFont(Colour c, Colour bgColour, Font f);
 	void setNumColumns(int numColumns);

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -502,9 +502,10 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::resized()
 
 	int height = (int)l.font.getHeight() * 2;
 	int y = getHeight() / 2 - height / 2;
+	int x = findParentComponentOfClass<PresetBrowserColumn>()->getFavoriteIconOffset();
 	
 	refreshShape();
-	auto r = Rectangle<int>(0, y, height, height);
+	auto r = Rectangle<int>(x, y, height, height);
 	b->setBounds(r.reduced(4));
 }
 

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -288,7 +288,7 @@ public:
 			{
 				index = newIndex;
 			}
-
+			
 			ScopedPointer<ShapeButton> b;
 
 			ColumnListModel& parent;
@@ -339,7 +339,7 @@ public:
 
 		bool empty = false;
 		bool showFavoritesOnly = false;
-
+		
 		Listener* listener;
 		bool editMode = false;
 		bool displayDirectories = true;
@@ -405,6 +405,16 @@ public:
 	{
 		listModel->allowRecursiveSearch = shouldAllow;
 		listbox->updateContent();
+	}
+
+	void setFavoriteIconOffset(int xOffset)
+	{
+		favoriteIconOffset = xOffset;
+	}
+
+	int getFavoriteIconOffset()
+	{
+		return favoriteIconOffset;
 	}
 
 	void setShowButtons(int buttonId, bool shouldBeShown)
@@ -530,6 +540,7 @@ private:
 	bool shouldShowDeleteButton = true;
 	bool buttonsInsideBorder = false;
 	int editButtonOffset = 10;
+	int favoriteIconOffset = 0;
 	double rowPadding = 0;
 	Rectangle<int> listArea;
 	Array<var> listAreaOffset;


### PR DESCRIPTION
Lets us offset the X position of the favorite icon overlay button in the preset browser's preset column. 

Related forum thread - https://forum.hise.audio/topic/12379/presetbrowser-set-position-and-size-for-the-favorite-preset-icon