### PR TITLE
Add preference to disable horizontal scrolling past line ends

### DIFF
--- a/hi_tools/mcl_editor/code_editor/FullEditor.cpp
+++ b/hi_tools/mcl_editor/code_editor/FullEditor.cpp
@@ -108,6 +108,7 @@ void FullEditor::loadSettings(const File& sFile)
 	editor.showAutocompleteAfterDelay = s.getProperty(TextEditorSettings::AutoAutocomplete, true);
     
     editor.showStickyLines = s.getProperty(TextEditorSettings::ShowStickyLines, true);
+    editor.enableHorizontalScrollPastLineEnds = s.getProperty(TextEditorSettings::EnableHorizontalScrollPastLineEnds, true);
 }
 
 void FullEditor::saveSetting(Component* c, const Identifier& id, const var& newValue)
@@ -141,6 +142,10 @@ void FullEditor::saveSetting(Component* c, const Identifier& id, const var& newV
     if (id == TextEditorSettings::ShowStickyLines)
     {
         pe->editor.showStickyLines = (bool)newValue;
+    }
+    if (id == TextEditorSettings::EnableHorizontalScrollPastLineEnds)
+    {
+        pe->editor.enableHorizontalScrollPastLineEnds = (bool)newValue;
     }
 	if (id == TextEditorSettings::LineBreaks)
 	{

--- a/hi_tools/mcl_editor/code_editor/FullEditor.hpp
+++ b/hi_tools/mcl_editor/code_editor/FullEditor.hpp
@@ -32,6 +32,7 @@ namespace TextEditorSettings
     DECLARE_ID(AutoAutocomplete);
     DECLARE_ID(ShowStickyLines);
     DECLARE_ID(FixWeirdTab);
+    DECLARE_ID(EnableHorizontalScrollPastLineEnds);
 }
 
 namespace TextEditorShortcuts

--- a/hi_tools/mcl_editor/code_editor/TextEditor.cpp
+++ b/hi_tools/mcl_editor/code_editor/TextEditor.cpp
@@ -1155,7 +1155,7 @@ void TextEditor::scrollBarMoved(ScrollBar* scrollBarThatHasMoved, double newRang
 		if (translation.x == 0)
 			translation.x = gutter.getGutterWidth();
 
-		xPos = translation.x;
+		xPos = translation.x - gutter.getGutterWidth();
 	}
 
 	updateViewTransform();
@@ -1797,6 +1797,34 @@ void mcl::TextEditor::updateViewTransform()
 	if (translation.x > 0.0)
 		translation.x = thisGutterWidth;
 
+	// Clamp horizontal translation based on the setting
+	if (!linebreakEnabled)
+	{
+		// Calculate the maximum width of any single line
+		float maxLineWidth = 0.0f;
+		auto charWidth = document.getCharacterRectangle().getWidth();
+		for (int i = 0; i < document.getNumRows(); i++)
+		{
+			float lineWidth = (float)document.getNumColumns(i) * charWidth + TEXT_INDENT;
+			maxLineWidth = jmax(maxLineWidth, lineWidth);
+		}
+		float maxWidth = maxLineWidth * viewScaleFactor;
+		float visibleWidth = (float)(getWidth() - thisGutterWidth);
+
+		// When enabled, allow scrolling one viewport width past the longest line
+		// When disabled, only allow scrolling to the end of the longest line
+		float allowedMaxWidth = enableHorizontalScrollPastLineEnds
+			? maxWidth + visibleWidth
+			: maxWidth;
+
+		// Clamp translation.x so we can't scroll past the allowed limit
+		float minTranslationX = thisGutterWidth - jmax(0.0f, allowedMaxWidth - visibleWidth);
+		translation.x = jlimit(minTranslationX, (float)thisGutterWidth, translation.x);
+
+		// Update xPos to match the clamped translation
+		xPos = translation.x - thisGutterWidth;
+	}
+
 	closeAutocomplete(true, {}, {});
 
 	if(autofixButton != nullptr)
@@ -1820,7 +1848,23 @@ void mcl::TextEditor::updateViewTransform()
 	if (!linebreakEnabled)
 	{
 		ScopedValueSetter<bool> svs(scrollBarRecursion, true);
-		horizontalScrollBar.setRangeLimits({ b.getX(), b.getRight() });
+		// Calculate the maximum width of any single line
+		float maxLineWidth = 0.0f;
+		auto charWidth = document.getCharacterRectangle().getWidth();
+		for (int i = 0; i < document.getNumRows(); i++)
+		{
+			float lineWidth = (float)document.getNumColumns(i) * charWidth + TEXT_INDENT;
+			maxLineWidth = jmax(maxLineWidth, lineWidth);
+		}
+		
+		// When enabled, allow scrolling one viewport width past the longest line
+		// When disabled, only allow scrolling to the end of the longest line
+		float visibleWidth = (float)(getWidth() - gutter.getGutterWidth());
+		float maxRight = enableHorizontalScrollPastLineEnds 
+			? maxLineWidth + visibleWidth 
+			: maxLineWidth;
+		
+		horizontalScrollBar.setRangeLimits({ b.getX(), maxRight });
 		auto visibleRange = getLocalBounds().toFloat().transformed(transform.inverted());
 		horizontalScrollBar.setCurrentRange({ visibleRange.getX(), visibleRange.getRight() }, sendNotificationSync);
 	}
@@ -2316,6 +2360,7 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
 			LineBreaks,
             AutoAutocomplete,
             ShowStickyLines,
+            EnableHorizontalScrollPastLineEnds,
 			BackgroundParsing,
             FixWeirdTab,
 			Preprocessor,
@@ -2348,6 +2393,7 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
 		menu.addItem(LineBreaks, "Enable line breaks", true, linebreakEnabled);
         menu.addItem(AutoAutocomplete, "Autoshow Autocomplete", true, showAutocompleteAfterDelay);
         menu.addItem(ShowStickyLines, "Show sticky lines on top", true, showStickyLines);
+        menu.addItem(EnableHorizontalScrollPastLineEnds, "Allow horizontal scroll past line ends", true, enableHorizontalScrollPastLineEnds);
         
 		menu.addSeparator();
 
@@ -2389,6 +2435,9 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
                 break;
             case ShowStickyLines:
                 FullEditor::saveSetting(this, TextEditorSettings::ShowStickyLines, !showStickyLines);
+                break;
+            case EnableHorizontalScrollPastLineEnds:
+                FullEditor::saveSetting(this, TextEditorSettings::EnableHorizontalScrollPastLineEnds, !enableHorizontalScrollPastLineEnds);
                 break;
         }
 
@@ -2580,9 +2629,6 @@ void mcl::TextEditor::mouseWheelMove(const MouseEvent& e, const MouseWheelDetail
 			xPos = jmin(-gutter.getGutterWidth(), xPos);
 
 		xPos += vToUse * factors[1];
-
-		auto maxWidth = document.getBounds().getWidth() * viewScaleFactor;
-		xPos = jmax(xPos, -maxWidth);
 
 	}
 	

--- a/hi_tools/mcl_editor/code_editor/TextEditor.hpp
+++ b/hi_tools/mcl_editor/code_editor/TextEditor.hpp
@@ -597,6 +597,7 @@ private:
 	bool autocompleteEnabled = true;
     bool showAutocompleteAfterDelay = false;
     bool showStickyLines = true;
+    bool enableHorizontalScrollPastLineEnds = true;
 	
 	Selection currentClosure[2];
 


### PR DESCRIPTION
Another niche one for the code editor.

Add preference to right-click context menu to allow/disallow horizontal scrolling past the end of the longest line.