### PR TITLE
Add toolbar button to toggle overlay image

### DIFF
--- a/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
+++ b/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
@@ -737,15 +737,61 @@ ScriptContentPanel::Editor::Editor(Canvas* c):
 			currentOverlayImage = format.loadFrom(currentOverlays[idx-1]);
 		}
 
-		overlayBroadcaster.sendMessage(sendNotificationSync, currentOverlayImage, overlayAlphaSlider->getValue());
+		float alphaToSend = overlayVisible ? overlayAlphaSlider->getValue() : 0.0f;
+		overlayBroadcaster.sendMessage(sendNotificationSync, currentOverlayImage, alphaToSend);
 	};
 
 	klaf.setDefaultColours(*overlaySelector);
+
+	using ActionButton = WrapperWithMenuBarBase::ActionButtonBase<Editor, Factory>;
+	auto overlayToggleButtonAction = new ActionButton(this, "overlay-toggle");
+	overlayToggleButtonAction->stateFunction = [](Editor& e) { return e.overlayVisible; };
+	overlayToggleButtonAction->enabledFunction = [](Editor& e) { return e.currentOverlayImage.isValid(); };
+	overlayToggleButtonAction->actionFunction = [](Editor& e)
+	{
+		e.overlayVisible = !e.overlayVisible;
+
+		if(e.overlayVisible)
+		{
+			if(!e.currentOverlayImage.isValid())
+			{
+				e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
+				return false;
+			}
+
+			float alphaToUse = e.overlayAlphaSlider->getValue();
+			e.overlayAlphaSlider->setValue(alphaToUse, dontSendNotification);
+			e.lastOverlayAlpha = alphaToUse;
+
+			auto nAlpha = e.overlayAlphaSlider->getValue();
+			if(nAlpha < 0.0)
+			{
+				Image copy = e.currentOverlayImage.createCopy();
+				gin::applyInvert(copy);
+				e.overlayBroadcaster.sendMessage(sendNotificationSync, copy, hmath::abs(nAlpha));
+			}
+			else
+			{
+				e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, hmath::abs(nAlpha));
+			}
+		}
+		else
+		{
+			e.lastOverlayAlpha = e.overlayAlphaSlider->getValue();
+			e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
+		}
+
+		return false;
+	};
+	overlayToggleButtonAction->setTooltip("Toggle overlay image visibility");
+	overlayToggleButton = overlayToggleButtonAction;
 
 	overlayAlphaSlider = new Slider("Alpha Overlay");
 
 	overlayAlphaSlider->setRange(-1.0, 1.0, 0.0);
 	overlayAlphaSlider->setDoubleClickReturnValue(true, 0.0);
+	overlayAlphaSlider->setValue(0.0, dontSendNotification);
+	lastOverlayAlpha = 0.0f;
     overlayAlphaSlider->setSliderStyle(Slider::SliderStyle::LinearHorizontal);
     overlayAlphaSlider->setTextBoxStyle(Slider::TextEntryBoxPosition::NoTextBox, true, 0, 0);
 	overlayAlphaSlider->setLookAndFeel(&slaf);
