### PR TITLE
Fix bug where radio button callbacks break in different parents

### DIFF
--- a/hi_scripting/scripting/ScriptProcessor.cpp
+++ b/hi_scripting/scripting/ScriptProcessor.cpp
@@ -166,7 +166,12 @@ void ProcessorWithScriptingContent::setControlValue(int index, float newValue)
 							if (auto other = dynamic_cast<ScriptingApi::Content::ScriptButton*>(content->getComponent(i)))
 							{
 								if ((int)other->getScriptObjectProperty(ScriptingApi::Content::ScriptButton::Properties::radioGroup) == group)
+								{
 									other->setValue(0);
+									// Explicitly trigger callback for buttons that get turned off in radio group
+									// to ensures callbacks fire properly regardless of component hierarchy
+									controlCallback(other, 0.0f);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
When a radio group buttons are in different parent panels, the callbacks don't fire properly.

When using radio group buttons to show/hide panels, the panels stay open when they should be closed by the callbacks.

Demo snippet:

```
HiseSnippet 1556.3ocsXs0aaaCElxIpq1qWV2sW1KD9ImMi.6lV21MTLGmKcFqt0KtqaCAEczRzwDUlTfhJotEAX+D1ek8On+J1ui81dL6PcW1xtNtX9gDwy0uygGdNTpuTXQ87DRjQkmM0khLtl4fob038FSXbT28QF2vrGwSQk3PRcl5R77n1HCiMdjlfQ4MQA+9muuCwgvsnojPnmKXVzGylvToT629GYNNGRroOiMIiz2ocWKAeOgivGvyFlMPtDqWQNg9DhVrRlnef3MFY70l22ZncqGXSt2vVsFdulV1OXTilOfPoC24t2eG5csZY0bTKRCjwUNvloDxAJhh5AFsivd5fwhy3gN34LO1PGpdQSz.vygjQ6Ml4X2ON43gPFa1OMUsQXp5yM6wrYIzSSYeR.CbpFYSZFkVFjZdIfjQFHsYHjtk4.KIyUkxQimO1rKG1AGQf8lrPITVTo2XZtm.jfq1dB4UzCkvhDMp0pQi5X3Oa8cUp.6OdJrK2ouj5QUcjhy7fRiGhi0+DpZOwDWAGVTq5rBVErQhIz4nGSIRdeBm5rLajWxbFY.UoX7S7Vl5wxjp3PEWmwWsfnHgyYJcUqVhULfVnFyaz2WvMibZCTgwcXbJdjO2RwDbsszJKEN0rh0rN9ThiOcK7aqTFX5Ibna6JYQlLRbrEwwgZiGIj3p3uAmnsFD0ppnuVUcKfdU7YL03PKFHXnsAnTlMBWqX0d3CwUcymQ0fYVzDlzwYx5kKOaQ01dPlLNDi8c4ywTGOJd4HXRb9uXu2q69cwQ7i7b9crO.W6krmUjmytiF32XBKviUNuRE89TMWLiiOd1TT84OuUO6omWrE1MmkGQfH.rbfMGFXyhNFTewk+0msH9EAA5vsAsetF20zMTVPbimoJbHLGHoNbX1bo1FA1LR78hjtVpE.QNO4zff+Dgh9Tdssp.nARa3YYMZTg7hLlCUVHa8jL4xTrF2exPcFKbSKVPnyc9wAWY0FGXE1OHifBdWNS8TWZz5CEN15175mme3AJpgB7zO2cehhnmmDQCjykJULMbL1mdJLAOb5RYy8oduRIbAXlzEBY7Qp.t2HZ1SGekRvQLv2ek4BqOPuNcvOu8zjE+wO01ibJsKOrPSOlRuSqGhkbZEII1LwijBe233aUPysLmojLCFd2YqBFpXFercoPnRHDtd7v3f3UifO0b1SlYSC+VVHbb6gBoMUNf8lbWnJj5Qf288xRmonShu5T4qfPWbQdp2NK4yX1pwoZ+6sGSYmLN8JZuS1VWMjDPWSEcgmv.5PGAQmEdFCJL0w0WT.il5PyzPatowOD4WSCaXQrOCW4Rjfqx3yBxUQ0mgEi2zLOygmjM7Q+67Ik+5h+r3jR3ufSAk96RlusBFWUWwN.JBBqep9sXkzmVOlyAu1kv8fC3d65AlxehVhfllIhDb9SVr55FMdyYSnOPn34XkRFZMAwKvqYiDk101tXWbDkC2ZtXd6ScnpEva.b.yZbGhLKiCImJjPZSe3IAEofHK6bp463zmnFGy2KWRJJV6B4QaZmfx5b7eh+jvTqVscBHEt9WzUQGAEZBfww.cLtw16Lyu5WR5.4WD3iGy7T6Jojj3LxC0K5eIZEhrif4iDaa3DvppWR5tivmaqiziCYzSHi1glkSZU4rbhyyywsx4qV+oOybt6Irv9zefMnt.U3YwHxy0f5z3wfFajMRJunH45lYtdyB6y+gEC.RKJFhIOWLjE3atHfeUyfmatnACnt4aMe0ENt6KMK5JaYsaPm4zEEOy6ll4tm9bC9lqwcRDfl+8Sg2LVX66PT4ecY8GRHhAzSM26npeOTnCgZZ1Ozvk3cnarz2gdUg3sL6yTViKFikJ.iv0o9+.iQe4gqadvnQTKUJ.2z7vecc+LCuG2ejvWeJpGQIY5Q5Pe4APstEE7NG1n8zivKouRY35FwS6GP41AKt.9EwrodsQDylwLQSHVRwKsBupr9aab0.J.l3Ae6mxl8zqwMQAWeNadVeqvWZYk2Tyo3sWWE2YcU7Nqqh2ccUr05p38VWEu+6WQ8zjc8UhIgGaPnd8OH3lVFFGvIPEXP0J5+.LKUruK
```

This small fix ensures the callback is fired immediately.