### PR TITLE
Fix #868: MatrixModulator not responding to target changes from dropdown

### DIFF
--- a/hi_core/hi_modules/modulators/mods/MatrixModulator.cpp
+++ b/hi_core/hi_modules/modulators/mods/MatrixModulator.cpp
@@ -811,6 +811,27 @@ void MatrixModulator::onModeChange(const ValueTree& v, const Identifier& id)
 	}
 }
 
+void MatrixModulator::onTargetChange(const ValueTree& v, const Identifier& id)
+{
+	auto matches = MatrixIds::Helpers::matchesTarget(v, getMatrixTargetId());
+
+	bool hadItem = false;
+
+	for(auto i: items)
+	{
+		if(i->watcher.isRegisteredTo(v))
+		{
+			hadItem = true;
+			break;
+		}
+	}
+
+	if(matches && !hadItem)
+		onMatrixChange(v, true);
+	else if(!matches && hadItem)
+		onMatrixChange(v, false);
+}
+
 double MatrixModulator::getModeValue(const var& v)
 {
 	return (double)v;
@@ -848,6 +869,11 @@ void MatrixModulator::init()
 		                        { MatrixIds::SourceIndex, MatrixIds::Mode },
 		                        valuetree::AsyncMode::Synchronously,
 		                        BIND_MEMBER_FUNCTION_2(MatrixModulator::onModeChange));
+
+		targetWatcher.setCallback(globalMatrixData,
+		                          { MatrixIds::TargetId },
+		                          valuetree::AsyncMode::Synchronously,
+		                          BIND_MEMBER_FUNCTION_2(MatrixModulator::onTargetChange));
 
 		container->matrixProperties.propertyUpdateBroadcaster.addListener(*this, [](MatrixModulator& mm, MatrixIds::Helpers::Properties* p, const String& changedTarget)
 		{

--- a/hi_core/hi_modules/modulators/mods/MatrixModulator.h
+++ b/hi_core/hi_modules/modulators/mods/MatrixModulator.h
@@ -190,6 +190,7 @@ private:
 	void rebuildModList();
 	void onMatrixChange(const ValueTree& v, bool wasAdded);
 	void onModeChange(const ValueTree& v, const Identifier& id);
+	void onTargetChange(const ValueTree& v, const Identifier& id);
 	static double getModeValue(const var& v);
 	void init();
 
@@ -211,6 +212,7 @@ private:
 	ValueTree globalMatrixData;
 	valuetree::ChildListener connectionWatcher;
 	valuetree::RecursivePropertyListener modeWatcher;
+	valuetree::RecursivePropertyListener targetWatcher;
 
 	valuetree::PropertyListener inputRangeWatcher;
 	valuetree::PropertyListener outputRangeWatcher;


### PR DESCRIPTION
## Summary

When changing a modulation target from the matrix dropdown, the `TargetId` property is updated on the existing `Connection` ValueTree node. However, `MatrixModulator` only listened for:
1. **Child add/remove** via `connectionWatcher` (ChildListener)
2. **`SourceIndex` and `Mode` property changes** via `modeWatcher` (RecursivePropertyListener)

It did **not** listen for `TargetId` changes, so the old `MatrixModulator` kept its `Item` (audio continued on the old target) while the UI showed the new target.

## Fix

Added a `RecursivePropertyListener` (`targetWatcher`) that watches for `TargetId` changes on Connection nodes. When a change is detected, it checks whether the connection now matches this modulator's target (add Item) or no longer matches (remove Item), delegating to the existing `onMatrixChange()` logic.

This mirrors the pattern already used by `MatrixCableConnection::sourceTargetListener` at `ScriptModulationMatrix.cpp:249-252`.

Fixes #868

## Change Type
Bug fix -- gap-fill in an established listener pattern.

## Evidence
- **Direct sibling precedent:** `MatrixCableConnection` already watches `TargetId` via `sourceTargetListener` and handles add/remove correctly (`ScriptModulationMatrix.cpp:249-252, 393-402`)
- **Pattern match:** Uses the same `RecursivePropertyListener` + `matchesTarget()` pattern as the existing `modeWatcher`
- **Reuse:** Delegates to existing `onMatrixChange()` which already handles Item add/remove with proper locking

## Testing
- Not yet build-verified by maintainer (no matching project setup)
- @ustk -- Could you please checkout the `fix/868-matrix-target-change` branch and verify this fixes the issue you reported? Specifically:
  1. Changing target from the matrix dropdown should now move the actual modulation to the new target
  2. Selecting "No Connection" from the dropdown should remove the modulation
  3. Double-click on dragger and delete button should continue working as before

## Files Changed
| File | Change |
|------|--------|
| `hi_core/hi_modules/modulators/mods/MatrixModulator.h` | +1 method declaration, +1 member variable |
| `hi_core/hi_modules/modulators/mods/MatrixModulator.cpp` | +4 lines watcher registration in `init()`, +21 lines `onTargetChange()` handler |

## Impact Checklist
- [x] DSP or audio rendering -- Only through existing `onMatrixChange` code path; no new audio-thread code
- [ ] Module parameter indices or attribute enums
- [ ] Serialization (exportAsValueTree / restoreFromValueTree)
- [ ] Backend/frontend guards (USE_BACKEND / USE_FRONTEND)
- [ ] Scripting engine (parser, preprocessor, include system)
- [ ] Per-instance objects (chains, processors, buffers)
- [ ] Could change existing HISEScript behavior
- [ ] Could change how projects sound or perform
