### PR TITLE
Fix issue where fast attack on table envelope used wrong sustain value

### DIFF
--- a/hi_core/hi_modules/modulators/mods/TableEnvelope.cpp
+++ b/hi_core/hi_modules/modulators/mods/TableEnvelope.cpp
@@ -310,12 +310,13 @@ float TableEnvelope::calculateNewValue(int voiceIndex)
 	{
 	case TableEnvelopeState::ATTACK:
 	{
-		state->current_value = attackTable->getInterpolatedValue(state->uptime / (double)SAMPLE_LOOKUP_TABLE_SIZE, dontSendNotification);
-
 		state->uptime += attackUptimeDelta * state->attackModValue;
 
 		if ((int)state->uptime >= SAMPLE_LOOKUP_TABLE_SIZE)
 		{
+			// Very short attack times caused the sustain phase to use the wrong value
+			// This makes sure we use the last value of the table for the sustain phase
+			state->current_value = attackTable->getInterpolatedValue(1.0, dontSendNotification);
 			state->uptime = 0.0f;
 
 			if (!isMonophonic && attackTable->getLastValue() <= 0.01f)
@@ -327,6 +328,10 @@ float TableEnvelope::calculateNewValue(int voiceIndex)
 			{
 				state->current_state = TableEnvelopeState::SUSTAIN;
 			}
+		}
+		else
+		{
+			state->current_value = attackTable->getInterpolatedValue(state->uptime / (double)SAMPLE_LOOKUP_TABLE_SIZE, dontSendNotification);
 		}
 		break;
 	}


### PR DESCRIPTION
The code calculates a delta and it looks like it goes out of bounds on very short attack times, causing the wrong value to be set for the sustain phase.

The fix ensures that the final table value is always used for the sustain phase.

Issue here #832 

Before fix:

https://github.com/user-attachments/assets/daee004d-72e1-45b2-8f49-fce16b4ce64d

After fix:

https://github.com/user-attachments/assets/ce8b8248-f9e8-4582-bb66-daea6102c70c


