### PR TITLE
Fix minmax node's missing drag target

### DIFF
--- a/hi_scripting/scripting/scriptnode/node_library/HiseNodeFactory.cpp
+++ b/hi_scripting/scripting/scriptnode/node_library/HiseNodeFactory.cpp
@@ -1085,7 +1085,7 @@ namespace control
 		registerPolyNoProcessNode<control::pma<1, parameter::dynamic_base_holder>, control::pma<NUM_POLYPHONIC_VOICES, parameter::dynamic_base_holder>, extra_drag_wrapper<pma_editor, Justification::bottom>>();
 		registerPolyNoProcessNode<control::pma_unscaled<1, parameter::dynamic_base_holder>, control::pma_unscaled<NUM_POLYPHONIC_VOICES, parameter::dynamic_base_holder>, extra_drag_wrapper<pma_editor, Justification::bottom>>();
 
-		registerPolyNoProcessNode<control::minmax<1, parameter::dynamic_base_holder>, control::minmax<NUM_POLYPHONIC_VOICES, parameter::dynamic_base_holder>, minmax_editor>();
+		registerPolyNoProcessNode<control::minmax<1, parameter::dynamic_base_holder>, control::minmax<NUM_POLYPHONIC_VOICES, parameter::dynamic_base_holder>, minmax_editor_wrapped>();
 
 		registerPolyNoProcessNode<control::logic_op<1, parameter::dynamic_base_holder>, control::logic_op<NUM_POLYPHONIC_VOICES, parameter::dynamic_base_holder>, logic_op_editor_wrapped>();
 


### PR DESCRIPTION
The minmax node was missing its drag target. Reported in issue #840 

This changes the node to use minmax_editor_wrapped, instead of minmax_editor, which adds the drag target functionality back in.

<img width="500" alt="CleanShot 2026-01-10 at 17 51 22@2x" src="https://github.com/user-attachments/assets/e4b6907f-6650-4628-8130-94eaecd2467b" />
