### PR TITLE
Initialise full expansion value tree

### DIFF
--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -2510,6 +2510,8 @@ juce::Result FullInstrumentExpansion::initialise()
 		if(iconData.isNotEmpty())
 			pool->getImagePool().setDataProvider(new PublicIconProvider(&pool->getImagePool(), iconData));
 
+		initialiseFromValueTree(allData);
+
 		fullyLoaded = false;
 
 		getMainController()->getExpansionHandler().addListener(this);


### PR DESCRIPTION
So that the `getSampleMapList` function works for full expansions. Let me know if there's a better way.

Forum thread: https://forum.hise.audio/topic/12220/expansion-getsamplemaplist-always-empty-full-expansions