### PR TITLE
Allow toggling comments for multiple selected lines of code

### DIFF
--- a/hi_tools/mcl_editor/code_editor/LanguageManager.cpp
+++ b/hi_tools/mcl_editor/code_editor/LanguageManager.cpp
@@ -37,6 +37,14 @@ bool LanguageManager::isLineCommented(TextDocument& document, Selection s) const
 
 void LanguageManager::toggleCommentForLine(TextEditor* editor, bool shouldBeCommented)
 {
+	auto& textDoc = editor->getTextDocument();
+	auto currentSelection = textDoc.getSelection(0);
+	int lineNumber = currentSelection.head.x;
+
+	// Skip empty lines (lines with only whitespace)
+	if (!textDoc.getLine(lineNumber).containsNonWhitespaceChars())
+		return;
+
 	if(shouldBeCommented)
 	{
         editor->insert("//");

--- a/hi_tools/mcl_editor/code_editor/TextEditor.cpp
+++ b/hi_tools/mcl_editor/code_editor/TextEditor.cpp
@@ -3294,54 +3294,65 @@ bool mcl::TextEditor::keyPressed (const KeyPress& key)
 
 	if (keyMatchesId(key, TextEditorShortcuts::comment_line)) // "Cmd + #"
 	{
-		bool anythingCommented = false;
-		bool anythingUncommented = false;
+		// Collect all unique line numbers from all selections
+		SparseSet<int> linesToProcess;
 
 		for (auto s : document.getSelections())
 		{
-			auto thisOne = languageManager->isLineCommented(document, s);
-
-			anythingCommented |= thisOne;
-			anythingUncommented |= !thisOne;
+			auto oriented = s.oriented();
+			for (int line = oriented.head.x; line <= oriented.tail.x; line++)
+			{
+				linesToProcess.addRange({line, line + 1});
+			}
 		}
 
-		if (anythingUncommented && anythingCommented)
+		if (linesToProcess.isEmpty())
 			return false;
 
-		Array<CodeDocument::Position> positions;
+		// Check non-empty lines with Visual Studio Code behaviour:
+		// If ANY line is not commented → comment ALL lines
+		// If ALL lines are commented → uncomment ALL lines
+		bool hasUncommentedLine = false;
 
-		for (auto s : document.getSelections())
+		for (int i = 0; i < linesToProcess.getNumRanges(); i++)
 		{
-			positions.add(s.toCodePosition(document.getCodeDocument()));
+			auto range = linesToProcess.getRange(i);
+			for (int line = range.getStart(); line < range.getEnd(); line++)
+			{
+				if (!document.getLine(line).containsNonWhitespaceChars())
+					continue;
+
+				Selection lineSelection(line, 0, line, 0);
+				if (!languageManager->isLineCommented(document, lineSelection))
+				{
+					hasUncommentedLine = true;
+					break;
+				}
+			}
+			if (hasUncommentedLine)
+				break;
 		}
 
-		for (auto& p : positions)
-			p.setPositionMaintained(true);
+		// Save original selections for restoration
+		Array<Selection> originalSelections = document.getSelections();
 
-		nav({}, TextDocument::Target::line, TextDocument::Direction::forwardCol);
-		nav({}, TextDocument::Target::firstnonwhitespace, TextDocument::Direction::backwardCol);
+		// Process each line (toggleCommentForLine skips empty lines internally)
+		bool shouldComment = hasUncommentedLine;
 
-		if (anythingUncommented)
+		for (int i = 0; i < linesToProcess.getNumRanges(); i++)
 		{
-			languageManager->toggleCommentForLine(this, true);
-
-			
-		}
-		else
-		{
-			languageManager->toggleCommentForLine(this, false);
-
-			
-		}
-
-		Array<Selection> newSelection;
-
-		for (auto p : positions)
-		{
-			newSelection.add(Selection::fromCodePosition(p));
+			auto range = linesToProcess.getRange(i);
+			for (int line = range.getStart(); line < range.getEnd(); line++)
+			{
+				Selection lineSel(line, 0, line, 0);
+				document.setSelections({lineSel}, false);
+				nav({}, TextDocument::Target::line, TextDocument::Direction::forwardCol);
+				nav({}, TextDocument::Target::firstnonwhitespace, TextDocument::Direction::backwardCol);
+				languageManager->toggleCommentForLine(this, shouldComment);
+			}
 		}
 
-		document.setSelections(newSelection, false);
+		document.setSelections(originalSelections, false);
 		return true;
 	}
     if (key == KeyPress ('x', ModifierKeys::commandModifier, 0))


### PR DESCRIPTION
The intention is to follow the Visual Studio Code style of toggling comments for multiple selected lines:

- If ALL selected lines are commented → un-comment ALL lines
- If ANY selected line is not commented → comment ALL lines

It restores the selection state after toggling, but does not move the cursor position. Meaning, if the line under the cursor is toggled, then the cursor will be out of place by 2 characters. But I didn't find that to be an issue.

It also includes the code from PR #835 that skips toggling comments for empty (whitespace-only) lines.