### PR TITLE
Add scripted look-and-feel support for MidiLearnPanel and FrontendMac…

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -288,6 +288,8 @@ public:
 
 	String getDynamicTitle() const { return dynamicTitle; }
 
+	String getFontName() const { return fontName; }
+
 	Font getFont() const
 	{
 		if (fontName.isEmpty())

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1649,20 +1649,10 @@ juce::String MidiLearnPanel::getCellText(int rowNumber, int columnId) const
 TableFloatingTileBase::InvertedButton::InvertedButton(TableFloatingTileBase &owner_) :
 	owner(owner_)
 {
-	laf.setFontForAll(owner.font);
-
-	addAndMakeVisible(t = new TextButton("Inverted"));
-	t->setButtonText("Inverted");
-	t->setLookAndFeel(&laf);
-	t->setConnectedEdges(Button::ConnectedOnLeft | Button::ConnectedOnRight);
+	addAndMakeVisible(t = new ToggleButton("Inverted"));
+	t->setButtonText("Normal");
 	t->addListener(this);
 	t->setTooltip("Invert the range of the macro control for this parameter.");
-	t->setColour(TextButton::buttonColourId, Colour(0x88000000));
-	t->setColour(TextButton::buttonOnColourId, Colour(0x88FFFFFF));
-	t->setColour(TextButton::textColourOnId, Colour(0xaa000000));
-	t->setColour(TextButton::textColourOffId, Colour(0x99ffffff));
-
-	t->setClickingTogglesState(true);
 }
 
 void TableFloatingTileBase::InvertedButton::resized()
@@ -1689,9 +1679,6 @@ TableFloatingTileBase::ValueSliderColumn::ValueSliderColumn(TableFloatingTileBas
 {
 	addAndMakeVisible(slider = new RangeSlider());
 
-	laf.setFontForAll(table.font);
-
-	slider->setLookAndFeel(&laf);
 	slider->setSliderStyle(Slider::LinearBar);
 	slider->setTextBoxStyle(Slider::TextBoxLeft, true, 80, 20);
 	slider->setColour(Slider::backgroundColourId, Colour(0x38ffffff));
@@ -1730,6 +1717,32 @@ void TableFloatingTileBase::ValueSliderColumn::sliderValueChanged(Slider *)
 		slider->setValue(actualValue, dontSendNotification);
 }
 
+void TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (rowIsSelected)
+		g.fillAll(Colours::white.withAlpha(0.2f));
+}
+
+void TableFloatingTileBase::LookAndFeelMethods::drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	g.setColour(d.textColour);
+	g.setFont(d.f);
+	g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+}
+
+TableFloatingTileBase::LookAndFeelData TableFloatingTileBase::getLookAndFeelData() const
+{
+	LookAndFeelData d;
+	d.f = font;
+	d.textColour = textColour;
+	d.bgColour = findPanelColour(FloatingTileContent::PanelColourId::bgColour);
+	d.itemColour1 = itemColour1;
+	d.itemColour2 = itemColour2;
+	d.itemColour3 = findPanelColour(FloatingTileContent::PanelColourId::itemColour3);
+	d.parentType = getIdentifierForBaseClass().toString();
+	return d;
+}
+
 TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 	FloatingTileContent(parent),
 	font(GLOBAL_FONT())
@@ -1739,6 +1752,8 @@ TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 
 void TableFloatingTileBase::initTable(bool addChannelColumn)
 {
+	hasChannelColumn = addChannelColumn;
+
 	// Create our table component and add it to this component..
 	addAndMakeVisible(table);
 	table.setModel(this);
@@ -1776,9 +1791,9 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 		table.getHeader().addColumn("Channel", Channel, fWidth, 30, -1, TableHeaderComponent::visible);
 
 	table.getHeader().addColumn("Parameter", ParameterName, 70, 30, -1);
-	table.getHeader().addColumn("Inverted", Inverted, 70, 70, 70);
-	table.getHeader().addColumn("Min", Minimum, 70, 70, 70);
-	table.getHeader().addColumn("Max", Maximum, 70, 70, 70);
+	table.getHeader().addColumn("Inverted", Inverted, 70, 30, -1);
+	table.getHeader().addColumn("Min", Minimum, 70, 30, -1);
+	table.getHeader().addColumn("Max", Maximum, 70, 30, -1);
 	table.getHeader().setStretchToFitActive(true);
 }
 
