### PR TITLE
Fix anchor link navigation in embedded markdown content

### DIFF
--- a/hi_tools/hi_markdown/Markdown.cpp
+++ b/hi_tools/hi_markdown/Markdown.cpp
@@ -48,6 +48,14 @@ bool MarkdownRenderer::NavigationAction::perform()
 	if (parent != nullptr)
 	{
 		parent->MarkdownParser::gotoLink(currentLink);
+		
+		// Force anchor jump for hash-only links (e.g., #introduction)
+		auto linkStr = currentLink.toString(MarkdownLink::Everything);
+		if (linkStr.startsWith("#"))
+		{
+			parent->jumpToCurrentAnchor();
+		}
+		
 		return true;
 	}
 
@@ -219,7 +227,11 @@ void MarkdownParser::setNewText(const String& newText)
 
 bool MarkdownParser::gotoLink(const MarkdownLink& url)
 {
-	if (url.isSamePage(lastLink))
+	// Check if this is an anchor-only link (starts with #)
+	auto urlStr = url.toString(MarkdownLink::Everything);
+	bool isAnchorOnlyLink = urlStr.startsWith("#");
+	
+	if (url.isSamePage(lastLink) || isAnchorOnlyLink)
 	{
 		lastLink = url;
 		jumpToCurrentAnchor();


### PR DESCRIPTION
This fixes issue where inline anchor links showed 'can't resolve link' errors in exported plugins.

- Modified MarkdownParser::gotoLink() to properly handle anchor-only links (#section)
- Added explicit detection for links starting with '#' to force anchor jumping
- Modified NavigationAction::perform() as backup to ensure anchor navigation works
