### PR TITLE
Add drawThumbnailMarkers and extend drawThumbnailRange LAF functions

### DIFF
--- a/hi_core/hi_components/audio_components/SampleComponents.cpp
+++ b/hi_core/hi_components/audio_components/SampleComponents.cpp
@@ -489,7 +489,7 @@ struct SamplerLaf : public HiseAudioThumbnail::LookAndFeelMethods,
 		g.fillRectList(rectList);
 	}
 
-	void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled) override
+	void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed) override
 	{
 		if (areaIndex == AudioDisplayComponent::AreaTypes::PlayArea)
 		{
@@ -498,6 +498,11 @@ struct SamplerLaf : public HiseAudioThumbnail::LookAndFeelMethods,
 			g.setColour(c.withAlpha(areaEnabled ? 0.4f : 0.2f));
 
 			ug.draw1PxRect(area);
+		}
+		else if (areaIndex == AudioDisplayComponent::AreaTypes::LoopCrossfadeArea || areaIndex == 4)
+		{
+			// Crossfade and release start use the default fade path drawing
+			HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRange(g, te, area, areaIndex, c, areaEnabled, gamma, reversed);
 		}
 		else
 		{
@@ -525,7 +530,7 @@ struct SamplerLaf : public HiseAudioThumbnail::LookAndFeelMethods,
 
 				break;
 			}
-			
+
 			case AudioDisplayComponent::AreaTypes::LoopArea:
 			{
 				g.setColour(c.withAlpha(areaEnabled ? 0.1f : 0.04f));
@@ -547,16 +552,28 @@ struct SamplerLaf : public HiseAudioThumbnail::LookAndFeelMethods,
 				break;
 			}
 			}
-			
+
 			const static StringArray names = { "play",  "samplestart", "loop", "xfade"};
 
-			if (area.getWidth() > 30)
+			if (areaIndex < names.size() && area.getWidth() > 30)
 			{
 				auto p = createPath(names[areaIndex]);
 				scalePath(p, area.removeFromRight(24.0f).removeFromTop(24.0f).reduced(4.0f));
 				g.setColour(c);
 				g.fillPath(p);
 			}
+		}
+	}
+
+	void drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled) override
+	{
+		// Only draw the release start marker here; other markers are already
+		// handled by drawThumbnailRange in the workspace view.
+		if (markerIndex == 4) // ReleaseStart
+		{
+			g.setColour(c.withAlpha(0.7f));
+			g.drawVerticalLine(roundToInt(x), 0.0f, h);
+			g.fillRect(x, 0.0f, 30.0f, 7.0f);
 		}
 	}
 };
@@ -640,13 +657,13 @@ void SamplerSoundWaveform::updateRange(AreaTypes a, bool refreshBounds)
 		break;
 	case hise::AudioDisplayComponent::SampleStartArea:
 	{
-		
+
 
 		auto isReversed = currentSound->getReferenceToSound(0)->isReversed();
 
 		Range<int> displayArea;
 		Range<int> leftDragRange, rightDragRange;
-		
+
 		auto startMod = (int)currentSound->getSampleProperty(SampleIds::SampleStartMod);
 
 		if (isReversed)
@@ -666,9 +683,10 @@ void SamplerSoundWaveform::updateRange(AreaTypes a, bool refreshBounds)
 			leftDragRange = currentSound->getPropertyRange(SampleIds::SampleStart);
 			rightDragRange = currentSound->getPropertyRange(SampleIds::SampleStartMod) + offset;
 		}
-		
+
 		area->setSampleRange(displayArea);
 		area->setAllowedPixelRanges(leftDragRange, rightDragRange);
+		area->setVisible(startMod > 0);
 		break;
 	}
 	case hise::AudioDisplayComponent::LoopArea:
@@ -701,6 +719,7 @@ void SamplerSoundWaveform::updateRange(AreaTypes a, bool refreshBounds)
 		}
 
 		area->setSampleRange(Range<int>(start, end));
+		area->setVisible(currentSound->getSampleProperty(SampleIds::LoopEnabled) && (end - start) > 0);
 		break;
 	}
 	case hise::AudioDisplayComponent::numAreas:
