### PR TITLE
Show global scripts as in project in code editor dropdown

### DIFF
--- a/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
+++ b/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
@@ -269,12 +269,18 @@ void CodeEditorPanel::fillIndexList(StringArray& indexList)
 			indexList.add(p->getSnippet(i)->getCallbackName().toString());
 		}
 
-        auto scriptRoot = getMainController()->getActiveFileHandler()->getSubDirectory(FileHandlerBase::SubDirectories::Scripts);
-        
+    auto scriptRoot = getMainController()->getActiveFileHandler()->getSubDirectory(FileHandlerBase::SubDirectories::Scripts);
+		
+		String globalScriptPath = dynamic_cast<const GlobalSettingManager*>(getMainController())->getSettingsObject().getSetting(HiseSettings::Scripting::GlobalScriptPath);
+		String globalScriptFolder = File(globalScriptPath).getFileName() + "/";
+
 		for (int i = 0; i < p->getNumWatchedFiles(); i++)
 		{
-            auto f = p->getWatchedFile(i);
+      auto f = p->getWatchedFile(i);
 			auto path = f.getRelativePathFrom(scriptRoot);
+
+			if (path.contains(globalScriptFolder))
+				path = path.fromFirstOccurrenceOf(globalScriptFolder, false, false);
 
 			if(p->isEmbeddedSnippetFile(i))
 				path << " (embedded)";


### PR DESCRIPTION
This solves the issue where the submenu in the code editor dropdown has a silly number of ../../ when including scripts from the global scripts folder.

It turns this
![image](https://github.com/user-attachments/assets/7f656e78-72a6-4378-a687-aaf7c65a0f88)

Into this
![Screenshot_2025-04-18_15-57-42](https://github.com/user-attachments/assets/ee2ab831-77df-48be-957e-56df877bf2dd)

Forum thread: https://forum.hise.audio/topic/8952/bug-script-selection-dropdown-displays-wrong-file/4

There is a possibility that if you have a global script and a project script with the same name you might some weird behaviour - I haven't tested.