@@ -755,15 +801,25 @@ ScriptContentPanel::Editor::Editor(Canvas* c):
     {
         auto nAlpha = overlayAlphaSlider->getValue();
 
+		if(overlayVisible)
+			lastOverlayAlpha = nAlpha;
+
+		if(!currentOverlayImage.isValid())
+		{
+			overlayBroadcaster.sendMessage(sendNotificationSync, currentOverlayImage, 0.0f);
+			overlayAlphaSlider->setColour(Slider::trackColourId, Colours::orange.withSaturation(0.0f).withAlpha(0.5f));
+			return;
+		}
+
 		if(nAlpha < 0.0)
 		{
 			Image copy = currentOverlayImage.createCopy();
 			gin::applyInvert(copy);
-			overlayBroadcaster.sendMessage(sendNotificationSync, copy, hmath::abs(nAlpha));
+			overlayBroadcaster.sendMessage(sendNotificationSync, copy, overlayVisible ? hmath::abs(nAlpha) : 0.0f);
 		}
 		else
 		{
-			overlayBroadcaster.sendMessage(sendNotificationSync, this->currentOverlayImage, hmath::abs(nAlpha));
+			overlayBroadcaster.sendMessage(sendNotificationSync, this->currentOverlayImage, overlayVisible ? hmath::abs(nAlpha) : 0.0f);
 		}
 		
 		overlayAlphaSlider->setColour(Slider::trackColourId, Colours::orange.withSaturation(hmath::abs(nAlpha)).withAlpha(0.5f));
@@ -826,6 +882,7 @@ void ScriptContentPanel::Editor::rebuildAfterContentChange()
 	addButton("profile");
 
 	addCustomComponent(overlaySelector);
+	addCustomComponent(overlayToggleButton);
 	addCustomComponent(overlayAlphaSlider);
 
 	setWantsKeyboardFocus(true);
@@ -2303,6 +2360,7 @@ juce::Path ScriptContentPanel::Factory::createPath(const String& id) const
 	LOAD_EPATH_IF_URL("debug-css", ColumnIcons::debugCSS);
 	LOAD_EPATH_IF_URL("suspend", EditorIcons::nightIcon);
 	LOAD_EPATH_IF_URL("profile", EditorIcons::profileIcon);
+	LOAD_EPATH_IF_URL("overlay-toggle", EditorIcons::imageIcon);
 
 	return p;
 }

--- a/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
+++ b/hi_scripting/scripting/components/ScriptingPanelTypes.cpp
@@ -747,42 +747,7 @@ ScriptContentPanel::Editor::Editor(Canvas* c):
 	auto overlayToggleButtonAction = new ActionButton(this, "overlay-toggle");
 	overlayToggleButtonAction->stateFunction = [](Editor& e) { return e.overlayVisible; };
 	overlayToggleButtonAction->enabledFunction = [](Editor& e) { return e.currentOverlayImage.isValid(); };
-	overlayToggleButtonAction->actionFunction = [](Editor& e)
-	{
-		e.overlayVisible = !e.overlayVisible;
-
-		if(e.overlayVisible)
-		{
-			if(!e.currentOverlayImage.isValid())
-			{
-				e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
-				return false;
-			}
-
-			float alphaToUse = e.overlayAlphaSlider->getValue();
-			e.overlayAlphaSlider->setValue(alphaToUse, dontSendNotification);
-			e.lastOverlayAlpha = alphaToUse;
-
-			auto nAlpha = e.overlayAlphaSlider->getValue();
-			if(nAlpha < 0.0)
-			{
-				Image copy = e.currentOverlayImage.createCopy();
-				gin::applyInvert(copy);
-				e.overlayBroadcaster.sendMessage(sendNotificationSync, copy, hmath::abs(nAlpha));
-			}
-			else
-			{
-				e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, hmath::abs(nAlpha));
-			}
-		}
-		else
-		{
-			e.lastOverlayAlpha = e.overlayAlphaSlider->getValue();
-			e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
-		}
-
-		return false;
-	};
+	overlayToggleButtonAction->actionFunction = Actions::toggleOverlay;
 	overlayToggleButtonAction->setTooltip("Toggle overlay image visibility");
 	overlayToggleButton = overlayToggleButtonAction;
 
@@ -1321,6 +1286,43 @@ bool ScriptContentPanel::Editor::Actions::lockSelection(Editor& e)
 	return true;
 }
 
+bool ScriptContentPanel::Editor::Actions::toggleOverlay(Editor& e)
+{
+	e.overlayVisible = !e.overlayVisible;
+
+	if(e.overlayVisible)
+	{
+		if(!e.currentOverlayImage.isValid())
+		{
+			e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
+			return false;
+		}
+
+		float alphaToUse = e.overlayAlphaSlider->getValue();
+		e.overlayAlphaSlider->setValue(alphaToUse, dontSendNotification);
+		e.lastOverlayAlpha = alphaToUse;
+
+		auto nAlpha = e.overlayAlphaSlider->getValue();
+		if(nAlpha < 0.0)
+		{
+			Image copy = e.currentOverlayImage.createCopy();
+			gin::applyInvert(copy);
+			e.overlayBroadcaster.sendMessage(sendNotificationSync, copy, hmath::abs(nAlpha));
+		}
+		else
+		{
+			e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, hmath::abs(nAlpha));
+		}
+	}
+	else
+	{
+		e.lastOverlayAlpha = e.overlayAlphaSlider->getValue();
+		e.overlayBroadcaster.sendMessage(sendNotificationSync, e.currentOverlayImage, 0.0f);
+	}
+
+	return false;
+}
+
 struct ComponentPositionComparator
 {
 	ComponentPositionComparator(bool isVertical_) :
@@ -1436,6 +1438,7 @@ void ScriptContentPanel::initKeyPresses(Component* root)
 
 	TopLevelWindowWithKeyMappings::addShortcut(root, cat, id_show_json, "Show JSON properties", KeyPress('j'));
     TopLevelWindowWithKeyMappings::addShortcut(root, cat, id_show_panel_data_json, "Show Panel.data as JSON", KeyPress('p'));
+	TopLevelWindowWithKeyMappings::addShortcut(root, cat, id_toggle_overlay, "Toggle overlay image visibility", KeyPress('o'));
 }
 
 bool ScriptContentPanel::Editor::keyPressed(const KeyPress& key)