@@ -794,39 +813,64 @@ void SamplerSoundWaveform::paintOverChildren(Graphics &g)
 {
 	AudioDisplayComponent::paintOverChildren(g);
 
-	#if HISE_SAMPLER_ALLOW_RELEASE_START
 	if(currentSound != nullptr)
 	{
-		auto rs = (int)currentSound->getSampleProperty(SampleIds::ReleaseStart);
-
-		if(rs != 0)
+		if(auto laf = dynamic_cast<HiseAudioThumbnail::LookAndFeelMethods*>(&getThumbnail()->getLookAndFeel()))
 		{
-			auto xOffset = roundToInt((double)getWidth() * (rs) / (double)getTotalSampleAmount());
-			auto rc = SampleArea::getReleaseStartColour();
+			auto h = (float)getHeight();
+			auto playAreaX = (float)areas[PlayArea]->getX();
 
-			g.setColour(rc.withAlpha(0.7f));
-			g.drawVerticalLine(xOffset, 0.0f, (float)getHeight());
-			g.fillRect((float)xOffset, 0.0f, 30.0f, JUCE_LIVE_CONSTANT_OFF(7.0f));
+			// 0: SampleStart marker
+			if(areas[SampleStartArea]->getSampleRange().getLength() != 0)
+			{
+				auto x = playAreaX + (float)areas[SampleStartArea]->getRight();
+				auto c = SampleArea::getAreaColour(SampleStartArea);
+				laf->drawThumbnailMarker(g, *getThumbnail(), x, h, 0, c, areas[SampleStartArea]->isAreaEnabled());
+			}
 
-			auto options = sampler->getSampleMap()->getReleaseStartOptions();
+			// 1: LoopStart marker, 2: LoopEnd marker
+			if(areas[LoopArea]->isVisible())
+			{
+				auto c = SampleArea::getAreaColour(LoopArea);
+				auto enabled = areas[LoopArea]->isAreaEnabled();
+				laf->drawThumbnailMarker(g, *getThumbnail(), playAreaX + (float)areas[LoopArea]->getX(), h, 1, c, enabled);
+				laf->drawThumbnailMarker(g, *getThumbnail(), playAreaX + (float)areas[LoopArea]->getRight(), h, 2, c, enabled);
+			}
 
-			g.setColour(rc.withAlpha(0.2f));
+			// 3: LoopCrossfade marker
+			if(areas[LoopArea]->isVisible() && areas[LoopCrossfadeArea]->getSampleRange().getLength() > 0)
+			{
+				auto c = SampleArea::getAreaColour(LoopCrossfadeArea);
+				auto enabled = areas[LoopCrossfadeArea]->isAreaEnabled();
+				auto isReversed = currentSound->getReferenceToSound(0)->isReversed();
+				auto x = isReversed ? playAreaX + (float)areas[LoopCrossfadeArea]->getRight()
+				                    : playAreaX + (float)areas[LoopCrossfadeArea]->getX();
 
-			auto fadeWidth = roundToInt((double)getWidth() * (double)options->releaseFadeTime / (double)getTotalSampleAmount());
-			Rectangle<float> fadeArea((float)xOffset, 0.0f, (float)fadeWidth, (float)getHeight());
-			g.fillRect(fadeArea.toFloat());
+				laf->drawThumbnailMarker(g, *getThumbnail(), x, h, 3, c, enabled);
+			}
 
-			Path p;
+			// 4: ReleaseStart marker and range
+			#if HISE_SAMPLER_ALLOW_RELEASE_START
+			{
+				auto rs = (int)currentSound->getSampleProperty(SampleIds::ReleaseStart);
 
-			p.startNewSubPath(0.0f, 0.0f);
-			p.quadraticTo(0.5f, std::pow(0.5f, options->fadeGamma), 1.0f, 1.0f);
-			p.scaleToFit(fadeArea.getX(), fadeArea.getY(), fadeArea.getWidth(), fadeArea.getHeight(), false);
-			g.setColour(rc.withAlpha(0.7f));
-			g.strokePath(p, PathStrokeType(1.0f));
+				if(rs != 0)
+				{
+					auto xOffset = (float)roundToInt((double)getWidth() * (rs) / (double)getTotalSampleAmount());
+					auto rc = SampleArea::getReleaseStartColour();
+
+					laf->drawThumbnailMarker(g, *getThumbnail(), xOffset, h, 4, rc, true);
+
+					auto options = sampler->getSampleMap()->getReleaseStartOptions();
+					auto fadeWidth = roundToInt((double)getWidth() * (double)options->releaseFadeTime / (double)getTotalSampleAmount());
+					Rectangle<float> fadeArea(xOffset, 0.0f, (float)fadeWidth, h);
+
+					laf->drawThumbnailRange(g, *getThumbnail(), fadeArea, 4, rc, true, options->fadeGamma);
+				}
+			}
+			#endif
 		}
-
 	}
-	#endif
 
 	if (xPos != -1)
 	{
@@ -877,6 +921,9 @@ void SamplerSoundWaveform::resized()
 	{
 		for (auto a : areas)
 		{
+			if (a == areas[PlayArea])
+				continue;
+
 			a->setVisible(a->isAreaEnabled());
 		}
 	}

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -2900,6 +2900,10 @@ void ScriptCreatedComponentWrappers::AudioWaveformWrapper::updateColours(AudioDi
 	tn->setColour(AudioDisplayComponent::ColourIds::fillColour, GET_OBJECT_COLOUR(itemColour2));
 	tn->setColour(AudioDisplayComponent::ColourIds::textColour, GET_OBJECT_COLOUR(textColour));
 
+	auto ic3 = ScriptingApi::Content::Helpers::getCleanedObjectColour(
+		getScriptComponent()->getScriptObjectProperty(
+			(int)ScriptingApi::Content::ScriptAudioWaveform::Properties::itemColour3));
+	tn->setColour(AudioDisplayComponent::ColourIds::itemColour3Id, ic3);
 
 	asb->repaint();
 	tn->repaint();

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -3748,9 +3748,15 @@ void ScriptingObjects::ScriptedLookAndFeel::CSSLaf::drawTextOverlay(Graphics& g,
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::CSSLaf::drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te,
-	Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled)
+	Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed)
 {
-				
+
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::CSSLaf::drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th,
+	float x, float h, int markerIndex, Colour c, bool enabled)
+{
+	HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailMarker(g, th, x, h, markerIndex, c, enabled);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::CSSLaf::drawStretchableLayoutResizerBar(Graphics& g, Component& resizer,
@@ -5222,7 +5228,7 @@ HiseAudioThumbnail::RenderOptions ScriptingObjects::ScriptedLookAndFeel::Laf::ge
     return defaultOptions;
 }
 
-void ScriptingObjects::ScriptedLookAndFeel::Laf::drawThumbnailRange(Graphics& g_, HiseAudioThumbnail& th, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled)
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawThumbnailRange(Graphics& g_, HiseAudioThumbnail& th, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed)
 {
 	if (functionDefined("drawThumbnailRange"))
 	{
@@ -5232,6 +5238,8 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawThumbnailRange(Graphics& g_
 		obj->setProperty("rangeIndex", areaIndex);
 		obj->setProperty("rangeColour", c.getARGB());
 		obj->setProperty("enabled", areaEnabled);
+		obj->setProperty("gamma", gamma);
+		obj->setProperty("reversed", reversed);
 
 		setColourOrBlack(obj, "bgColour", th, AudioDisplayComponent::ColourIds::bgColour);
 		setColourOrBlack(obj, "itemColour", th, AudioDisplayComponent::ColourIds::fillColour);
@@ -5241,7 +5249,34 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawThumbnailRange(Graphics& g_
 			return;
 	}
 
-	HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRange(g_, th, area, areaIndex, c, areaEnabled);
+	HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRange(g_, th, area, areaIndex, c, areaEnabled, gamma, reversed);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawThumbnailMarker(Graphics& g_, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled)
+{
+	if (functionDefined("drawThumbnailMarkers"))
+	{
+		static const StringArray markerIds = { "SampleStart", "LoopStart", "LoopEnd", "LoopCrossfade", "ReleaseStart" };
+
+		auto obj = new DynamicObject();
+		writeId(obj, &th);
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, th.getLocalBounds().toFloat()));
+		obj->setProperty("xPosition", x);
+		obj->setProperty("index", markerIndex);
+		obj->setProperty("id", markerIndex < markerIds.size() ? markerIds[markerIndex] : String());
+		obj->setProperty("enabled", enabled);
+
+		setColourOrBlack(obj, "bgColour", th, AudioDisplayComponent::ColourIds::bgColour);
+		setColourOrBlack(obj, "itemColour1", th, AudioDisplayComponent::ColourIds::outlineColour);
+		setColourOrBlack(obj, "itemColour2", th, AudioDisplayComponent::ColourIds::fillColour);
+		setColourOrBlack(obj, "itemColour3", th, AudioDisplayComponent::ColourIds::itemColour3Id);
+		setColourOrBlack(obj, "textColour", th, AudioDisplayComponent::ColourIds::textColour);
+
+		if (get()->callWithGraphics(g_, "drawThumbnailMarkers", var(obj), &th))
+			return;
+	}
+
+	HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailMarker(g_, th, x, h, markerIndex, c, enabled);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTextOverlay(Graphics& g_, HiseAudioThumbnail& th, const String& text, Rectangle<float> area)
@@ -5252,7 +5287,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTextOverlay(Graphics& g_, H
 		writeId(obj, &th);
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, area));
 		obj->setProperty("text", text);
-		
+
 		if (get()->callWithGraphics(g_, "drawThumbnailText", var(obj), &th))
 			return;
 	}

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -910,14 +910,16 @@ namespace ScriptingObjects
 
 			void drawMidiDropper(Graphics& g, Rectangle<float> area, const String& text, MidiFileDragAndDropper& d) override;
 
-            void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled);
+            void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed) override;
             void drawHiseThumbnailBackground(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, Rectangle<int> area) override;
             void drawHiseThumbnailPath(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const Path& path) override;
             void drawHiseThumbnailRectList(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const HiseAudioThumbnail::RectangleListType& rectList) override;
 
             HiseAudioThumbnail::RenderOptions getThumbnailRenderOptions(HiseAudioThumbnail& th, const HiseAudioThumbnail::RenderOptions& defaultOptions) override;
-            
+
 			void drawThumbnailRuler(Graphics& g, HiseAudioThumbnail& te, int xPosition) override;
+
+			void drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled) override;
 
             void drawTextOverlay(Graphics& g, HiseAudioThumbnail& th, const String& text, Rectangle<float> area) override;
             
