### PR TITLE
Add relative path support to Engine.loadFontAs

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -1292,6 +1292,7 @@ ScriptingObject(p),
 ApiClass(0),
 parentMidiProcessor(dynamic_cast<ScriptBaseMidiProcessor*>(p))
 {
+	setWantsCurrentLocation(true);
 	ADD_API_METHOD_0(getProjectInfo);
 	ADD_API_METHOD_0(allNotesOff);
 	ADD_API_METHOD_0(getUptime);
@@ -1573,8 +1574,29 @@ void ScriptingApi::Engine::loadFontAs(String fileName, String fontId)
 			return;
 	}
 
-	const String absolutePath = GET_PROJECT_HANDLER(getProcessor()).getFilePath(fileName, ProjectHandler::SubDirectories::Images);
-	File f(absolutePath);
+	File f;
+
+	if (fileName.startsWith("./") || fileName.startsWith("../"))
+	{
+		auto loc = getCurrentLocationInFunctionCall();
+
+		if (loc.fileName.isNotEmpty())
+		{
+			File scriptFile(loc.fileName);
+			f = scriptFile.getParentDirectory().getChildFile(fileName);
+		}
+		else
+		{
+			reportScriptError("Relative font path can only be used from an external script file");
+			return;
+		}
+	}
+	else
+	{
+		const String absolutePath = GET_PROJECT_HANDLER(getProcessor()).getFilePath(fileName, ProjectHandler::SubDirectories::Images);
+		f = File(absolutePath);
+	}
+
 	auto fis = f.createInputStream();
 
 	if (fis == nullptr)

--- a/hi_scripting/scripting/api/ScriptingApi.h
+++ b/hi_scripting/scripting/api/ScriptingApi.h
@@ -250,7 +250,7 @@ public:
 		/** Loads a font file. This is deprecated, because it might result in different names on various OS. Use loadFontAs() instead. */
 		void loadFont(const String &fileName);
 
-		/** Loads the font from the given file in the image folder and registers it under the fontId. This is platform agnostic. */
+		/** Loads the font from the given file in the image folder and registers it under the fontId. This is platform agnostic. If the fileName starts with "./" or "../", it will be resolved relative to the calling script file. */
 		void loadFontAs(String fileName, String fontId);
 
 		/** Sets the font that will be used as default font for various things. */

--- a/hi_scripting/scripting/engine/JavascriptEngineCustom.cpp
+++ b/hi_scripting/scripting/engine/JavascriptEngineCustom.cpp
@@ -203,6 +203,9 @@ struct HiseJavascriptEngine::RootObject::ApiCall : public Expression
 
 		CHECK_CONDITION_WITH_LOCATION(apiClass != nullptr, "API class does not exist");
 
+		if(apiClass->wantsCurrentLocation())
+			apiClass->setCurrentLocation(location.externalFile, location.getCharIndex());
+
 		try
 		{
 #if ENABLE_SCRIPTING_BREAKPOINTS


### PR DESCRIPTION
Allow loadFontAs to resolve font file paths relative to the calling script file when the path starts with "./" or "../". This uses the ApiClass location tracking mechanism to determine which script file is making the call, matching the pattern used by include() for relative path resolution.

https://claude.ai/code/session_01UPLMVNtrzxbK4WBFemokTW