### PR TITLE
Cast values to int before saving UI XML

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -6246,10 +6246,11 @@ void ScriptingApi::Content::ScriptDynamicContainer::ChildReference::setBounds(va
 	if(r.failed())
 		reportScriptError(r.getErrorMessage());
 
-	componentData.setProperty(dyncomp::dcid::x, b.getX(), um);
-	componentData.setProperty(dyncomp::dcid::y, b.getY(), um);
-	componentData.setProperty(dyncomp::dcid::width, b.getWidth(), um);
-	componentData.setProperty(dyncomp::dcid::height, b.getHeight(), um);
+	// Cast to int to preserve integer format in XML (prevents "34.0" instead of "34")
+	componentData.setProperty(dyncomp::dcid::x, (int)b.getX(), um);
+	componentData.setProperty(dyncomp::dcid::y, (int)b.getY(), um);
+	componentData.setProperty(dyncomp::dcid::width, (int)b.getWidth(), um);
+	componentData.setProperty(dyncomp::dcid::height, (int)b.getHeight(), um);
 }
 
 var ScriptingApi::Content::ScriptDynamicContainer::ChildReference::getLocalBounds(int margin) const

--- a/hi_scripting/scripting/api/ScriptingBaseObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingBaseObjects.cpp
@@ -307,10 +307,11 @@ ValueTree ValueTreeConverters::convertDynamicObjectToContentProperties(const var
 			if(nv.name == dyncomp::dcid::bounds)
 			{
 				auto bounds = ApiHelpers::getRectangleFromVar(nv.value);
-				root.setProperty(dyncomp::dcid::x, bounds.getX(), nullptr);
-				root.setProperty(dyncomp::dcid::y, bounds.getY(), nullptr);
-				root.setProperty(dyncomp::dcid::width, bounds.getWidth(), nullptr);
-				root.setProperty(dyncomp::dcid::height, bounds.getHeight(), nullptr);
+				// Cast to int to preserve integer format in XML (prevents "34.0" instead of "34")
+				root.setProperty(dyncomp::dcid::x, (int)bounds.getX(), nullptr);
+				root.setProperty(dyncomp::dcid::y, (int)bounds.getY(), nullptr);
+				root.setProperty(dyncomp::dcid::width, (int)bounds.getWidth(), nullptr);
+				root.setProperty(dyncomp::dcid::height, (int)bounds.getHeight(), nullptr);
 			}
 			else
 			{


### PR DESCRIPTION
This is meant to prevent occasional changes in UI XML values from integers to floats, causing unnecessary git noise.

I quite often see small changes in diffs like this:

```
// MyPluginDesktop.xml
diff
- width="340" height="20"
+ width="340.0" height="20.0"
```