@@ -1036,7 +1038,8 @@ namespace ScriptingObjects
 			void drawHiseThumbnailPath(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const Path& path) override;
 			void drawHiseThumbnailRectList(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const HiseAudioThumbnail::RectangleListType& rectList) override;
 			void drawTextOverlay(Graphics& g, HiseAudioThumbnail& th, const String& text, Rectangle<float> area) override;
-			void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled) override;
+			void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed) override;
+			void drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled) override;
 			void drawStretchableLayoutResizerBar (Graphics &g, Component& resizer, int w, int h, bool isVerticalBar, bool isMouseOver, bool isMouseDragging) override;
 			void drawThumbnailRuler(Graphics& g, HiseAudioThumbnail& te, int xPosition) override;
 
@@ -1183,9 +1186,14 @@ namespace ScriptingObjects
 				CALL_LAF_ID("drawThumbnailText", drawTextOverlay, g, th, text, area);
 			}
 
-			void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled) override
+			void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed) override
 			{
-				CALL_LAF(drawThumbnailRange, g, te, area, areaIndex, c, areaEnabled);
+				CALL_LAF(drawThumbnailRange, g, te, area, areaIndex, c, areaEnabled, gamma, reversed);
+			}
+
+			void drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled) override
+			{
+				CALL_LAF_ID("drawThumbnailMarkers", drawThumbnailMarker, g, th, x, h, markerIndex, c, enabled);
 			}
 
 			void drawStretchableLayoutResizerBar (Graphics &g, Component& resizer, int w, int h, bool isVerticalBar, bool isMouseOver, bool isMouseDragging) override