@@ -1787,9 +1802,44 @@ void TableFloatingTileBase::updateContent()
 	table.updateContent();
 }
 
+var TableFloatingTileBase::toDynamicObject() const
+{
+	auto obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, SpecialPanelIds::ColumnWidthRatio, var(columnWidthRatios));
+	return obj;
+}
+
+Identifier TableFloatingTileBase::getDefaultablePropertyId(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultablePropertyId(index);
+
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnWidthRatio, "ColumnWidthRatio");
+
+	return {};
+}
+
+var TableFloatingTileBase::getDefaultProperty(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultProperty(index);
+
+	Array<var> defaultRatios;
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ColumnWidthRatio, var(defaultRatios));
+
+	return {};
+}
+
 void TableFloatingTileBase::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
+
+	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
+	if (ratios.isArray())
+	{
+		columnWidthRatios.clear();
+		columnWidthRatios.addArray(*ratios.getArray());
+	}
 
 	table.setColour(ListBox::backgroundColourId, findPanelColour(FloatingTileContent::PanelColourId::bgColour));
 
@@ -1836,12 +1886,17 @@ void TableFloatingTileBase::paintRowBackground(Graphics& g, int rowNumber, int w
 	}
 	else
 	{
-		if (rowIsSelected)
-		{
-			g.fillAll(Colours::white.withAlpha(0.2f));
-		}
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		lafToUse->drawTableRowBackground(g, getLookAndFeelData(), rowNumber, width, height, rowIsSelected, rowNumber == hoverRow);
 	}
-	
+
 }
 
 void TableFloatingTileBase::resized()
@@ -1859,6 +1914,8 @@ void TableFloatingTileBase::resized()
 
 			if (root->css.getWithAllStates(this, simple_css::Selector("th")) != nullptr)
 				table.getHeader().setLookAndFeel(css_laf);
+			else if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+				table.getHeader().setLookAndFeel(&getLookAndFeel());
 			else
 				table.getHeader().setLookAndFeel(laf);
 		}
@@ -1935,6 +1992,10 @@ void TableFloatingTileBase::resized()
 			auto ma = ss->getArea(getLocalBounds().toFloat(), {"margin", 0});
 			ma = ss->getArea(ma, {"padding", 0} );
 			table.setBounds(ma.toNearestInt());
+
+			auto scrollbarVisible = table.getViewport()->getVerticalScrollBar().isVisible();
+			auto scrollbarWidth = scrollbarVisible ? table.getViewport()->getScrollBarThickness() : 0;
+			table.getHeader().resizeAllColumnsToFit(ma.toNearestInt().getWidth() - scrollbarWidth);
 			return;
 		}
 
@@ -1942,9 +2003,39 @@ void TableFloatingTileBase::resized()
 
 	}
 
-	
-	
+	if (css_laf == nullptr)
+	{
+		if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+			table.getHeader().setLookAndFeel(&getLookAndFeel());
+		else
+			table.getHeader().setLookAndFeel(laf);
+	}
+
 	table.setBounds(getLocalBounds());
