### PR TITLE
Add LabelAlignment property to CustomSettings floating tile

### DIFF
--- a/hi_core/hi_components/plugin_components/PanelTypes.cpp
+++ b/hi_core/hi_components/plugin_components/PanelTypes.cpp
@@ -92,6 +92,7 @@ var CustomSettingsWindowPanel::toDynamicObject() const
 	SET(CustomSettingsWindow::Properties::UseOpenGL);
 
 	storePropertyInObject(obj, (int)CustomSettingsWindow::Properties::ScaleFactorList, var(window->scaleFactorList));
+	storePropertyInObject(obj, (int)CustomSettingsWindow::Properties::LabelAlignment, window->labelRight ? "right" : "left");
 
 	return obj;
 }
@@ -138,6 +139,9 @@ void CustomSettingsWindowPanel::fromDynamicObject(const var& object)
 
 		window->rebuildScaleFactorList();
 	}
+
+	auto alignment = getPropertyWithDefault(object, (int)CustomSettingsWindow::Properties::LabelAlignment).toString();
+	window->labelRight = (alignment != "left");
 }
 
 #undef SET
@@ -163,7 +167,7 @@ Identifier CustomSettingsWindowPanel::getDefaultablePropertyId(int index) const
 	SET(CustomSettingsWindow::Properties::DebugMode);
 	SET(CustomSettingsWindow::Properties::ScaleFactorList);
 	SET(CustomSettingsWindow::Properties::UseOpenGL);
-
+	SET(CustomSettingsWindow::Properties::LabelAlignment);
 
 	jassertfalse;
 	return{};
@@ -192,6 +196,8 @@ var CustomSettingsWindowPanel::getDefaultProperty(int index) const
 	SET(CustomSettingsWindow::Properties::UseOpenGL);
 
 	if (index == (int)CustomSettingsWindow::Properties::ScaleFactorList) return var({ var(0.5), var(0.75), var(1.0), var(1.25), var(1.5), var(2.0) });
+
+	if (index == (int)CustomSettingsWindow::Properties::LabelAlignment) return var("right");
 
 	jassertfalse;
 	return{};

--- a/hi_core/hi_components/plugin_components/PanelTypes.h
+++ b/hi_core/hi_components/plugin_components/PanelTypes.h
@@ -75,7 +75,8 @@ const var data = {
 "ClearMidiCC": true,
 "SampleLocation": true,
 "DebugMode": true,
-"ScaleFactorList": [0.5, 1, 2]
+"ScaleFactorList": [0.5, 1, 2],
+"LabelAlignment": "right"
 };
 ```
 
@@ -102,6 +103,7 @@ public:
 		SampleLocation, ///< shows the location of the sample folder and a button to relocate
 		DebugMode, ///< enables Debug mode which creates a useful log file for bug chasing
 		ScaleFactorList, ///< an array containing all available zoom factors (eg. `[0.5, 1.5, 1.25]` for 50%, 100%, 125%)
+		LabelAlignment, ///< the alignment of the text labels ("left" or "right", default is "right")
 		numProperties
 	};
 

--- a/hi_core/hi_components/plugin_components/StandalonePopupComponents.cpp
+++ b/hi_core/hi_components/plugin_components/StandalonePopupComponents.cpp
@@ -117,6 +117,7 @@ CustomSettingsWindow::CustomSettingsWindow(MainController* mc_, bool buildMenus)
 	ADD(SampleLocation);
 	ADD(DebugMode);
 	ADD(ScaleFactorList);
+	ADD(LabelAlignment);
 	
 	setColour(ColourIds::textColour, Colours::white);
 
@@ -617,9 +618,9 @@ void CustomSettingsWindow::paint(Graphics& g)
 
 	drawLabel = [&](Properties id, const char* text)
 	{
-		if (isOn(id)) 
-		{ 
-			g.drawText(text, 0, y, getWidth() / 2 - 30, 30, Justification::centredRight); 
+		if (isOn(id))
+		{
+			g.drawText(text, 0, y, getWidth() / 2 - 30, 30, labelRight ? Justification::centredRight : Justification::centredLeft);
 			y += 40;
 		}
 	};

--- a/hi_core/hi_components/plugin_components/StandalonePopupComponents.h
+++ b/hi_core/hi_components/plugin_components/StandalonePopupComponents.h
@@ -125,6 +125,7 @@ public:
 		SampleLocation, /// shows the sample location
 		DebugMode, /// toggles the Debug mode
 		ScaleFactorList, ///< the list of scale factors as Array<var> containing doubles.
+		LabelAlignment, ///< the alignment of the text labels ("left" or "right")
 		numProperties
 	};
 
@@ -172,6 +173,8 @@ private:
 	Array<Identifier> propIds;
 
 	Array<var> scaleFactorList;
+
+	bool labelRight = true;
 
 	BlackTextButtonLookAndFeel blaf;
 


### PR DESCRIPTION
Adds a Data property to control the alignment of text labels (Driver, Audio Device, Output, etc.) in the CustomSettings panel. Accepts "left" or "right" as values, defaulting to "right".
https://claude.ai/code/session_01CGfmrkLNf9HAtZu8TJWyrh