--- a/hi_tools/hi_standalone_components/SampleDisplayComponent.cpp
+++ b/hi_tools/hi_standalone_components/SampleDisplayComponent.cpp
@@ -726,15 +726,87 @@ void AudioDisplayComponent::SampleArea::mouseDrag(const MouseEvent& e)
 	parentWaveform->refreshSampleAreaBounds(this);
 };
 
-void HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled)
+void HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma, bool reversed)
 {
-    UnblurryGraphics ug(g, te, true);
-    
-    g.setColour(c.withAlpha(areaEnabled ? 0.1f : 0.02f));
-    g.fillAll();
+    if (areaIndex == AudioDisplayComponent::AreaTypes::LoopCrossfadeArea)
+    {
+        Path fadePath;
 
-    g.setColour(c.withAlpha(0.3f));
-    ug.draw1PxRect(area);
+        auto w = area.getWidth();
+        auto h = area.getHeight();
+
+        if (!reversed)
+        {
+            fadePath.startNewSubPath(area.getX(), area.getBottom());
+
+            if (gamma == 1.0f)
+            {
+                fadePath.lineTo(area.getRight(), area.getY());
+                fadePath.lineTo(area.getRight(), area.getBottom());
+            }
+            else
+            {
+                for (float x = 0.0f; x < w; x += 3.0f)
+                {
+                    float gain = x / w;
+                    gain = std::pow(gain, gamma);
+                    fadePath.lineTo(area.getX() + x, area.getBottom() - gain * h);
+                }
+                fadePath.lineTo(area.getRight(), area.getBottom());
+            }
+
+            fadePath.closeSubPath();
+        }
+        else
+        {
+            if (gamma == 1.0f)
+            {
+                fadePath.startNewSubPath(area.getX(), area.getY());
+                fadePath.lineTo(area.getRight(), area.getBottom());
+                fadePath.lineTo(area.getX(), area.getBottom());
+            }
+            else
+            {
+                fadePath.startNewSubPath(area.getRight(), area.getBottom());
+                for (float x = 0.0f; x < w; x += 3.0f)
+                {
+                    float gain = x / w;
+                    gain = std::pow(gain, gamma);
+                    fadePath.lineTo(area.getRight() - x, area.getBottom() - gain * h);
+                }
+                fadePath.lineTo(area.getX(), area.getBottom());
+            }
+
+            fadePath.closeSubPath();
+        }
+
+        g.setColour(c.withAlpha(areaEnabled ? 0.1f : 0.05f));
+        g.fillPath(fadePath);
+        g.setColour(c.withAlpha(0.3f));
+        g.strokePath(fadePath, PathStrokeType(1.0f));
+    }
+    else if (areaIndex == 4) // ReleaseStartArea
+    {
+        g.setColour(c.withAlpha(0.2f));
+        g.fillRect(area);
+
+        Path p;
+        p.startNewSubPath(0.0f, 0.0f);
+        p.quadraticTo(0.5f, std::pow(0.5f, gamma), 1.0f, 1.0f);
+        p.scaleToFit(area.getX(), area.getY(), area.getWidth(), area.getHeight(), false);
+        g.setColour(c.withAlpha(0.7f));
+        g.strokePath(p, PathStrokeType(1.0f));
+    }
+    else
+    {
+        UnblurryGraphics ug(g, te, true);
+
+        g.setColour(c.withAlpha(areaEnabled ? 0.1f : 0.02f));
+        g.fillAll();
+
+        g.setColour(c.withAlpha(0.3f));
+        ug.draw1PxRect(area);
+    }
 }
 
 void HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRuler(Graphics& g, HiseAudioThumbnail& te, int x)
