### PR TITLE
Pass viewport colour properties to drawScrollbar look and feel function

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1875,7 +1875,19 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateComponent()
 		auto vp = dynamic_cast<Viewport*>(component.get());
 
 		vp->setScrollBarThickness(vpc->getScriptObjectProperty(ScriptingApi::Content::ScriptedViewport::Properties::scrollbarThickness));
-		vp->setColour(ScrollBar::ColourIds::thumbColourId, GET_OBJECT_COLOUR(itemColour));
+
+		auto bgColour = GET_OBJECT_COLOUR(bgColour);
+		auto itemColour1 = GET_OBJECT_COLOUR(itemColour);
+		auto itemColour2 = GET_OBJECT_COLOUR(itemColour2);
+		auto tc = GET_OBJECT_COLOUR(textColour);
+
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		vp->getProperties().set("textColour", (int64)tc.getARGB());
 	}
 	else
 	{
@@ -1926,7 +1938,35 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateComponent(int proper
 		switch (propertyIndex)
 		{
 			PROPERTY_CASE::ScriptedViewport::Properties::scrollbarThickness: vp->setScrollBarThickness(newValue); break;
-			PROPERTY_CASE::ScriptComponent::itemColour: vp->setColour(ScrollBar::ColourIds::thumbColourId, GET_OBJECT_COLOUR(itemColour)); break;
+			PROPERTY_CASE::ScriptComponent::bgColour:
+			{
+				auto c = GET_OBJECT_COLOUR(bgColour);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::itemColour:
+			{
+				auto c = GET_OBJECT_COLOUR(itemColour);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::itemColour2:
+			{
+				auto c = GET_OBJECT_COLOUR(itemColour2);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::textColour:
+			{
+				auto c = GET_OBJECT_COLOUR(textColour);
+				vp->getProperties().set("textColour", (int64)c.getARGB());
+				vp->getVerticalScrollBar().repaint();
+				vp->getHorizontalScrollBar().repaint();
+				break;
+			}
 		}
 	}
 }
@@ -2038,7 +2078,14 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateColours()
 			tableModel->setColours(textColour, bgColour, itemColour1, itemColour2);
 		}
 
-		listBox->getViewport()->setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		auto lbvp = listBox->getViewport();
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		lbvp->getProperties().set("textColour", (int64)textColour.getARGB());
 
 		listBox->setColour(ListBox::ColourIds::backgroundColourId, bgColour);
 		listBox->setColour(ListBox::ColourIds::outlineColourId, itemColour2);

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4977,7 +4977,40 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 		setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
 		setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
 
-		addParentFloatingTile(scrollbar, obj);
+			if (getIdOfParentFloatingTile(scrollbar) == pb)
+			{
+				obj->setProperty("bgColour", backgroundColour.getARGB());
+				obj->setProperty("itemColour1", highlightColour.getARGB());
+				obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+				obj->setProperty("itemColour3", itemColour3.getARGB());
+				obj->setProperty("textColour", textColour.getARGB());
+				obj->setProperty("parentType", pb.toString());
+			}
+			else
+			{
+				setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
+				setColourOrBlack(obj, "itemColour1",  scrollbar, ScrollBar::ColourIds::thumbColourId);
+				setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+
+				if (auto vp = scrollbar.findParentComponentOfClass<juce::Viewport>())
+				{
+					auto id = vp->getComponentID();
+
+					// For Viewport mode, the ID is on the Viewport itself.
+					// For List/Table mode, the ID is on the parent ListBox.
+					if (id.isEmpty() && vp->getParentComponent() != nullptr)
+						id = vp->getParentComponent()->getComponentID();
+
+					if (id.isNotEmpty())
+						obj->setProperty("id", id);
+
+					if (vp->getProperties().contains("textColour"))
+						obj->setProperty("textColour", (int64)vp->getProperties()["textColour"]);
+				}
+
+				addParentFloatingTile(scrollbar, obj);
+			}
+		}
 
 		if (get()->callWithGraphics(g_, "drawScrollbar", var(obj), &scrollbar))
 			return;


### PR DESCRIPTION
When using drawScrollbar with a ScriptedViewport, the viewport's colour properties (bgColour, itemColour1, itemColour2, textColour) and  component
id are now available in the look and feel object. Previously only itemColour (thumbColourId) was forwarded in Viewport mode and the scrollbar had no way to identify its parent viewport. https://claude.ai/code/session_011TU5VtPPhYL242EHJRkQKU