+
+	auto scrollbarVisible = table.getViewport()->getVerticalScrollBar().isVisible();
+	auto scrollbarWidth = scrollbarVisible ? table.getViewport()->getScrollBarThickness() : 0;
+
+	table.getHeader().resizeAllColumnsToFit(getWidth() - scrollbarWidth);
+
+	if (columnWidthRatios.size() > 0)
+	{
+		auto numCols = table.getHeader().getNumColumns(true);
+
+		if (columnWidthRatios.size() == numCols)
+		{
+			table.getHeader().setStretchToFitActive(false);
+			auto w = (double)(getWidth() - scrollbarWidth);
+
+			for (int i = 0; i < numCols; i++)
+			{
+				auto id = table.getHeader().getColumnIdOfIndex(i, true);
+				auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
+				auto colWidth = roundToInt(w * r);
+				table.getHeader().setColumnWidth(id, colWidth);
+			}
+		}
+	}
 }
 
 double TableFloatingTileBase::setRangeValue(int row, ColumnId column, double newRangeValue)
@@ -2053,10 +2144,11 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 
 		slider->slider->setDoubleClickReturnValue(true, columnId == Maximum ? fullRange.end : fullRange.start);
 
+		slider->slider->setComponentID(columnId == Maximum ? "max" : "min");
 		slider->slider->setColour(Slider::ColourIds::backgroundColourId, Colours::transparentBlack);
 		slider->slider->setColour(Slider::ColourIds::thumbColourId, itemColour1);
 		slider->slider->setColour(Slider::ColourIds::textBoxTextColourId, textColour);
-		
+
 		slider->setRowAndColumn(rowNumber, (ColumnId)columnId, value, fullRange);
 
 		ValueToTextConverter vtc = getValueToTextConverter(rowNumber);
@@ -2081,10 +2173,9 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 			b->t->setLookAndFeel(css_laf.get());
 		}
 		
-		b->t->setColour(TextButton::buttonOnColourId, itemColour1);
-		b->t->setColour(TextButton::textColourOnId, textColour);
-		b->t->setColour(TextButton::buttonColourId, Colours::transparentBlack);
-		b->t->setColour(TextButton::textColourOffId, textColour);
+		b->t->setColour(ToggleButton::textColourId, textColour);
+		b->t->setColour(ToggleButton::tickColourId, itemColour1);
+		b->t->setColour(ToggleButton::tickDisabledColourId, textColour);
 
 		b->setRowAndColumn(rowNumber, isInverted(rowNumber));
 
@@ -2109,7 +2200,7 @@ void TableFloatingTileBase::paintCell(Graphics& g, int rowNumber, int columnId, 
 	{
 		Renderer r(nullptr, rootDialog.stateWatcher);
 		auto state = r.getPseudoClassFromComponent(this);
-                
+
 		if(rowIsSelected)
 			state |= (int)PseudoClassType::Focus;
 
@@ -2121,9 +2212,16 @@ void TableFloatingTileBase::paintCell(Graphics& g, int rowNumber, int columnId, 
 	}
 	else
 	{
-		g.setColour(textColour);
-		g.setFont(font);
-		g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		auto visualIndex = table.getHeader().getIndexOfColumnId(columnId, true);
+		lafToUse->drawTableCell(g, getLookAndFeelData(), text, rowNumber, visualIndex, width, height, rowIsSelected, false, rowNumber == hoverRow);
 	}
 }
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1734,6 +1734,7 @@ TableFloatingTileBase::LookAndFeelData TableFloatingTileBase::getLookAndFeelData
 {
 	LookAndFeelData d;
 	d.f = font;
+	d.fontName = getFontName();
 	d.textColour = textColour;
 	d.bgColour = findPanelColour(FloatingTileContent::PanelColourId::bgColour);
 	d.itemColour1 = itemColour1;

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -720,6 +720,7 @@ public:
 	struct LookAndFeelData
 	{
 		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
 		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
 		String parentType;
 	};

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -708,9 +708,32 @@ public:
 		Inverted,
 		Minimum,
 		Maximum,
-		numColumns,
-		columnWidthRatio
+		numColumns
 	};
+
+	enum SpecialPanelIds
+	{
+		ColumnWidthRatio = (int)FloatingTileContent::PanelPropertyId::numPropertyIds,
+		numSpecialPanelIds
+	};
+
+	struct LookAndFeelData
+	{
+		Font f = GLOBAL_BOLD_FONT();
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
+		String parentType;
+	};
+
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {}
+
+		virtual void drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered);
+
+		virtual void drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered);
+	};
+
+	LookAndFeelData getLookAndFeelData() const;
 
 	TableFloatingTileBase(FloatingTile* parent);
 	void initTable(bool addChannelColumn=false);