@@ -749,88 +821,26 @@ void HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailRuler(Graphics& g, His
 	g.drawLine(l, 0.5f);
 }
 
+void HiseAudioThumbnail::LookAndFeelMethods::drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled)
+{
+	g.setColour(c.withAlpha(enabled ? 0.8f : 0.4f));
+	g.drawVerticalLine(roundToInt(x), 0.0f, h);
+	g.fillRect(x, 0.0f, 20.0f, 5.0f);
+}
+
 void AudioDisplayComponent::SampleArea::paint(Graphics &g)
 {
-	if(area == AreaTypes::LoopCrossfadeArea)
-	{
-		Path fadeInPath;
+    if (!areaEnabled && area == AreaTypes::PlayArea)
+        return;
 
-		auto w = (float)getWidth();
-		auto h = (float)getHeight();
-		auto z = 0.0f;
-
-		
-
-		if (!reversed)
-		{
-			fadeInPath.startNewSubPath(z, h);
-
-			if (gamma == 1.0f)
-			{
-				fadeInPath.lineTo(w, z);
-				fadeInPath.lineTo(w, h);
-			}
-			else
-			{
-				for (float x = z; x < w; x += 3.0f)
-				{
-					float gain = (x - z) / w;
-					gain = std::pow(gain, gamma);
-					float y = h - gain * h;
-					fadeInPath.lineTo(x, y);
-				}
-
-				fadeInPath.lineTo(w, h);
-			}
-			
-			fadeInPath.closeSubPath();
-		}
-		else
-		{
-			
-
-			if (gamma == 1.0f)
-			{
-				fadeInPath.startNewSubPath(z, z);
-				fadeInPath.lineTo(w, h);
-				fadeInPath.lineTo(z, h);
-			}
-			else
-			{
-				fadeInPath.startNewSubPath(w, h);
-				for (float x = z; x < w; x += 3.0f)
-				{
-					float gain = (x - z) / w;
-					gain = std::pow(gain, gamma);
-					float y = h - gain * h;
-					fadeInPath.lineTo(w - x, y);
-				}
-
-				fadeInPath.lineTo(z, h);
-			}
-			
-			fadeInPath.closeSubPath();
-		}
-
-		g.setColour(getAreaColour((AreaTypes)area).withAlpha(areaEnabled ? 0.1f : 0.05f));
-		g.fillPath(fadeInPath);
-
-		g.setColour(getAreaColour((AreaTypes)area).withAlpha(0.3f));
-		PathStrokeType stroke(1.0f);
-		g.strokePath(fadeInPath, stroke);
-	}
-	else
-	{
-        auto p = findParentComponentOfClass<AudioDisplayComponent>();
-        if(auto laf = dynamic_cast<HiseAudioThumbnail::LookAndFeelMethods*>(&p->getThumbnail()->getLookAndFeel()))
-        {
-            auto a = getLocalBounds().toFloat();
-            
-            laf->drawThumbnailRange(g, *p->getThumbnail(), a, (int)area, getAreaColour((AreaTypes)area), areaEnabled);
-        }
-        else
-            jassertfalse;
-	}
+    auto p = findParentComponentOfClass<AudioDisplayComponent>();
+    if(auto laf = dynamic_cast<HiseAudioThumbnail::LookAndFeelMethods*>(&p->getThumbnail()->getLookAndFeel()))
+    {
+        auto a = getLocalBounds().toFloat();
+        laf->drawThumbnailRange(g, *p->getThumbnail(), a, (int)area, getAreaColour((AreaTypes)area), areaEnabled, gamma, reversed);
+    }
+    else
+        jassertfalse;
 }
 
 void AudioDisplayComponent::SampleArea::checkBounds()

