### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
+++ b/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
@@ -2558,7 +2558,9 @@ FLAC__bool write_bitbuffer_(FLAC__StreamEncoder *encoder, unsigned samples, FLAC
 			encoder->private_->verify.needs_magic_hack = true;
 		}
 		else {
-			if(!FLAC__stream_decoder_process_single(encoder->private_->verify.decoder)) {
+			if(!FLAC__stream_decoder_process_single(encoder->private_->verify.decoder)
+			    || (!is_last_block
+				    && (FLAC__stream_encoder_get_verify_decoder_state(encoder) == FLAC__STREAM_DECODER_END_OF_STREAM))) {
 				FLAC__bitwriter_release_buffer(encoder->private_->frame);
 				FLAC__bitwriter_clear(encoder->private_->frame);
 				if(encoder->protected_->state != FLAC__STREAM_ENCODER_VERIFY_MISMATCH_IN_AUDIO_DATA)


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function write_bitbuffer_() in `JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c` sourced from [xiph/flac](https://github.com/xiph/flac). This issue, originally reported in [CVE-2021-0561](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2021-0561), was resolved in the repository via this commit https://github.com/xiph/flac/commit/e1575e4a7c5157cbf4e4a16dbd39b74f7174c7be.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!