@@ -718,7 +741,13 @@ public:
 	virtual ~TableFloatingTileBase() {};
 
 	void updateContent();
-	void fromDynamicObject(const var& object);
+
+	int getNumDefaultableProperties() const override { return (int)SpecialPanelIds::numSpecialPanelIds; }
+	Identifier getDefaultablePropertyId(int index) const override;
+	var getDefaultProperty(int index) const override;
+	var toDynamicObject() const override;
+	void fromDynamicObject(const var& object) override;
+
 	void paintRowBackground(Graphics& g, int /*rowNumber*/, int /*width*/, int /*height*/, bool rowIsSelected) override;
 
 	//==============================================================================
@@ -817,8 +846,6 @@ protected:
 	private:
 		TableFloatingTileBase &owner;
 
-		HiPropertyPanelLookAndFeel laf;
-
 		int row;
 		int columnId;
 
@@ -835,7 +862,7 @@ protected:
 		void setRowAndColumn(const int newRow, bool value);
 		void buttonClicked(Button *b);;
 
-		ScopedPointer<TextButton> t;
+		ScopedPointer<ToggleButton> t;
 
 	private:
 
@@ -849,8 +876,11 @@ protected:
 	TableListBox table;     // the table component itself
 	Font font;
 	int numRows;            // The number of rows of data we've got
+	Array<var> columnWidthRatios;
+	bool hasChannelColumn = false;
 	ScopedPointer<TableHeaderLookAndFeel> laf;
 	ScopedPointer<simple_css::StyleSheetLookAndFeel> css_laf;
+	LookAndFeelMethods fallbackLaf;
 };
 
 

--- a/hi_scripting/scripting/api/ScriptTableListModel.cpp
+++ b/hi_scripting/scripting/api/ScriptTableListModel.cpp
@@ -714,8 +714,21 @@ ScriptTableListModel::LookAndFeelData ScriptTableListModel::LookAndFeelMethods::
 		{
 			return st->d;
 		}
+
+		if (auto ft = dynamic_cast<TableFloatingTileBase*>(table->getModel()))
+		{
+			auto ftd = ft->getLookAndFeelData();
+			LookAndFeelData d;
+			d.f = ftd.f;
+			d.textColour = ftd.textColour;
+			d.bgColour = ftd.bgColour;
+			d.itemColour1 = ftd.itemColour1;
+			d.itemColour2 = ftd.itemColour2;
+			d.itemColour3 = ftd.itemColour3;
+			return d;
+		}
 	}
-	
+
 	return {};
 }
 

--- a/hi_scripting/scripting/api/ScriptTableListModel.cpp
+++ b/hi_scripting/scripting/api/ScriptTableListModel.cpp
@@ -720,6 +720,7 @@ ScriptTableListModel::LookAndFeelData ScriptTableListModel::LookAndFeelMethods::
 			auto ftd = ft->getLookAndFeelData();
 			LookAndFeelData d;
 			d.f = ftd.f;
+			d.fontName = ftd.fontName;
 			d.textColour = ftd.textColour;
 			d.bgColour = ftd.bgColour;
 			d.itemColour1 = ftd.itemColour1;

--- a/hi_scripting/scripting/api/ScriptTableListModel.h
+++ b/hi_scripting/scripting/api/ScriptTableListModel.h
@@ -75,6 +75,7 @@ struct ScriptTableListModel : public juce::TableListBoxModel,
 		bool sortForward = true;
 
 		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
 		Justification c = Justification::centredLeft;
 		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
 	};

