### PR TITLE
Skip empty lines when toggling comments

### DIFF
--- a/hi_tools/mcl_editor/code_editor/LanguageManager.cpp
+++ b/hi_tools/mcl_editor/code_editor/LanguageManager.cpp
@@ -37,6 +37,14 @@ bool LanguageManager::isLineCommented(TextDocument& document, Selection s) const
 
 void LanguageManager::toggleCommentForLine(TextEditor* editor, bool shouldBeCommented)
 {
+	auto& textDoc = editor->getTextDocument();
+	auto currentSelection = textDoc.getSelection(0);
+	int lineNumber = currentSelection.head.x;
+
+	// Skip empty lines (lines with only whitespace)
+	if (!textDoc.getLine(lineNumber).containsNonWhitespaceChars())
+		return;
+
 	if(shouldBeCommented)
 	{
         editor->insert("//");


### PR DESCRIPTION
Skip toggling comments for empty (whitespace-only) lines.