### PR TITLE
Fix itemColour2 and itemColour3 not available in preset browser LAF c…

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -972,6 +972,8 @@ PresetBrowserPanel::PresetBrowserPanel(FloatingTile* parent) :
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::black.withAlpha(0.97f));
     setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 	setDefaultPanelColour(PanelColourId::itemColour1, Colour(SIGNAL_COLOUR));
+	setDefaultPanelColour(PanelColourId::itemColour2, Colours::black.withAlpha(0.7f));
+	setDefaultPanelColour(PanelColourId::itemColour3, Colours::white.withAlpha(0.6f));
 
 	addAndMakeVisible(presetBrowser = new PresetBrowser(getMainController()));
 	
@@ -1091,6 +1093,8 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.showFavoriteIcons = getPropertyWithDefault(object, SpecialPanelIds::ShowFavoriteIcon);
 	options.backgroundColour = findPanelColour(PanelColourId::bgColour);
 	options.highlightColour = findPanelColour(PanelColourId::itemColour1);
+	options.modalBackgroundColour = findPanelColour(PanelColourId::itemColour2);
+	options.itemColour3 = findPanelColour(PanelColourId::itemColour3);
 	options.textColour = findPanelColour(PanelColourId::textColour);
 	options.font = getFont();
 	

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1292,6 +1292,8 @@ void PresetBrowser::setOptions(const Options& newOptions)
 	setHighlightColourAndFont(newOptions.highlightColour, newOptions.backgroundColour, newOptions.font);
 
 	getPresetBrowserLookAndFeel().textColour = newOptions.textColour;
+	getPresetBrowserLookAndFeel().modalBackgroundColour = newOptions.modalBackgroundColour;
+	getPresetBrowserLookAndFeel().itemColour3 = newOptions.itemColour3;
 	setNumColumns(newOptions.numColumns);
 	columnWidthRatios.clear();
 	columnWidthRatios.addArray(newOptions.columnWidthRatios);

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -69,6 +69,8 @@ public:
 		Colour highlightedTextColour;
 		Colour backgroundColour;
 		Colour textColour;
+		Colour modalBackgroundColour;
+		Colour itemColour3;
 		Font font;
 
 		int numColumns = 3;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4731,6 +4731,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPresetBrowserBackground(Gra
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserBackground", var(obj), p))
@@ -4751,6 +4752,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawColumnBackground(Graphics& 
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserColumnBackground", var(obj), nullptr))
@@ -4774,6 +4776,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawListItem(Graphics& g_, Comp
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserListItem", var(obj), nullptr))
@@ -4792,6 +4795,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawSearchBar(Graphics& g_, Com
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		auto p = new ScriptingObjects::PathObject(get()->getScriptProcessor());
@@ -5964,6 +5968,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTag(Graphics& g_, Component
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserTag", var(obj), nullptr))
@@ -5985,6 +5990,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawModalOverlay(Graphics& g_, 
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
 
 		if (l->callWithGraphics(g_, "drawPresetBrowserDialog", var(obj), nullptr))

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -331,6 +331,7 @@ public:
 	Colour highlightColour;
 	Colour textColour;
 	Colour modalBackgroundColour;
+	Colour itemColour3;
 	Font font;
 };
 


### PR DESCRIPTION
…allbacks

The itemColour2 and itemColour3 properties from the PresetBrowser floating tile's ColourData were not being passed through to the look and feel methods. This meant the drawPresetBrowserListItem (and other preset browser LAF callbacks) could not access these colors.

- Add modalBackgroundColour and itemColour3 fields to PresetBrowser::Options
- Set default panel colours for itemColour2/itemColour3 in PresetBrowserPanel
- Read itemColour2/itemColour3 from panel colours and pass to options
- Forward options to PresetBrowserLookAndFeelMethods in setOptions()
- Add itemColour3 member to PresetBrowserLookAndFeelMethods
- Pass itemColour3 property in all scripted preset browser LAF callbacks

https://claude.ai/code/session_0181pHLzprT46JudjPUbAyFM