### PR TITLE
Fix MIDI Overlay crashing compiled plugins

### DIFF
--- a/hi_core/hi_components/midi_overlays/MidiOverlayFactory.h
+++ b/hi_core/hi_components/midi_overlays/MidiOverlayFactory.h
@@ -37,7 +37,7 @@ namespace hise {
 using namespace juce;
 
 
-class MidiOverlayFactory: public DeletedAtShutdown
+class MidiOverlayFactory
 {
 public:
 


### PR DESCRIPTION
Fixes an issue where compiled plugins with midi overlay tiles would crash when multiple instances were initialized, discovered + resolved in the [forum](https://forum.hise.audio/topic/4656/midi-overlay-panels-in-compiled-plugin-crashing-daws)