### PR TITLE
Fix setting component Z level on init

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -510,7 +510,16 @@ void ScriptCreatedComponentWrapper::initAllProperties()
 	}
 }
 
-
+void ScriptCreatedComponentWrapper::postInit()
+{
+	// Apply the current z-level after component is fully initialized
+	auto sc = getScriptComponent();
+	auto currentLevel = sc->getCurrentZLevel();
+	if (currentLevel != ScriptingApi::Content::ScriptComponent::ZLevelListener::ZLevel::Default)
+	{
+		zLevelChanged(currentLevel);
+	}
+}
 
 ScriptCreatedComponentWrappers::SliderWrapper::SliderWrapper(ScriptContentComponent *content, ScriptingApi::Content::ScriptSlider *sc, int index) :
 ScriptCreatedComponentWrapper(content, index)

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.h
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.h
@@ -322,7 +322,7 @@ public:
 	/** Don't forget to deregister the listener here. */
 	virtual ~ScriptCreatedComponentWrapper();;
 
-	virtual void postInit() {};
+	virtual void postInit();
 
 	/** Overwrite this method and update the component. */
 	virtual void updateComponent() = 0;

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -548,6 +548,9 @@ public:
 		/** Changes the depth hierarchy (z-axis) of sibling components (Back, Default, Front or AlwaysOnTop). */
 		void setZLevel(String zLevel);
 
+		/** Returns the current z-level. */
+		ZLevelListener::ZLevel getCurrentZLevel() const { return currentZLevel; }
+
 		/** Adds a callback to react on key presses (when this component is focused). */
 		void setKeyPressCallback(var keyboardFunction);
 


### PR DESCRIPTION
Fixes #731 - setZLevel not executing when initialising component.

Added `postInit()` to apply z-level after component is fully initialised.