### PR TITLE
Add preference to enable/disable CMD+scroll font resize in code editor

### DIFF
--- a/hi_tools/mcl_editor/code_editor/FullEditor.cpp
+++ b/hi_tools/mcl_editor/code_editor/FullEditor.cpp
@@ -108,6 +108,7 @@ void FullEditor::loadSettings(const File& sFile)
 	editor.showAutocompleteAfterDelay = s.getProperty(TextEditorSettings::AutoAutocomplete, true);
     
     editor.showStickyLines = s.getProperty(TextEditorSettings::ShowStickyLines, true);
+    editor.enableCmdScrollFontResize = s.getProperty(TextEditorSettings::EnableCmdScrollFontResize, true);
 }
 
 void FullEditor::saveSetting(Component* c, const Identifier& id, const var& newValue)
@@ -141,6 +142,10 @@ void FullEditor::saveSetting(Component* c, const Identifier& id, const var& newV
     if (id == TextEditorSettings::ShowStickyLines)
     {
         pe->editor.showStickyLines = (bool)newValue;
+    }
+    if (id == TextEditorSettings::EnableCmdScrollFontResize)
+    {
+        pe->editor.enableCmdScrollFontResize = (bool)newValue;
     }
 	if (id == TextEditorSettings::LineBreaks)
 	{

--- a/hi_tools/mcl_editor/code_editor/FullEditor.hpp
+++ b/hi_tools/mcl_editor/code_editor/FullEditor.hpp
@@ -32,6 +32,7 @@ namespace TextEditorSettings
     DECLARE_ID(AutoAutocomplete);
     DECLARE_ID(ShowStickyLines);
     DECLARE_ID(FixWeirdTab);
+    DECLARE_ID(EnableCmdScrollFontResize);
 }
 
 namespace TextEditorShortcuts

--- a/hi_tools/mcl_editor/code_editor/TextEditor.cpp
+++ b/hi_tools/mcl_editor/code_editor/TextEditor.cpp
@@ -2316,6 +2316,7 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
 			LineBreaks,
             AutoAutocomplete,
             ShowStickyLines,
+            EnableCmdScrollFontResize,
 			BackgroundParsing,
             FixWeirdTab,
 			Preprocessor,
@@ -2348,6 +2349,7 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
 		menu.addItem(LineBreaks, "Enable line breaks", true, linebreakEnabled);
         menu.addItem(AutoAutocomplete, "Autoshow Autocomplete", true, showAutocompleteAfterDelay);
         menu.addItem(ShowStickyLines, "Show sticky lines on top", true, showStickyLines);
+        menu.addItem(EnableCmdScrollFontResize, "Enable Cmd+Scroll font resize", true, enableCmdScrollFontResize);
         
 		menu.addSeparator();
 
@@ -2389,6 +2391,9 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
                 break;
             case ShowStickyLines:
                 FullEditor::saveSetting(this, TextEditorSettings::ShowStickyLines, !showStickyLines);
+                break;
+            case EnableCmdScrollFontResize:
+                FullEditor::saveSetting(this, TextEditorSettings::EnableCmdScrollFontResize, !enableCmdScrollFontResize);
                 break;
         }
 
@@ -2555,7 +2560,7 @@ void mcl::TextEditor::mouseDoubleClick (const MouseEvent& e)
 
 void mcl::TextEditor::mouseWheelMove(const MouseEvent& e, const MouseWheelDetails& d)
 {
-	if (e.mods.isCommandDown())
+	if (e.mods.isCommandDown() && enableCmdScrollFontResize)
 	{
 		auto factor = 1.0f + (float)d.deltaY / 5.0f;
 

--- a/hi_tools/mcl_editor/code_editor/TextEditor.hpp
+++ b/hi_tools/mcl_editor/code_editor/TextEditor.hpp
@@ -597,6 +597,7 @@ private:
 	bool autocompleteEnabled = true;
     bool showAutocompleteAfterDelay = false;
     bool showStickyLines = true;
+    bool enableCmdScrollFontResize = true;
 	
 	Selection currentClosure[2];
 


### PR DESCRIPTION
This is pretty niche but thought I'd submit anyway.

Adds a preference to the right-click context menu in the code editor to enable/disable font resizing on CTRL/CMD+scroll