### PR TITLE
Feature/neural improvements clean

### DIFF
--- a/hi_dsp_library/dsp_nodes/MathNodes.h
+++ b/hi_dsp_library/dsp_nodes/MathNodes.h
@@ -32,6 +32,9 @@
 
 #pragma once
 
+#include <array>
+#include <cmath>
+
 namespace scriptnode {
 using namespace juce;
 using namespace hise;
@@ -797,6 +800,12 @@ template <int NV, class ExpressionClass> using expr = OpNode<expression_base<Exp
 
 #if HISE_INCLUDE_RT_NEURAL
 
+enum class HpfFrequency
+{
+    Off = 0,
+    Hz1,
+    Hz5
+};
 
 /** TODO:
  * - Parameters
@@ -823,6 +832,21 @@ public:
     ~neural()
     {
         this->disconnect();
+    }
+
+    void setHpfFrequency(HpfFrequency newFrequency)
+    {
+        if(hpfFrequency == newFrequency)
+            return;
+
+        hpfFrequency = newFrequency;
+        clearFilterState();
+        updateHpfCoefficients(lastSpecs.sampleRate);
+    }
+
+    void createParameters(ParameterDataList&)
+    {
+        // Neural node currently exposes no adjustable parameters at the DSP level.
     }
     
     void prepare(PrepareSpecs ps)
@@ -854,10 +878,11 @@ public:
             }
         }
 
+        filterState.prepare(ps);
+        updateHpfCoefficients(ps.sampleRate);
+
         reset();
     }
-
-    PolyData<int, NV> voiceIndexOffsets;
 
     static constexpr bool isPolyphonic() { return NV > 1; }
 
@@ -875,6 +900,8 @@ public:
                 }
             }
         }
+
+        clearFilterState();
     }
 
     void onValue(NeuralNetwork*) override {};
@@ -898,14 +925,28 @@ public:
         if(currentNetwork != nullptr && getNumExpectedNetworks() == currentNetwork->getNumNetworks())
         {
             auto offset = voiceIndexOffsets.get();
+            const bool useHpf = hpfFrequency != HpfFrequency::Off;
+            auto* state = useHpf ? &filterState.get() : nullptr;
 
             int c = 0;
+
             for(auto& ch: data)
             {
                 auto bl = data.toChannelData(ch);
 
-                for(auto& s: bl)
-                    currentNetwork->process(offset + c, &s, &s);
+                if(useHpf && state != nullptr)
+                {
+                    for(auto& s: bl)
+                    {
+                        currentNetwork->process(offset + c, &s, &s);
+                        s = processHpfSample(s, c, *state);
+                    }
+                }
+                else
+                {
+                    for(auto& s: bl)
+                        currentNetwork->process(offset + c, &s, &s);
+                }
 
                 c++;
             }
@@ -918,10 +959,25 @@ public:
         if(currentNetwork != nullptr && data.size() == currentNetwork->getNumNetworks())
         {
             auto offset = voiceIndexOffsets.get();
+            const bool useHpf = hpfFrequency != HpfFrequency::Off;
+            auto* state = useHpf ? &filterState.get() : nullptr;
 
             int c = 0;
-            for(auto& s: data)
-                currentNetwork->process(offset + c++, &s, &s);
+
+            if(useHpf && state != nullptr)
+            {
+                for(auto& s: data)
+                {
+                    currentNetwork->process(offset + c, &s, &s);
+                    s = processHpfSample(s, c, *state);
+                    c++;
+                }
+            }
+            else
+            {
+                for(auto& s: data)
+                    currentNetwork->process(offset + c++, &s, &s);
+            }
         }
     }
 
@@ -929,12 +985,80 @@ public:
     {
         return thisNetwork.get();
     }
+
+private:
+
+    static constexpr int maxFilterChannels = 4;
+    using FilterStateArray = std::array<float, maxFilterChannels * 4>;
+
+    void updateHpfCoefficients(double sampleRate)
+    {
+        if(sampleRate <= 0.0 || hpfFrequency == HpfFrequency::Off)
+        {
+            setBypassCoefficients();
+            return;
+        }
+
+        double freq = (hpfFrequency == HpfFrequency::Hz1) ? 1.0 : 5.0;
+        const double K = std::tan(double_Pi * freq / sampleRate);
+        const double rootTwo = std::sqrt(2.0);
+        const double norm = 1.0 / (1.0 + rootTwo * K + K * K);
+
+        b0 = static_cast<float>(norm);
+        b1 = static_cast<float>(-2.0 * norm);
+        b2 = static_cast<float>(norm);
+        a1 = static_cast<float>(2.0 * (K * K - 1.0) * norm);
+        a2 = static_cast<float>((1.0 - rootTwo * K + K * K) * norm);
+    }
+
+    void setBypassCoefficients()
+    {
+        b0 = 1.0f;
+        b1 = 0.0f;
+        b2 = 0.0f;
+        a1 = 0.0f;
+        a2 = 0.0f;
+    }
+
+    void clearFilterState()
+    {
+        typename decltype(filterState)::ScopedVoiceSetter scope(filterState, true);
+
+        for(auto& voiceState : filterState)
+            voiceState.fill(0.0f);
+    }
+
+    float processHpfSample(float input, int channel, FilterStateArray& state)
+    {
+        if(channel >= maxFilterChannels)
+            return input;
+
+        const int offset = channel * 4;
+
+        const float x1 = state[offset];
+        const float x2 = state[offset + 1];
+        const float y1 = state[offset + 2];
+        const float y2 = state[offset + 3];
+
+        const float output = b0 * input + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2;
+
+        state[offset + 1] = x1;
+        state[offset] = input;
+        state[offset + 3] = y1;
+        state[offset + 2] = output;
+
+        return output;
+    }
     
     int warmup = HISE_NEURAL_NETWORK_WARMUP_TIME;
 
     NeuralNetwork::Ptr thisNetwork;
-    
     PrepareSpecs lastSpecs;
+    PolyData<int, NV> voiceIndexOffsets;
+    PolyData<FilterStateArray, NV> filterState;
+    HpfFrequency hpfFrequency = HpfFrequency::Off;
+    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;
+    float a1 = 0.0f, a2 = 0.0f;
 };
 
 #else

--- a/hi_dsp_library/node_api/helpers/node_ids.h
+++ b/hi_dsp_library/node_api/helpers/node_ids.h
@@ -130,6 +130,7 @@ DECLARE_ID(ClassId);
 DECLARE_ID(AllowSubBlocks);
 DECLARE_ID(Mode);
 DECLARE_ID(Model);
+DECLARE_ID(HpfFreq);
 DECLARE_ID(BlockSize);
 DECLARE_ID(IsPolyphonic);
 DECLARE_ID(UseRingBuffer);

--- a/hi_scripting/scripting/scriptnode/node_library/HiseNodeFactory.cpp
+++ b/hi_scripting/scripting/scriptnode/node_library/HiseNodeFactory.cpp
@@ -1039,26 +1039,39 @@ namespace math
 
 
 struct NeuralComp : public ScriptnodeExtraComponent<NodeBase>
-              
 {
     NeuralComp(NodeBase* n, PooledUIUpdater* updater) :
         ScriptnodeExtraComponent<NodeBase>(n, updater),
-        networkSelector("", PropertyIds::Model)
+        networkSelector("", PropertyIds::Model),
+        hpfSelector("Off", PropertyIds::HpfFreq)
     {
 #if HISE_INCLUDE_RT_NEURAL
         auto& holder = n->getScriptProcessor()->getMainController_()->getNeuralNetworks();
         networkSelector.initModes(holder.getIdList(), n);
-		addAndMakeVisible(networkSelector);
+        addAndMakeVisible(networkSelector);
+
+        hpfSelector.initModes({ "Off", "1 Hz", "5 Hz" }, n);
+        addAndMakeVisible(hpfSelector);
 #endif
-        
-        setSize(128, 32);
+
+        setSize(128, 64);
     };
 
     ComboBoxWithModeProperty networkSelector;
+    ComboBoxWithModeProperty hpfSelector;
 
     void resized() override
     {
+#if HISE_INCLUDE_RT_NEURAL
+        auto area = getLocalBounds().reduced(0, 4);
+        const int rowHeight = 24;
+
+        networkSelector.setBounds(area.removeFromTop(rowHeight));
+        area.removeFromTop(4);
+        hpfSelector.setBounds(area.removeFromTop(rowHeight));
+#else
         networkSelector.setBounds(getLocalBounds());
+#endif
     }
 
     void timerCallback() override
@@ -1083,17 +1096,21 @@ template <int NV> struct NeuralNode: public NodeBase
     
     NeuralNode(DspNetwork* root, const ValueTree& data):
       NodeBase(root, data, 0),
-      networkId(PropertyIds::Model, "")
+      networkId(PropertyIds::Model, ""),
+      hpfFrequency(PropertyIds::HpfFreq, "Off")
     {
         cppgen::CustomNodeProperties::setPropertyForObject(*this, PropertyIds::IsFixRuntimeTarget);
         
         networkId.initialise(this);
         networkId.setAdditionalCallback(BIND_MEMBER_FUNCTION_2(NeuralNode::updateModel), true);
+
+        hpfFrequency.initialise(this);
+        hpfFrequency.setAdditionalCallback(BIND_MEMBER_FUNCTION_2(NeuralNode::updateHpf), true);
     }
     
     AttributedString getDescription() const override
     {
-        return AttributedString(obj.getDescription());
+        return AttributedString(obj.getWrappedObject().getDescription());
     }
 
     NodeComponent* createComponent() override
@@ -1151,25 +1168,58 @@ template <int NV> struct NeuralNode: public NodeBase
 
 
             auto nn = getScriptProcessor()->getMainController_()->getNeuralNetworks().getOrCreate(newId);
-            
+
             // make sure it matches when connecting
-            obj.getIndex().currentHash = nn->getRuntimeHash();
-            obj.connectToRuntimeTarget(true, nn->createConnection());
+            auto& neuralObj = obj.getWrappedObject();
+            neuralObj.getIndex().currentHash = nn->getRuntimeHash();
+            neuralObj.connectToRuntimeTarget(true, nn->createConnection());
 
         }
         else
         {
-            if(auto nn = obj.getCurrentNetwork())
+            auto& neuralObj = obj.getWrappedObject();
+
+            if(auto nn = neuralObj.getCurrentNetwork())
             {
-                obj.connectToRuntimeTarget(false, nn->createConnection());
+                neuralObj.connectToRuntimeTarget(false, nn->createConnection());
             }
         }
 #endif
     }
+
+    void updateHpf(Identifier, var value)
+    {
+#if HISE_INCLUDE_RT_NEURAL
+        auto text = value.toString().trim();
+        auto lower = text.toLowerCase();
+
+        auto& neuralObj = obj.getWrappedObject();
+        auto freq = NeuralType::HpfFrequency::Off;
+
+        if(lower == "1 hz" || lower == "1hz" || lower == "1")
+            freq = NeuralType::HpfFrequency::Hz1;
+        else if(lower == "5 hz" || lower == "5hz" || lower == "5")
+            freq = NeuralType::HpfFrequency::Hz5;
+
+        neuralObj.setHpfFrequency(freq);
+#else
+        ignoreUnused(value);
+#endif
+    }
+
+    void setBypassed(bool shouldBeBypassed) override
+    {
+        NodeBase::setBypassed(shouldBeBypassed);
+        obj.setBypassed(shouldBeBypassed);
+    }
+
+    using NeuralType = neural<NV, runtime_target::indexers::dynamic>;
+    using BypassWrapper = bypass::simple<NeuralType>;
     
-    neural<NV, runtime_target::indexers::dynamic> obj;
+    BypassWrapper obj;
     
     NodePropertyT<String> networkId;
+    NodePropertyT<String> hpfFrequency;
 };
 
 struct map_editor : public simple_visualiser


### PR DESCRIPTION
## This PR adds two improvements to the neural scriptnode:

### Add selectable HPF to neural scriptnode (aa159d6c8)
- Adds high-pass filter options: Off, 1 Hz, 5 Hz
- Adds UI component for HPF selection in scriptnode editor

### Wrap neural node in bypass helper (1e6db8793)
- Wraps neural node in bypass helper for proper bypass functionality

## Changes in commit dcef33b3a535c058f7100bbed66160de1e85317a:

### remove unused .patch files