### PR TITLE
Add ShowIcon and Fade properties to TooltipPanel

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -923,8 +923,8 @@ void TooltipPanel::fromDynamicObject(const var& object)
 var TooltipPanel::toDynamicObject() const
 {
 	var obj = FloatingTileContent::toDynamicObject();
-	storePropertyInObject(obj, SpecialPanelIds::Fade, useFade, true);
-	storePropertyInObject(obj, SpecialPanelIds::ShowIcon, showIcon, true);
+	storePropertyInObject(obj, SpecialPanelIds::Fade, useFade);
+	storePropertyInObject(obj, SpecialPanelIds::ShowIcon, showIcon);
 	return obj;
 }
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -912,6 +912,44 @@ void TooltipPanel::fromDynamicObject(const var& object)
 	tooltipBar->setColour(TooltipBar::textColour, findPanelColour(PanelColourId::textColour));
 
 	tooltipBar->setFont(getFont());
+
+	useFade = getPropertyWithDefault(object, SpecialPanelIds::Fade);
+	tooltipBar->setUseFade(useFade);
+
+	showIcon = getPropertyWithDefault(object, SpecialPanelIds::ShowIcon);
+	tooltipBar->setShowInfoIcon(showIcon);
+}
+
+var TooltipPanel::toDynamicObject() const
+{
+	var obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, SpecialPanelIds::Fade, useFade, true);
+	storePropertyInObject(obj, SpecialPanelIds::ShowIcon, showIcon, true);
+	return obj;
+}
+
+Identifier TooltipPanel::getDefaultablePropertyId(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultablePropertyId(index);
+
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::Fade, "Fade");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowIcon, "ShowIcon");
+
+	jassertfalse;
+	return{};
+}
+
+var TooltipPanel::getDefaultProperty(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultProperty(index);
+
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::Fade, true);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowIcon, true);
+
+	jassertfalse;
+	return{};
 }
 
 void TooltipPanel::resized()

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -547,6 +547,8 @@ private:
 *	- `ColourData::itemColour1`: the icon colour
 *	- `Font`
 *	- `FontSize`
+*	- `Fade`: enable fade animation (default: true)
+*	- `ShowIcon`: show info icon (default: true)
 *
 *	### Example JSON
 *
@@ -555,6 +557,8 @@ private:
 	  "Type": "TooltipPanel",
 	  "Font": "Arial Italic",
 	  "FontSize": 20,
+	  "Fade": false,
+	  "ShowIcon": true,
 	  "ColourData": {
 		"bgColour": "0x22FF0000",
 		"textColour": "0xFFFFFFFF",
@@ -578,10 +582,24 @@ public:
 	void fromDynamicObject(const var& object) override;
 	void resized() override;
 
+	enum SpecialPanelIds
+	{
+		Fade = (int)FloatingTileContent::PanelPropertyId::numPropertyIds,
+		ShowIcon,
+		numPropertyIds
+	};
+
+	int getNumDefaultableProperties() const override { return SpecialPanelIds::numPropertyIds; }
+	Identifier getDefaultablePropertyId(int index) const override;
+	var getDefaultProperty(int index) const override;
+	var toDynamicObject() const override;
+
 private:
 
 	String fontName;
 	float fontSize = 14.0f;
+	bool useFade = true;
+	bool showIcon = true;
 
 	ScopedPointer<TooltipBar> tooltipBar;
 };

--- a/hi_core/hi_core/Popup.cpp
+++ b/hi_core/hi_core/Popup.cpp
@@ -80,7 +80,7 @@ void TooltipBar::LookAndFeelMethods::drawTooltipBar(Graphics& g, TooltipBar& bar
 {
 	int offset = 0;
 
-	g.setColour(bar.findColour(backgroundColour).withMultipliedAlpha(alpha));
+	g.setColour(bar.findColour(backgroundColour).withMultipliedAlpha(bar.useFade ? alpha : 1.0f));
 
 	g.fillRect(0.0f, 0.0f, (float)bar.getWidth(), (float)bar.getHeight());
 
@@ -88,12 +88,12 @@ void TooltipBar::LookAndFeelMethods::drawTooltipBar(Graphics& g, TooltipBar& bar
 	{
 		icon.scaleToFit(4.0f, 4.0f, (float)(bar.getHeight() - 8), (float)(bar.getHeight() - 8), true);
 
-		g.setColour(bar.findColour(iconColour).withMultipliedAlpha(alpha));
+		g.setColour(bar.findColour(iconColour).withMultipliedAlpha(bar.useFade ? alpha : 1.0f));
 		g.fillPath(icon);
 		offset = 24;
 	}
 
-	g.setColour(bar.findColour(textColour).withMultipliedAlpha(alpha));
+	g.setColour(bar.findColour(textColour).withMultipliedAlpha(bar.useFade ? alpha : 1.0f));
 	g.setFont(bar.font);
 	g.drawText(text, offset + 4, 0, bar.getWidth() - offset, bar.getHeight(), Justification::centredLeft, true);
 }
@@ -224,5 +224,3 @@ void TooltipBar::mouseDown(const MouseEvent &)
 }
 
 } // namespace hise
-
-

--- a/hi_core/hi_core/Popup.h
+++ b/hi_core/hi_core/Popup.h
@@ -88,6 +88,8 @@ public:
 
     void setFont(Font f);
 
+	void setUseFade(bool shouldUseFade) { useFade = shouldUseFade; }
+
 private:
 
     Font font;
@@ -96,6 +98,7 @@ private:
 
 	bool showIcon = true;
 	bool isFadingOut = false;
+	bool useFade = true;
 
 
 	int counterSinceLastTextChange;


### PR DESCRIPTION
Adds new Fade and ShowIcon properties to the TooltipPanel.

Fade [boolean, default: true] enables or disables the fade animation when the tooltip appears/disappears.
ShowIcon [boolean, default: true] shows or hides the info icon. If false, it removes the text offset too.

Both default to true for backwards compatibility.

FIXED: ~~They don't show in the Data section of the UI (don't know how to get that working yet), but you can add them manually.~~

~~If anyone can help finishing this PR I'd appreciate it! 😀~~

<img width="932" height="492" alt="CleanShot 2025-11-06 at 13 58 03@2x" src="https://github.com/user-attachments/assets/814d8f36-f729-4106-aab4-a50c515c71b1" />