--- a/hi_scripting/scripting/api/ScriptTableListModel.h
+++ b/hi_scripting/scripting/api/ScriptTableListModel.h
@@ -76,7 +76,7 @@ struct ScriptTableListModel : public juce::TableListBoxModel,
 
 		Font f = GLOBAL_BOLD_FONT();
 		Justification c = Justification::centredLeft;
-		Colour textColour, bgColour, itemColour1, itemColour2;
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
 	};
 
 	struct LookAndFeelMethods

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4444,12 +4444,26 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawToggleButton(Graphics &g_, 
 		obj->setProperty("down", b.isMouseButtonDown(true));
 		obj->setProperty("value", b.getToggleState());
 
-		setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
-		setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
-		setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
-		setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
-
-		addParentFloatingTile(b, obj);
+		if (auto ft = b.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.f.getTypefaceName());
+		}
+		else
+		{
+			setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
+			setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
+			setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
+			setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
+			addParentFloatingTile(b, obj);
+		}
 
 		if (get()->callWithGraphics(g_, "drawToggleButton", var(obj), &b))
 			return;
@@ -4568,7 +4582,25 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawLinearSlider(Graphics &g, i
 			setColourOrBlack(obj, "textColour", *parentPack, Slider::trackColourId);
 		}
 
-		addParentFloatingTile(slider, obj);
+		if (auto ft = slider.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.f.getTypefaceName());
+
+			slider.setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
+			slider.setTextBoxStyle(Slider::NoTextBox, true, 0, 0);
+		}
+		else
+		{
+			addParentFloatingTile(slider, obj);
+		}
 
 		if (get()->callWithGraphics(g, "drawLinearSlider", var(obj), &slider))
 			return;
@@ -4973,11 +5005,25 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 		obj->setProperty("vertical", isScrollbarVertical);
 		obj->setProperty("over", isMouseOver);
 		obj->setProperty("down", isMouseDown);
-		setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
-		setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
-		setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
-
-		addParentFloatingTile(scrollbar, obj);
+		if (auto ft = scrollbar.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("font", d.f.getTypefaceName());
+			obj->setProperty("fontSize", d.f.getHeight());
+		}
+		else
+		{
+			setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
+			setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
+			setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+			addParentFloatingTile(scrollbar, obj);
+		}
 
 		if (get()->callWithGraphics(g_, "drawScrollbar", var(obj), &scrollbar))
 			return;
@@ -5432,7 +5478,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("rowIndex", rowNumber);
 		obj->setProperty("selected", rowIsSelected);
@@ -5458,7 +5507,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, con
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", text);
 		obj->setProperty("rowIndex", rowNumber);
