### PR TITLE
Fix autosave bug when switching projects

### DIFF
--- a/hi_core/hi_core/UtilityClasses.cpp
+++ b/hi_core/hi_core/UtilityClasses.cpp
@@ -203,8 +203,13 @@ File AutoSaver::getAutoSaveFile()
 
 	if (presetDirectory.isDirectory())
 	{
-		if (fileList.size() == 0)
+		bool projectChanged = fileList.size() > 0 && fileList[0].getParentDirectory() != presetDirectory;
+
+		if (fileList.size() == 0 || projectChanged)
 		{
+			fileList.clear();
+			currentAutoSaveIndex = 0;
+
 			fileList.add(presetDirectory.getChildFile("Autosave_1.hip"));
 			fileList.add(presetDirectory.getChildFile("Autosave_2.hip"));
 			fileList.add(presetDirectory.getChildFile("Autosave_3.hip"));


### PR DESCRIPTION
Fixes bug #795 by checking if the project directory has changed before autosaving.

Test:
1. Create Project1 and Project2
2. Load Project1 and let autosave work for 2 saves, then switch to Project2
3. Check where the next autosave file is saved to

**Before fix**: after switching to Project2, the third autosave still goes in the Project1 folder ❌

<img width="1242" height="720" alt="HISE-Bug-AutosaveAfterSwitchingProject" src="https://github.com/user-attachments/assets/084a1237-16c4-4139-a5a7-ce25aff616f7" />


**After fix**: after switching to Project2, the third autosave goes in the Project2 folder ✅

<img width="1238" height="716" alt="HISE-Bug-AutosaveAfterSwitchingProject-Fixed" src="https://github.com/user-attachments/assets/163f196d-1a07-4d74-86ad-adaa956d53e6" />