### PR TITLE
Fix CSS setStyleSheetProperty value converter for unit suffixes

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -182,6 +182,14 @@ var ApiHelpers::convertStyleSheetProperty(const var& value, const String& type)
 	{
 		return var(String("#") + ApiHelpers::getColourFromVar(value).toDisplayString(true));
 	}
+	else if(type == "%")
+	{
+		return var(String((double)value * 100.0) + "%");
+	}
+	else if(type == "px" || type == "em" || type == "vh" || type == "deg")
+	{
+		return var(String((double)value) + type);
+	}
 
 	return value;
 }


### PR DESCRIPTION
## Summary
`setStyleSheetProperty()` ignored CSS unit suffixes like `"%"`, `"px"`, `"em"`, `"vh"`, and `"deg"` passed as the `type` parameter. The value was stored as a raw number, so the CSS engine never saw the unit. For example, `laf.setStyleSheetProperty("myProp", 0.5, "%")` stored `0.5` instead of `"50%"`.

The fix adds handling for these unit types in `ApiHelpers::convertStyleSheetProperty()`, following the same pattern as the existing `"path"` and `"color"` branches.

Fixes #769

### Risk Assessment

**Change type:** Bugfix

**Evidence:** The existing `"path"` and `"color"` branches in `convertStyleSheetProperty()` (`ScriptingApi.cpp:174`) already convert values to CSS-compatible strings. This fix adds the missing unit suffix branches following the same pattern. The CSS expression parser (`CssParser.cpp:890` `evaluateLiteral()`) already handles `%`, `px`, `em`, `vh`, `deg` — it just needs the suffix to be present in the string.

**Impact check:**
- [ ] Modifies DSP or audio rendering code
- [ ] Modifies module parameter indices or attribute enums
- [ ] Modifies serialization (exportAsValueTree / restoreFromValueTree)
- [ ] Modifies code with USE_BACKEND / USE_FRONTEND guards
- [ ] Modifies scripting engine (parser, preprocessor, include system)
- [ ] Adds per-instance objects to a module (chains, processors, buffers)
- [ ] Could change behavior of existing HISEScript projects
- [ ] Could change how existing projects sound or perform

**Testing:** Verified with a test script using `laf.setStyleSheetProperty()` with `"%"` suffix — panel width correctly renders at 50% after fix.

**Files changed:** 1 file, +8/-0 lines
**Maintainer guidance:** N/A
**AI Conversation:** N/A
