### PR TITLE
Fix missing ScriptNode SVF Notch filter and add Q to Bandpass filter

### DIFF
--- a/hi_dsp_library/dsp_basics/MultiChannelFilters.cpp
+++ b/hi_dsp_library/dsp_basics/MultiChannelFilters.cpp
@@ -177,7 +177,8 @@ FilterDataObject::CoefficientData MultiChannelFilter<FilterSubType>::getApproxim
 	case FilterHelpers::LowPassReso:	return { IIRCoefficients::makeLowPass(sampleRate, f_, q_), 1 };
 	case FilterHelpers::Ladder24db:	    return { IIRCoefficients::makeLowPass(sampleRate, f_, q_), 2 };
 	case FilterHelpers::LowPass:		return { IIRCoefficients::makeLowPass(sampleRate, f_), 1 };
-	case FilterHelpers::BandPass:		return { IIRCoefficients::makeBandPass(sampleRate, f_), 1 };
+	case FilterHelpers::BandPass:		return { IIRCoefficients::makeBandPass(sampleRate, f_, q_), 1 };
+	case FilterHelpers::Notch:			return { IIRCoefficients::makeNotchFilter(sampleRate, f_, q_), 1 };
 	case FilterHelpers::LowShelf:		return { IIRCoefficients::makeLowShelf(sampleRate, f_, q_, g_), 1 };
 	case FilterHelpers::HighShelf:		return { IIRCoefficients::makeHighShelf(sampleRate, f_, q_, g_), 1 };
 	case FilterHelpers::Peak:			return { IIRCoefficients::makePeakFilter(sampleRate, f_, q_, g_), 1 };
@@ -935,7 +936,7 @@ juce::StringArray StateVariableFilterSubType::getModes() const
 Array<hise::FilterHelpers::CoefficientType> StateVariableFilterSubType::getCoefficientTypeList() const
 {
 	return { FilterHelpers::LowPassReso, FilterHelpers::HighPass,
-			 FilterHelpers::BandPass, FilterHelpers::BandPass,
+			 FilterHelpers::BandPass, FilterHelpers::Notch,
 			 FilterHelpers::AllPass };
 }
 

--- a/hi_dsp_library/dsp_basics/MultiChannelFilters.h
+++ b/hi_dsp_library/dsp_basics/MultiChannelFilters.h
@@ -78,6 +78,7 @@ public:
 		LowPassReso,
 		HighPass,
 		BandPass,
+		Notch,
 		Peak,
 		LowShelf,
 		HighShelf,


### PR DESCRIPTION
Add missing Notch filter to the list and add missing Q to Bandpass filter.

Fixes #703 

https://github.com/user-attachments/assets/fec75b31-b3fd-461d-8f45-71b60d8a99c1

Video also here: https://share.cleanshot.com/rhkh5Lyh