--- a/hi_tools/hi_standalone_components/SampleDisplayComponent.h
+++ b/hi_tools/hi_standalone_components/SampleDisplayComponent.h
@@ -87,10 +87,12 @@ public:
 		virtual void drawHiseThumbnailPath(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const Path& path);
 		virtual void drawHiseThumbnailRectList(Graphics& g, HiseAudioThumbnail& th, bool areaIsEnabled, const RectangleListType& rectList);
 		virtual void drawTextOverlay(Graphics& g, HiseAudioThumbnail& th, const String& text, Rectangle<float> area);
-        virtual void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled);
+        virtual void drawThumbnailRange(Graphics& g, HiseAudioThumbnail& te, Rectangle<float> area, int areaIndex, Colour c, bool areaEnabled, float gamma = 1.0f, bool reversed = false);
 
 		virtual void drawThumbnailRuler(Graphics& g, HiseAudioThumbnail& te, int xPosition);
-        
+
+		virtual void drawThumbnailMarker(Graphics& g, HiseAudioThumbnail& th, float x, float h, int markerIndex, Colour c, bool enabled);
+
         virtual RenderOptions getThumbnailRenderOptions(HiseAudioThumbnail& te, const RenderOptions& defaultRenderOptions);
 	};
 
@@ -265,6 +267,7 @@ public:
 		outlineColour,
 		fillColour,
 		textColour,
+		itemColour3Id,
 		numColourIds,
 	};
 


### PR DESCRIPTION
Forum thread: https://forum.hise.audio/topic/5499/audiowaveform-laf

Add a new drawThumbnailMarker LAF function for customising the AudioWaveform marker rendering. The scripting obj includes xPosition, markerIndex, markerColour, enabled state, and all component colour properties (bgColour, itemColour, textColour).

Marker indices: 0=SampleStart, 1=LoopStart, 2=LoopEnd, 3=LoopCrossfade, 4=ReleaseStart

Extend drawThumbnailRange to support the loop crossfade range and release start fade range. Add gamma and reversed parameters to the virtual method (with backward-compatible defaults). The crossfade is now routed through drawThumbnailRange instead of being drawn directly in SampleArea::paint, and the release start fade area is routed through drawThumbnailRange from paintOverChildren.

Range indices: 0=PlayArea, 1=SampleStartArea, 2=LoopArea, 3=LoopCrossfadeArea, 4=ReleaseStartArea

Also fix marker positions when SampleStart > 0 by accounting for PlayArea's x offset, and add proper setVisible calls for SampleStartArea and LoopCrossfadeArea in updateRange so they render correctly on the scripting interface.

https://claude.ai/code/session_01NT7CPgBbvgopGVmGUMvQqd