### PR TITLE
JUCE/modules/juce_core/zip/zlib: Remove offset pointer optimization i…

### DIFF
--- a/JUCE/modules/juce_core/zip/zlib/inftrees.c
+++ b/JUCE/modules/juce_core/zip/zlib/inftrees.c
@@ -53,7 +53,7 @@ int inflate_table (codetype type,
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
+    unsigned match;             /* use base and extra for symbol >= match */
     unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
@@ -181,19 +181,17 @@ int inflate_table (codetype type,
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -215,13 +213,13 @@ int inflate_table (codetype type,
     for (;;) {
         /* create table entry */
         thisx.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if ((work[sym]) + 1 < match) {
             thisx.op = (unsigned char)0;
             thisx.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            thisx.op = (unsigned char)(extra[work[sym]]);
-            thisx.val = base[work[sym]];
+        else if ((work[sym]) >= match) {
+            thisx.op = (unsigned char)(extra[work[sym] - match]);
+            thisx.val = base[work[sym] - match];
         }
         else {
             thisx.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function inflate_table() in `JUCE/modules/juce_core/zip/zlib/inftrees.c` sourced from [madler/zlib](https://github.com/madler/zlib). This issue, originally reported in [CVE-2016-9840](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2016-9840), was resolved in the repository via this commit https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!