### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
+++ b/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
@@ -830,7 +830,7 @@ incomplete_lsbs:
 			cwords = br->consumed_words;
 			words = br->words;
 			ucbits = FLAC__BITS_PER_WORD - br->consumed_bits;
-			b = br->buffer[cwords] << br->consumed_bits;
+			b = cwords < br->capacity ? br->buffer[cwords] << br->consumed_bits : 0;
 		} while(cwords >= words && val < end);
 	}
 


### PR DESCRIPTION
Hi Development Team,

I identified another potential vulnerability in a clone function FLAC__bitreader_read_rice_signed_block() in `JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c` sourced from [xiph/flac](https://github.com/xiph/flac). This issue, originally reported in [CVE-2020-0499](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2020-0499), was resolved in the repository via this commit https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!