### PR TITLE
Folding parent module hides child modules in Module Tree

### DIFF
--- a/hi_backend/backend/debug_components/PatchBrowser.cpp
+++ b/hi_backend/backend/debug_components/PatchBrowser.cpp
@@ -528,6 +528,9 @@ void PatchBrowser::paint(Graphics &g)
         
 		if (!c->hasVisibleItems()) continue;
 
+		// Skip drawing joining lines if parent is folded
+		if (c->isParentFolded()) continue;
+
         Processor *p = c->getProcessor();
 
 		if (p == nullptr) return;
@@ -1488,6 +1491,56 @@ void PatchBrowser::PatchCollection::paint(Graphics &g)
 	}
 }
 
+
+bool PatchBrowser::PatchCollection::isParentFolded() const
+{
+	auto* pb = findParentComponentOfClass<PatchBrowser>();
+	if (pb == nullptr)
+		return false;
+
+	const Processor* thisProcessor = getProcessor();
+	if (thisProcessor == nullptr)
+		return false;
+
+	// Check if any parent is folded
+	const Processor* currentParent = ProcessorHelpers::findParentProcessor(thisProcessor, true);
+
+	while (currentParent != nullptr)
+	{
+		// Check all Collections to see if any matches the current parent processor
+		int numCollections = pb->getNumCollections();
+		for (int i = 0; i < numCollections; i++)
+		{
+			auto* pc = dynamic_cast<PatchCollection*>(pb->getCollection(i));
+			if (pc == nullptr || pc == this)
+				continue;
+
+			// Check if this Collection represents the parent processor
+			if (pc->getProcessor() == currentParent)
+			{
+				if (pc->isFolded())
+					return true;
+				// otherwise, keep checking higher parents
+				break;
+			}
+		}
+
+		// Move up to next parent processor, until it's null
+		currentParent = ProcessorHelpers::findParentProcessor(currentParent, true);
+	}
+
+	return false;
+}
+
+int PatchBrowser::PatchCollection::getHeightForCollection() const
+{
+	// If a parent is folded, hide this Collection
+	if (isParentFolded())
+		return 0;
+
+	// Otherwise, use the base class implementation
+	return SearchableListComponent::Collection::getHeightForCollection();
+}
 
 void PatchBrowser::PatchCollection::refreshFoldButton()
 {

--- a/hi_backend/backend/debug_components/PatchBrowser.h
+++ b/hi_backend/backend/debug_components/PatchBrowser.h
@@ -410,6 +410,11 @@ private:
 		void resetDragState();
 		void toggleShowChains();
 
+		bool isParentFolded() const;
+
+		/** Override to hide Collection if parent is folded */
+		int getHeightForCollection() const override;
+
 		void setInPopup(bool isInPopup)
 		{
 			if (inPopup != isInPopup)

--- a/hi_backend/backend/debug_components/ProcessorCollection.h
+++ b/hi_backend/backend/debug_components/ProcessorCollection.h
@@ -320,7 +320,7 @@ public:
 		*/
 		bool hasVisibleItems() const;
 
-		int getHeightForCollection() const;
+		virtual int getHeightForCollection() const;
 
 		void resized() override;
 


### PR DESCRIPTION
Updates the Module Tree so folding a parent module folds (hides) any child modules.

Works recursively with nested modules.

![HISE-FoldChildModules](https://github.com/user-attachments/assets/bb75adf0-088a-4bd4-bf0a-1cba22f1c10b)