@@ -5489,10 +5541,15 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderBackground(Graph
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		auto a = h.getLocalBounds();
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		addParentFloatingTile(h, obj);
 
 		if (get()->callWithGraphics(g_, "drawTableHeaderBackground", var(obj), &h))
 			return;
@@ -5512,10 +5569,13 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", columnName);
-		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("columnIndex", h.getIndexOfColumnId(columnId, true));
 		obj->setProperty("hover", isMouseOver);
 		obj->setProperty("down", isMouseDown);
 
@@ -5526,11 +5586,76 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
 
+		addParentFloatingTile(h, obj);
+
 		if (get()->callWithGraphics(g_, "drawTableHeaderColumn", var(obj), &h))
 			return;
 	}
 
 	drawDefaultTableHeaderColumn(g_, h, columnName, columnId, width, height, isMouseOver, isMouseDown, columnFlags);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (functionDefined("drawTableRowBackground"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("hover", rowIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableRowBackground", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(g_, d, rowNumber, width, height, rowIsSelected, rowIsHovered);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	if (functionDefined("drawTableCell"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("text", text);
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("clicked", cellIsClicked);
+		obj->setProperty("hover", cellIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableCell", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableCell(g_, d, text, rowNumber, columnId, width, height, rowIsSelected, cellIsClicked, cellIsHovered);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawMatrixPeakMeter(Graphics& g_, float* peakValues, float* maxPeaks, int numChannels, bool isVertical, float segmentSize, float paddingSize, Component* c)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4454,7 +4454,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawToggleButton(Graphics &g_, 
 			obj->setProperty("textColour", d.textColour.getARGB());
 			obj->setProperty("parentType", d.parentType);
 			obj->setProperty("fontSize", d.f.getHeight());
-			obj->setProperty("font", d.f.getTypefaceName());
+			obj->setProperty("font", d.fontName);
 		}
 		else
 		{
@@ -4592,7 +4592,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawLinearSlider(Graphics &g, i
 			obj->setProperty("textColour", d.textColour.getARGB());
 			obj->setProperty("parentType", d.parentType);
 			obj->setProperty("fontSize", d.f.getHeight());
-			obj->setProperty("font", d.f.getTypefaceName());
+			obj->setProperty("font", d.fontName);
 
 			slider.setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
 			slider.setTextBoxStyle(Slider::NoTextBox, true, 0, 0);
@@ -5014,7 +5014,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
 			obj->setProperty("textColour", d.textColour.getARGB());
 			obj->setProperty("parentType", d.parentType);
-			obj->setProperty("font", d.f.getTypefaceName());
+			obj->setProperty("font", d.fontName);
 			obj->setProperty("fontSize", d.f.getHeight());
 		}
 		else
@@ -5480,7 +5480,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("rowIndex", rowNumber);
@@ -5509,7 +5509,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, con
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", text);
@@ -5543,7 +5543,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderBackground(Graph
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		auto a = h.getLocalBounds();
@@ -5571,7 +5571,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", columnName);
@@ -5606,7 +5606,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("rowIndex", rowNumber);
@@ -5636,7 +5636,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, con
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
 		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
-		obj->setProperty("font", d.f.getTypefaceName());
+		obj->setProperty("font", d.fontName);
 		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", text);

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -834,6 +834,7 @@ namespace ScriptingObjects
 			public CustomKeyboardLookAndFeelBase,
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
+			public TableFloatingTileBase::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
 			public HiSlider::HoverPopupLookandFeel
 		{
@@ -937,6 +938,10 @@ namespace ScriptingObjects
 			void drawTableHeaderBackground(Graphics& g, TableHeaderComponent& h) override;
 
 			void drawTableHeaderColumn(Graphics& g, TableHeaderComponent&, const String& columnName, int columnId, int width, int height, bool isMouseOver, bool isMouseDown, int columnFlags) override;
+
+			void drawTableRowBackground(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered) override;
+
+			void drawTableCell(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered) override;
 
             void getIdealPopupMenuItemSize(const String &text, bool isSeparator, int standardMenuItemHeight, int &idealWidth, int &idealHeight) override;
             


### PR DESCRIPTION
…roPanel

Enables full LAF customisation of TableFloatingTileBase panels:

- Route drawTableHeaderBackground, drawTableHeaderColumn, drawTableCell, drawToggleButton, drawLinearSlider, and drawScrollbar through the scripted look-and-feel system
- Pass all floating tile colour properties (bgColour, itemColour1-3, textColour), font, fontSize, and parentType to LAF callbacks
- Add ColumnWidthRatio property for configurable column proportions
- Account for scrollbar thickness in column width calculations, only reserving space when the scrollbar is actually visible
- Change InvertedButton from TextButton to ToggleButton for drawToggleButton support
- Set component IDs on min/max sliders and hide text boxes when drawLinearSlider LAF is active

https://claude.ai/code/session_01E1nPYm3ugRjMYoHCwRZkR4