### PR TITLE
Use MatrixPeakMeter itemColour3 to colour the overs in the max peak display

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -50,6 +50,7 @@ namespace hise { using namespace juce;
 		auto tc = c->findColour(trackColour);
 		auto pc = c->findColour(peakColour);
 		auto mc = c->findColour(maxPeakColour);
+		auto oc = c->findColour(overPeakColour);
             
 		RectangleList<float> onSegments, offSegments, maxSegments;
             
@@ -75,7 +76,14 @@ namespace hise { using namespace juce;
 				{
 					auto maxPos = fullSize * maxPeaks[i];
                         
-					g.setColour(mc);
+					if (maxPeaks[i] >= 0.99f && oc.getAlpha() > 0)
+					{
+						g.setColour(oc);
+					}
+					else
+					{
+						g.setColour(mc);
+					}
                         
 					auto c = isVertical ? maxCopy.removeFromBottom(maxPos).withHeight(2.0f) :
 						         maxCopy.removeFromLeft(maxPos).removeFromRight(2.0f);
@@ -373,6 +381,7 @@ namespace hise { using namespace juce;
 			ni->setColour(peakColour, findPanelColour(PanelColourId::itemColour1));
 			ni->setColour(trackColour, findPanelColour(PanelColourId::itemColour2));
 			ni->setColour(maxPeakColour, findPanelColour(PanelColourId::textColour));
+			ni->setColour(overPeakColour, findPanelColour(PanelColourId::itemColour3));
             
 			if(ni->findColour(bgColour).isOpaque())
 				ni->setOpaque(true);

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -45,7 +45,8 @@ public:
         bgColour,
         trackColour,
         peakColour,
-        maxPeakColour
+        maxPeakColour,
+        overPeakColour
     };
     
     enum class SpecialProperties

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5454,6 +5454,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawMatrixPeakMeter(Graphics& g
         setColourOrBlack(obj, "itemColour", *c, MatrixPeakMeter::ColourIds::peakColour);
         setColourOrBlack(obj, "itemColour2", *c, MatrixPeakMeter::ColourIds::trackColour);
         setColourOrBlack(obj, "textColour", *c, MatrixPeakMeter::ColourIds::maxPeakColour);
+        setColourOrBlack(obj, "itemColour3", *c, MatrixPeakMeter::ColourIds::overPeakColour);
 
         if (get()->callWithGraphics(g_, "drawMatrixPeakMeter", var(obj), c))
             return;


### PR DESCRIPTION
If itemColour3 is defined for a MatrixPeakMeter (or rather, it has alpha) it will be used to colour the overs in the max peaks.

I found myself wanting to colour the overs in red for the peak meter component. Initially I hardcoded them as red but later noticed itemColour3 isn't used for anything for this component, so it was an easy addition.