### PR TITLE
BREAKING CHANGE: add MaxBands attribute to Parametric EQ

### DIFF
--- a/hi_core/hi_modules/effects/fx/CurveEq.cpp
+++ b/hi_core/hi_modules/effects/fx/CurveEq.cpp
@@ -51,6 +51,9 @@ CurveEq::CurveEq(MainController *mc, const String &id) :
     
     fftBuffer->setActive(false);
 
+	parameterNames.add("MaxBands");
+	parameterDescriptions.add("The maximum number of filter bands that can be added (0 = unlimited).");
+
 	parameterNames.add("Gain");
 	parameterDescriptions.add("The gain in decibels if supported from the filter type.");
 
@@ -73,6 +76,19 @@ CurveEq::CurveEq(MainController *mc, const String &id) :
 float CurveEq::getAttribute(int index) const
 {
 	if(index == -1) return 0.0f;
+
+	// Handle global effect parameters
+	if (index < numEffectParameters)
+	{
+		switch (index)
+		{
+		case MaxBands: return (float)maxBands;
+		default:       return 0.0f;
+		}
+	}
+
+	// Handle band-specific parameters (offset by numEffectParameters)
+	index -= numEffectParameters;
 
 	const int filterIndex = index / BandParameter::numBandParameters;
 	const BandParameter parameter = (BandParameter)(index % BandParameter::numBandParameters);
@@ -107,6 +123,19 @@ float CurveEq::getAttribute(int index) const
 void CurveEq::setInternalAttribute(int index, float newValue)
 {
 	if (index == -1) return;
+
+	// Handle global effect parameters
+	if (index < numEffectParameters)
+	{
+		switch (index)
+		{
+		case MaxBands: maxBands = jmax(0, (int)newValue); return;
+		default:       return;
+		}
+	}
+
+	// Handle band-specific parameters (offset by numEffectParameters)
+	index -= numEffectParameters;
 
 	const int filterIndex = index / BandParameter::numBandParameters;
 	const BandParameter parameter = (BandParameter)(index % BandParameter::numBandParameters);

--- a/hi_core/hi_modules/effects/fx/CurveEq.h
+++ b/hi_core/hi_modules/effects/fx/CurveEq.h
@@ -62,6 +62,7 @@ public:
 
 	enum Parameters
 	{
+		MaxBands = 0, ///< The maximum number of filter bands that can be added (0 = unlimited)
 		numEffectParameters
 	};
 
@@ -119,7 +120,7 @@ public:
 
 	int getParameterIndex(int filterIndex, int parameterType) const
 	{
-		return filterIndex * BandParameter::numBandParameters + parameterType;
+		return numEffectParameters + filterIndex * BandParameter::numBandParameters + parameterType;
 	}
 
 	float getAttribute(int index) const override;;
@@ -200,6 +201,10 @@ public:
 
 	void addFilterBand(double freq, double gain, int insertIndex=-1)
 	{
+		// Check if we've reached the maximum number of bands (0 = unlimited)
+		if (maxBands > 0 && filterBands.size() >= maxBands)
+			return;
+
 		ScopedLock sl(getMainController()->getLock());
 
 		StereoFilter *f = new StereoFilter();
@@ -264,11 +269,12 @@ public:
 	{
 		ValueTree v = MasterEffectProcessor::exportAsValueTree();
 
+		v.setProperty("MaxBands", maxBands, nullptr);
 		v.setProperty("NumFilters", filterBands.size(), nullptr);
 
 		for(int i = 0; i < filterBands.size() * BandParameter::numBandParameters; i++)
 		{
-			v.setProperty("Band" + String(i), getAttribute(i), nullptr);
+			v.setProperty("Band" + String(i), getAttribute(numEffectParameters + i), nullptr);
 		}
 
 		v.setProperty("FFTEnabled", fftBuffer->isActive(), nullptr);
@@ -281,6 +287,8 @@ public:
 		MasterEffectProcessor::restoreFromValueTree(v);
 
 		ScopedLock sl(getMainController()->getLock());
+
+		maxBands = v.getProperty("MaxBands", 0);
 
 		OwnedArray<StereoFilter> newFilters;
 		
@@ -304,7 +312,7 @@ public:
 		for(int i = 0; i < numFilters * BandParameter::numBandParameters; i++)
 		{
             const float value = v.getProperty("Band" + String(i), 0.0f);
-            setAttribute(i, value, dontSendNotification);
+            setAttribute(numEffectParameters + i, value, dontSendNotification);
 		}
 
 		enableSpectrumAnalyser(v.getProperty("FFTEnabled", false));
@@ -324,7 +332,7 @@ public:
 
 	int getNumChildProcessors() const override { return 0; };
 
-	int getNumAttributes() const override { return BandParameter::numBandParameters * filterBands.size(); }
+	int getNumAttributes() const override { return numEffectParameters + BandParameter::numBandParameters * filterBands.size(); }
 
 	Processor *getChildProcessor(int /*processorIndex*/) override { return nullptr; };
 
@@ -393,6 +401,8 @@ private:
 	OwnedArray<StereoFilter> filterBands;
 	
 	double lastSampleRate = 0.0;
+
+	int maxBands = 0; // 0 = unlimited
 
 	JUCE_DECLARE_WEAK_REFERENCEABLE(CurveEq);
 };


### PR DESCRIPTION
Adds a MaxBands global attribute to Parametric EQ to allow us to set the maximum numbers of bands/nodes allowed.

THIS IS A BREAKING CHANGE, so we probably need to find a better way to do it.

[Forum post](https://forum.hise.audio/post/116818):

This seems to be a breaking change for any existing projects using the per-band indices to access and/or change values.

The [docs page](https://docs.hise.dev/hise-modules/effects/list/curveeq.html#parameters) shows 6 attributes for the Parametric EQ, and I believe they are per-band, so band 1 Gain is index 0, band 2 Gain is index 6, and so on.

The MaxBands attribute I introduced here would be a new (and only) global attribute for the module, at index 0, which would shift all the per-band indices by 1.