### PR TITLE
Cast x, y, width and height to int before saving XML

### DIFF
--- a/hi_backend/backend/BackendApplicationCommands.cpp
+++ b/hi_backend/backend/BackendApplicationCommands.cpp
@@ -1837,6 +1837,8 @@ void BackendCommandTarget::Actions::saveFileXml(BackendRootWindow * bpe)
 
 			            v.setProperty("BuildVersion", BUILD_SUB_VERSION, nullptr);
 			            
+						XmlBackupFunctions::normalizePositionProperties(v);
+
 						auto xml = v.createXml();
 						
 						XmlBackupFunctions::removeEditorStatesFromXml(*xml);
@@ -1933,6 +1935,8 @@ void BackendCommandTarget::Actions::saveFileAsXml(BackendRootWindow * bpe)
 
             v.setProperty("BuildVersion", BUILD_SUB_VERSION, nullptr);
             
+			XmlBackupFunctions::normalizePositionProperties(v);
+
 			auto xml = v.createXml();
 
 			FullInstrumentExpansion::setNewDefault(bpe->owner, v);
@@ -3541,6 +3545,32 @@ void XmlBackupFunctions::removeAllScripts(XmlElement &xml)
 	for (int i = 0; i < xml.getNumChildElements(); i++)
 	{
 		removeAllScripts(*xml.getChildElement(i));
+	}
+}
+
+void XmlBackupFunctions::normalizePositionProperties(ValueTree& v)
+{
+	static const Identifier x("x");
+	static const Identifier y("y");
+	static const Identifier width("width");
+	static const Identifier height("height");
+
+	// Cast all position props to int to prevent "34.0" in XML
+	for (int i = 0; i < v.getNumProperties(); i++)
+	{
+		auto propName = v.getPropertyName(i);
+		if (propName == x || propName == y || propName == width || propName == height)
+		{
+			var propValue = v.getProperty(propName);
+			v.setProperty(propName, (int)propValue, nullptr);
+		}
+	}
+
+	// Recursively normalize child trees
+	for (int i = 0; i < v.getNumChildren(); i++)
+	{
+		auto child = v.getChild(i);
+		normalizePositionProperties(child);
 	}
 }
 

--- a/hi_backend/backend/BackendApplicationCommands.h
+++ b/hi_backend/backend/BackendApplicationCommands.h
@@ -439,6 +439,8 @@ struct XmlBackupFunctions
 
 	static XmlElement* getFirstChildElementWithAttribute(XmlElement* parent, const String& attributeName, const String& value);
 
+	static void normalizePositionProperties(ValueTree& v);
+
 	static void addContentFromSubdirectory(XmlElement& xml, const File& fileToLoad);
 
 	static void extractContentData(XmlElement& xml, const String& interfaceId, const File& xmlFile);


### PR DESCRIPTION
This is meant to prevent occasional changes in UI XML values from integers to floats, causing unnecessary git noise.

I quite often see small changes in diffs like this:

```
// MyPluginDesktop.xml
diff
- width="340" height="20"
+ width="340.0" height="20.0"
```

All x, y, width and height values are read from the XML as strings, then converted to integer for the UI anyway, so saving them as integer in the first place prevents to occasional float values like `34.0` creeping into git commits.

A helper function is called on the Value Tree during Save XML and Save As XML.