### PR TITLE
Fix EQ repaint bug when removing last node

### DIFF
--- a/hi_core/hi_components/audio_components/EqComponent.cpp
+++ b/hi_core/hi_components/audio_components/EqComponent.cpp
@@ -658,7 +658,7 @@ void FilterDragOverlay::updateFilters()
 
 	if (numFilters == 0)
 	{
-		filterGraph.repaint();
+		filterGraph.refreshAsync();
 	}
 }
 


### PR DESCRIPTION
Fixes the issue where removing the last EQ node didn't update the path.

Changes `repaint()`, which I believe uses a cached path, to `refreshAsync()`, which forces a proper repaint.