@@ -1454,6 +1457,19 @@ bool ScriptContentPanel::Editor::keyPressed(const KeyPress& key)
 		return Actions::zoomOut(*this);
 	else if (TopLevelWindowWithKeyMappings::matches(this, key, id_lock_selection))
 		return Actions::lockSelection(*this);
+	else if (TopLevelWindowWithKeyMappings::matches(this, key, id_toggle_overlay))
+	{
+		if (overlayToggleButton && overlayToggleButton->isEnabled())
+		{
+			Actions::toggleOverlay(*this);
+			// Update button state
+			if (auto* actionButton = dynamic_cast<WrapperWithMenuBarBase::ActionButtonBase<Editor, Factory>*>(overlayToggleButton))
+			{
+				actionButton->repaint();
+			}
+		}
+		return true;
+	}
 
 	return false;
 }
@@ -2332,6 +2348,7 @@ Array<PathFactory::KeyMapping> ScriptContentPanel::Factory::getKeyMapping() cons
 	km.add({ "Undo", 'z', ModifierKeys::commandModifier });
 	km.add({ "Redo", 'y', ModifierKeys::commandModifier });
 	km.add({ "Edit JSON", 'j' });
+	km.add({ "overlay-toggle", 'o' });
 	
 	return km;
 }

--- a/hi_scripting/scripting/components/ScriptingPanelTypes.h
+++ b/hi_scripting/scripting/components/ScriptingPanelTypes.h
@@ -47,6 +47,7 @@ namespace InterfaceDesignerShortcuts
 	DECLARE_ID(id_show_json);
     DECLARE_ID(id_show_panel_data_json);
 	DECLARE_ID(id_duplicate);
+	DECLARE_ID(id_toggle_overlay);
 }
 #undef DECLARE_ID
 
@@ -240,6 +241,8 @@ public:
 			static bool distribute(Editor* editor, bool isVertical);
 			static bool align(Editor* editor, bool isVertical);
 			static bool undo(Editor * e, bool shouldUndo);
+
+			static bool toggleOverlay(Editor& e);
 		};
 
 		LambdaBroadcaster<Image, float> overlayBroadcaster;

--- a/hi_scripting/scripting/components/ScriptingPanelTypes.h
+++ b/hi_scripting/scripting/components/ScriptingPanelTypes.h
@@ -250,7 +250,10 @@ public:
 		LookAndFeel_V4 slaf;
 		ComboBox* zoomSelector;
 		ComboBox* overlaySelector;
+		Component* overlayToggleButton;
 		Slider* overlayAlphaSlider;
+		float lastOverlayAlpha = 0.0f;
+		bool overlayVisible = true;
 
 		JUCE_DECLARE_WEAK_REFERENCEABLE(Editor);
 	};


### PR DESCRIPTION
I like using overlay images to ensure my Figma design is translated properly to HISE. Currently, the only way to toggle the image visibility is to select/unselect the image, or quickly slide the alpha slider.

This PR adds a toggle button between the image dropdown and the alpha slider. It uses an existing image icon for the button and respects the alpha slider value.

This allows me to toggle the image without taking my eyes off the interface, making it easier to spot changes.

![HISE-Overlay-Image-Toggle](https://github.com/user-attachments/assets/6a811dc2-e4fa-46c7-b3ef-595d619c8266)
