### PR TITLE
Allow popup menu background to be transparent

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4342,6 +4342,15 @@ hise::MarkdownLayout::StyleData ScriptingObjects::ScriptedLookAndFeel::Laf::getA
 	return s;
 }
 
+void ScriptingObjects::ScriptedLookAndFeel::Laf::preparePopupMenuWindow(Component& newWindow)
+{
+	// Force the component to be non-opaque so it doesn't fill with white before drawing
+	if (functionDefined("drawPopupMenuBackground"))
+	{
+		newWindow.setOpaque(false);
+	}
+}
+
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphics& g_, int width, int height)
 {
 	if (functionDefined("drawPopupMenuBackground"))

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -853,6 +853,8 @@ namespace ScriptingObjects
 
 			MarkdownLayout::StyleData getAlertWindowMarkdownStyleData() override;
 
+			void preparePopupMenuWindow(Component& newWindow) override;
+
 			void drawPopupMenuBackground(Graphics& g_, int width, int height) override;
 
 			void drawPopupMenuItem(Graphics& g, const Rectangle<int>& area,


### PR DESCRIPTION
Forces the popup menu to be non-opaque so we can use transparent/semi-transparent colours for the background.

Current default is a white background underneath whatever fill colour we specify.

Forum post: https://forum.hise.audio/topic/6494/look-feel-combobox-background/6

![HISE-PopupTransparentBackground](https://github.com/user-attachments/assets/2233a2e1-c06a-488d-a690-3521c1826787)
