### PR TITLE
Add Z and X octave keys to QWERTY piano keyboard

### DIFF
--- a/hi_core/hi_components/keyboard/CustomKeyboard.cpp
+++ b/hi_core/hi_components/keyboard/CustomKeyboard.cpp
@@ -70,9 +70,10 @@ CustomKeyboard::CustomKeyboard(MainController* mc_) :
 	state(&mc_->getKeyboardState()),
 	mc(mc_),
     narrowKeys(true),
-    lowKey(12)
+  lowKey(12),
+	currentKeyboardOctave(5)
 {
-	setKeyPressBaseOctave(5);
+	setKeyPressBaseOctave(currentKeyboardOctave);
 
 	state->addChangeListener(this);
    
@@ -195,6 +196,33 @@ void CustomKeyboard::mouseDrag(const MouseEvent& e)
 {
 	if (!toggleMode)
 		MidiKeyboardComponent::mouseDrag(e);
+}
+
+bool CustomKeyboard::keyPressed(const KeyPress& key)
+{
+	// Handle Z key - decrease octave
+	if (key.getKeyCode() == 'z' || key.getKeyCode() == 'Z')
+	{
+		if (currentKeyboardOctave > 0)
+		{
+			currentKeyboardOctave--;
+			setKeyPressBaseOctave(currentKeyboardOctave);
+		}
+		return true;
+	}
+	// Handle X key - increase octave
+	else if (key.getKeyCode() == 'x' || key.getKeyCode() == 'X')
+	{
+		if (currentKeyboardOctave < 10)
+		{
+			currentKeyboardOctave++;
+			setKeyPressBaseOctave(currentKeyboardOctave);
+		}
+		return true;
+	}
+
+	// Let the parent class handle other keys (including the awsedftgyhujkolp; note keys)
+	return MidiKeyboardComponent::keyPressed(key);
 }
 
 void CustomKeyboard::setUseCustomGraphics(bool shouldUseCustomGraphics)

--- a/hi_core/hi_components/keyboard/CustomKeyboard.h
+++ b/hi_core/hi_components/keyboard/CustomKeyboard.h
@@ -118,6 +118,7 @@ public:
     void mouseDown(const MouseEvent& e) override;
 	void mouseUp(const MouseEvent& e) override;
 	void mouseDrag(const MouseEvent& e) override;
+	bool keyPressed(const KeyPress& key) override;
 	bool isMPEKeyboard() const override { return false; }
 	bool isUsingCustomGraphics() const noexcept override { return useCustomGraphics; };
 	void setUseCustomGraphics(bool shouldUseCustomGraphics) override;
@@ -198,6 +199,8 @@ private:
 	bool displayOctaveNumber = false;
 
 	bool toggleMode = false;
+
+	int currentKeyboardOctave = 5;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CustomKeyboard)


### PR DESCRIPTION
Add Z and X keys to adjust current octave of QWERTY piano keyboard.