### PR TITLE
Set LookAndFeel on combo box to allow font settings from Interface Designer

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1121,7 +1121,7 @@ ScriptCreatedComponentWrapper(content, index)
 
 	cb->setup(getProcessor(), getIndex(), scriptComboBox->name.toString());
 	cb->addListener(this);
-	//cb->setLookAndFeel(&plaf);
+	cb->setLookAndFeel(&plaf);
 
 	component = cb;
 


### PR DESCRIPTION
Fixes the issue of Interface Designer font settings not updating a Combo Box. Font and font size now works as expected.

The line that applies the LAF to Combo Box was commented out. There might be a good reason for this, and this fix could cause other unforeseen issues.  But it does fix bug #837 