### PR TITLE
Fix viewPositionX and viewPositionY property notifications for Viewport

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -2000,7 +2000,8 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::scrollBarMoved(ScrollBar* 
 
 		auto sv = dynamic_cast<ScriptingApi::Content::ScriptedViewport*>(getScriptComponent());
 		sv->positionBroadcaster.sendMessage(dontSendNotification, pos[0], pos[1]);
-		getScriptComponent()->setScriptObjectProperty(propertyToChange, normPos, dontSendNotification);
+		// Use sendNotificationAsync so the script's broadcaster gets notified, but async to avoid circular updates
+		getScriptComponent()->setScriptObjectProperty(propertyToChange, normPos, sendNotificationAsync);
 	}
 }
 


### PR DESCRIPTION
Fixes #742 

viewPositionX and viewPositionY properties were being set with dontSendNotification. This prevented script broadcasters from receiving property change notifications, which caused the script's broadcaster to miss scroll events and produce unusual console output.

Changed setScriptObjectProperty to use sendNotificationAsync in scrollBarMoved callback, ensuring script broadcasters receive notifications, while using async delivery to prevent circular update loops.