### PR TITLE
Add area property to PopupMenuBackground data object

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4347,6 +4347,8 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphic
 	if (functionDefined("drawPopupMenuBackground"))
 	{
 		auto obj = new DynamicObject();
+		Rectangle<float> area(0.0f, 0.0f, (float)width, (float)height);
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, area));
 		obj->setProperty("width", width);
 		obj->setProperty("height", height);
 


### PR DESCRIPTION
Adds an area property, based on the supplied width and height, to the PopupMenuBackground data object.

Useful when drawing or filling the PopUpMenuBackground.