### PR TITLE
Add selectedSource and accumulated modulation range LAF properties

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -1079,7 +1079,7 @@ HiSlider::HoverPopupLookandFeel& HiSlider::getHoverPopupLookAndFeel()
 
 	return fallback;
 }
-
+/*
 void HiSlider::ModUpdater::timerCallback()
 {
 	if(modFunction != nullptr)
@@ -1103,9 +1103,46 @@ void HiSlider::ModUpdater::timerCallback()
 			}
 		}
 	}
+}*/
+
+void HiSlider::ModUpdater::timerCallback()
+{
+    if(modFunction != nullptr)
+    {
+        if(auto p = parent.getProcessor())
+        {
+            auto nr = parent.getRange();
+            auto mv = modFunction->getDisplayValue(p, parent.getValue(), nr, currentExlusiveIndex);
+            
+            // Populate new ranges
+            mv.selectedSourceRange = (currentExlusiveIndex >= 0) ? mv.modulationRange : Range<double>();
+            
+            // Get accumulated range by calling with -1 if we're in exclusive mode
+            // Get accumulated live value
+            if(currentExlusiveIndex >= 0)
+            {
+                auto accMv = modFunction->getDisplayValue(p, parent.getValue(), nr, -1);
+                mv.accumulatedSourceRange = accMv.modulationRange;
+                mv.accumulatedLiveValue = accMv.scaledValue + accMv.addValue;
+            }
+            else
+            {
+                mv.accumulatedSourceRange = mv.modulationRange;
+                mv.accumulatedLiveValue = mv.scaledValue + mv.addValue;
+            }
+            
+            auto lastModValue = lastValue.lastModValue;
+            auto thisModValue = mv.getNormalisedModulationValue();
+            auto shouldSmooth = std::abs(lastModValue - thisModValue) > JUCE_LIVE_CONSTANT(0.01);
+            if(lastValue != mv || shouldSmooth)
+            {
+                mv.lastModValue = lastModValue * 0.9 + thisModValue * 0.1;
+                mv.storeToComponent(parent);
+                lastValue = mv;
+            }
+        }
+    }
 }
-
-
 
 bool HiSlider::ModUpdater::canBeDropped(const var& info) const
 {
@@ -1295,8 +1332,6 @@ struct HiSlider::HoverPopup: public Component,
 
 		if(!labelArea.isEmpty())
 			labelArea = labelArea.transformed(translationToOrigin);
-
-		
 
 		gc = ProcessorHelpers::getFirstProcessorWithType<GlobalModulatorContainer>(slider.getProcessor()->getMainController()->getMainSynthChain());
 
@@ -1782,28 +1817,33 @@ struct HiSlider::HoverPopup: public Component,
 
 void HiSlider::ModUpdater::onExclusiveSourceSelection(ModUpdater& mu, int index)
 {
-	auto& slider = mu.parent;
-	auto matrixData = MatrixIds::Helpers::getMatrixDataFromGlobalContainer(slider.getProcessor()->getMainController());
-	auto targetId = slider.getProcessor()->getModulationTargetId(slider.getParameter());
-	auto hasConnection = MatrixIds::Helpers::getConnection(matrixData, index, targetId).isValid();
+    auto& slider = mu.parent;
 
-	if (hasConnection)
-	{
-		mu.currentExlusiveIndex = index;
-		Array<int> connectedSources;
-		connectedSources.add(index);
-		StringArray allSources, sourceList;
-		MatrixIds::Helpers::fillModSourceList(slider.getProcessor()->getMainController(), allSources);
-		sourceList.add(allSources[index]);
+    // Guard: don't rebuild hover popup if component isn't visible yet
+    if(!slider.isShowing())
+        return;
 
-		if (auto pd = slider.getHoverPopupLookAndFeel().getModulatorDragData(slider, sourceList))
-			slider.currentHoverPopup = new HoverPopup(slider, matrixData, targetId, connectedSources, sourceList, pd, true);
-	}
-	else
-	{
-		mu.currentExlusiveIndex = -1;
-		slider.currentHoverPopup = nullptr;
-	}
+    auto matrixData = MatrixIds::Helpers::getMatrixDataFromGlobalContainer(slider.getProcessor()->getMainController());
+    auto targetId = slider.getProcessor()->getModulationTargetId(slider.getParameter());
+    auto hasConnection = MatrixIds::Helpers::getConnection(matrixData, index, targetId).isValid();
+
+    if (hasConnection)
+    {
+        mu.currentExlusiveIndex = index;
+        Array<int> connectedSources;
+        connectedSources.add(index);
+        StringArray allSources, sourceList;
+        MatrixIds::Helpers::fillModSourceList(slider.getProcessor()->getMainController(), allSources);
+        sourceList.add(allSources[index]);
+
+        if (auto pd = slider.getHoverPopupLookAndFeel().getModulatorDragData(slider, sourceList))
+            slider.currentHoverPopup = new HoverPopup(slider, matrixData, targetId, connectedSources, sourceList, pd, true);
+    }
+    else
+    {
+        mu.currentExlusiveIndex = -1;
+        slider.currentHoverPopup = nullptr;
+    }
 }
 
 void HiSlider::ModUpdater::setUpdateFunction(const ModulationDisplayValue::QueryFunction::Ptr f)

--- a/hi_tools/hi_tools/MiscToolClasses.h
+++ b/hi_tools/hi_tools/MiscToolClasses.h
@@ -2844,6 +2844,8 @@ struct ModulationDisplayValue
 			   addValue == other.addValue &&
 			   modulationActive == other.modulationActive &&
 			   modulationRange == other.modulationRange;
+               selectedSourceRange == other.selectedSourceRange &&     // NEW
+               accumulatedSourceRange == other.accumulatedSourceRange; // NEW
 	}
 
 	bool operator!=(const ModulationDisplayValue& other) const
@@ -2856,29 +2858,44 @@ struct ModulationDisplayValue
 	double scaledValue = 1.0;
 	double addValue = 0.0;
 	Range<double> modulationRange;
+    Range<double> selectedSourceRange;      // NEW
+    Range<double> accumulatedSourceRange;   // NEW
 	bool modulationActive = false;
 	double lastModValue = 0.0;
+    double accumulatedLiveValue = 0.0;
 
 private:
 
-	static ModulationDisplayValue fromNamedValueSet(const NamedValueSet& set)
-	{
-		ModulationDisplayValue v;
-		v.scaledValue = set["scaledValue"];
-		v.normalisedValue = set["valueNormalized"];
-		v.addValue = set["addValue"];
-		v.modulationActive = set["modulationActive"];
-		v.lastModValue = set["lastModValue"];
+    static ModulationDisplayValue fromNamedValueSet(const NamedValueSet& set)
+    {
+        ModulationDisplayValue v;
+        v.scaledValue = set["scaledValue"];
+        v.normalisedValue = set["valueNormalized"];
+        v.addValue = set["addValue"];
+        v.modulationActive = set["modulationActive"];
+        v.lastModValue = set["lastModValue"];
 
-		auto minv = (float)set["modMinValue"];
-		auto maxv = (float)set["modMaxValue"];
+        auto minv = (float)set["modMinValue"];
+        auto maxv = (float)set["modMaxValue"];
+        minv = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(minv));
+        maxv = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(maxv));
+        v.modulationRange = { minv, maxv };
 
-		minv = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(minv));
-		maxv = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(maxv));
-		v.modulationRange = { minv, maxv };
+        auto selMinV = (float)set["modSelectedMinValue"];
+        auto selMaxV = (float)set["modSelectedMaxValue"];
+        selMinV = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(selMinV));
+        selMaxV = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(selMaxV));
+        v.selectedSourceRange = { selMinV, selMaxV };
 
-		return v;
-	}
+        auto accMinV = (float)set["modAccumulatedMinValue"];
+        auto accMaxV = (float)set["modAccumulatedMaxValue"];
+        accMinV = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(accMinV));
+        accMaxV = jlimit(0.0f, 1.0f, FloatSanitizers::sanitizeFloatNumber(accMaxV));
+        v.accumulatedSourceRange = { accMinV, accMaxV };
+        v.accumulatedLiveValue = set["modAccumulatedLiveValue"];
+
+        return v;
+    }
 
 	void store(NamedValueSet& set) const
 	{
@@ -2888,7 +2905,12 @@ private:
 		set.set("modulationActive", modulationActive);
 		set.set("modMinValue", modulationRange.getStart());
 		set.set("modMaxValue", modulationRange.getEnd());
+        set.set("modSelectedMinValue", selectedSourceRange.getStart());   // NEW
+        set.set("modSelectedMaxValue", selectedSourceRange.getEnd());     // NEW
+        set.set("modAccumulatedMinValue", accumulatedSourceRange.getStart()); // NEW
+        set.set("modAccumulatedMaxValue", accumulatedSourceRange.getEnd());   // NEW
 		set.set("lastModValue", lastModValue);
+        set.set("modAccumulatedLiveValue", accumulatedLiveValue);   // NEW
 	}
 };
 

--- a/projects/standalone/HISE Standalone.jucer
+++ b/projects/standalone/HISE Standalone.jucer
@@ -31,7 +31,7 @@
                customPList="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;&#10;&lt;plist version=&quot;1.0&quot;&gt;&#10;&lt;dict&gt;&#10;&lt;key&gt;NSAppTransportSecurity&lt;/key&gt; &#10;&lt;dict&gt; &#10;&lt;key&gt;NSAllowsArbitraryLoads&lt;/key&gt;&lt;true/&gt;&#10;&lt;/dict&gt;&#10;&lt;/dict&gt;&#10;&lt;/plist&gt;"
                extraDefs="HI_ENABLE_EXPANSION_EDITING=1&#10;HISE_ENABLE_EXPANSIONS=1&#10;HISE_SCRIPT_SERVER_TIMEOUT=20000&#10;HISE_INCLUDE_PROFILING_TOOLKIT=0&#10;"
                extraCompilerFlags="-Wno-reorder -Wno-inconsistent-missing-override -faligned-allocation -Wno-switch -ffp-contract=off"
-               xcodeValidArchs="arm64,arm64e,x86_64" extraLinkerFlags="-rpath $(SRCROOT)/../../../../tools/faust/lib "
+               xcodeValidArchs="arm64,arm64e" extraLinkerFlags="-rpath $(SRCROOT)/../../../../tools/faust/lib "
                externalLibraries="faust" iosDevelopmentTeamID="">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" osxCompatibility="10.13 SDK" isDebug="1" optimisation="1"
@@ -47,10 +47,10 @@
                        enablePluginBinaryCopyStep="1" stripLocalSymbols="1" defines="HISE_CI=1&#10;HI_RUN_UNIT_TESTS=1&#10;PERFETTO=0"
                        macOSDeploymentTarget="10.13" libraryPath="../../../../tools/faust/fakelib&#10;"/>
         <CONFIGURATION name="Release with Faust" osxCompatibility="10.13 SDK" isDebug="0"
-                       optimisation="3" targetName="HISE" linkTimeOptimisation="1" cppLibType="libc++"
-                       enablePluginBinaryCopyStep="1" macOSDeploymentTarget="10.13"
+                       optimisation="3" targetName="HISE FAUST" linkTimeOptimisation="1"
+                       cppLibType="libc++" enablePluginBinaryCopyStep="1" macOSDeploymentTarget="10.13"
                        libraryPath="../../../../tools/faust/lib" binaryPath="Builds/MacOSX/build/Release"
-                       headerPath="../../../../tools/faust/include" defines="HISE_INCLUDE_FAUST=1&#10;HISE_FAUST_USE_LLVM_JIT=1&#10;HISE_INCLUDE_FAUST_JIT=1&#10;PERFETTO=0"/>
+                       headerPath="../../../../tools/faust/include" defines="HISE_INCLUDE_FAUST=1&#10;HISE_FAUST_USE_LLVM_JIT=1&#10;HISE_INCLUDE_FAUST_JIT=1&#10;PERFETTO=0&#10;HISE_SAMPLE_DIALOG_SHOW_INSTALL_BUTTON=1&#10;HISE_SAMPLE_DIALOG_SHOW_LOCATE_BUTTON=0&#10;ENABLE_ALL_PEAK_METERS=1&#10;HISE_USE_OPENGL_FOR_PLUGIN=1&#10;HISE_DEACTIVATE_OVERLAY=1&#10;HISE_DEFAULT_OPENGL_VALUE=1&#10;HISE_USE_EXTENDED_TEMPO_VALUES&#10;HISE_INCLUDE_PROFILING_TOOLKIT=1&#10;HISE_NUM_SCRIPTNODE_FX_MODS=10&#10;HISE_NUM_POLYPHONIC_SCRIPTNODE_FX_MODS=10&#10;HISE_NUM_SCRIPTNODE_SYNTH_MODS=10&#10;NUM_HARDCODED_FX_MODS=10&#10;NUM_HARDCODED_POLY_FX_MODS=10&#10;NUM_HARDCODED_SYNTH_MODS=10"/>
         <CONFIGURATION name="Debug with Faust" osxCompatibility="10.13 SDK" isDebug="1"
                        optimisation="1" targetName="HISE Debug" linkTimeOptimisation="0"
                        cppLibType="libc++" enablePluginBinaryCopyStep="1" macOSDeploymentTarget="10.13"

--- a/projects/standalone/JuceLibraryCode/AppConfig.h
+++ b/projects/standalone/JuceLibraryCode/AppConfig.h
@@ -22,7 +22,30 @@
 
 // [END_USER_CODE_SECTION]
 
-#define JUCE_PROJUCER_VERSION 0x8000c
+/*
+  ==============================================================================
+
+   In accordance with the terms of the JUCE 6 End-Use License Agreement, the
+   JUCE Code in SECTION A cannot be removed, changed or otherwise rendered
+   ineffective unless you have a JUCE Indie or Pro license, or are using JUCE
+   under the GPL v3 license.
+
+   End User License Agreement: www.juce.com/juce-6-licence
+
+  ==============================================================================
+*/
+
+// BEGIN SECTION A
+
+#ifndef JUCE_DISPLAY_SPLASH_SCREEN
+ #define JUCE_DISPLAY_SPLASH_SCREEN 0
+#endif
+
+// END SECTION A
+
+#define JUCE_USE_DARK_SPLASH_SCREEN 1
+
+#define JUCE_PROJUCER_VERSION 0x60104
 
 //==============================================================================
 #define JUCE_MODULE_AVAILABLE_hi_backend                          1
@@ -132,7 +155,7 @@
 #endif
 
 #ifndef    FORCE_INPUT_CHANNELS
- //#define FORCE_INPUT_CHANNELS 1
+ //#define FORCE_INPUT_CHANNELS 0
 #endif
 
 #ifndef    HI_DONT_SEND_ATTRIBUTE_UPDATES
@@ -452,16 +475,8 @@
  //#define JUCE_USE_WINRT_MIDI 0
 #endif
 
-#ifndef    JUCE_USE_WINDOWS_MIDI_SERVICES
- //#define JUCE_USE_WINDOWS_MIDI_SERVICES 0
-#endif
-
 #ifndef    JUCE_ASIO
  #define   JUCE_ASIO 1
-#endif
-
-#ifndef    JUCE_ASIO_USE_EXTERNAL_SDK
- //#define JUCE_ASIO_USE_EXTERNAL_SDK 0
 #endif
 
 #ifndef    JUCE_WASAPI
@@ -478,6 +493,10 @@
 
 #ifndef    JUCE_JACK
  #define   JUCE_JACK 1
+#endif
+
+#ifndef    JUCE_BELA
+ //#define JUCE_BELA 0
 #endif
 
 #ifndef    JUCE_USE_ANDROID_OBOE
@@ -520,7 +539,7 @@
 #endif
 
 //==============================================================================
-// juce_audio_processors_headless flags:
+// juce_audio_processors flags:
 
 #ifndef    JUCE_PLUGINHOST_VST
  //#define JUCE_PLUGINHOST_VST 0
@@ -538,16 +557,15 @@
  //#define JUCE_PLUGINHOST_LADSPA 0
 #endif
 
-#ifndef    JUCE_PLUGINHOST_LV2
- //#define JUCE_PLUGINHOST_LV2 0
-#endif
-
-#ifndef    JUCE_PLUGINHOST_ARA
- //#define JUCE_PLUGINHOST_ARA 0
-#endif
-
 #ifndef    JUCE_CUSTOM_VST3_SDK
  //#define JUCE_CUSTOM_VST3_SDK 0
+#endif
+
+//==============================================================================
+// juce_audio_processors_headless flags:
+
+#ifndef    JUCE_RANDOM_SETTING_2000
+ //#define JUCE_RANDOM_SETTING_2000 0
 #endif
 
 //==============================================================================
@@ -649,6 +667,10 @@
  //#define JUCE_USE_COREIMAGE_LOADER 1
 #endif
 
+#ifndef    JUCE_USE_DIRECTWRITE
+ #define   JUCE_USE_DIRECTWRITE 1
+#endif
+
 #ifndef    JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING
  //#define JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING 0
 #endif
@@ -689,10 +711,6 @@
 
 #ifndef    JUCE_WEB_BROWSER
  //#define JUCE_WEB_BROWSER 1
-#endif
-
-#ifndef    JUCE_USE_WIN_WEBVIEW2_WITH_STATIC_LINKING
- //#define JUCE_USE_WIN_WEBVIEW2_WITH_STATIC_LINKING 0
 #endif
 
 #ifndef    JUCE_USE_WIN_WEBVIEW2


### PR DESCRIPTION
+ IntensityText Crash Prevention

I've added three new property pairs to the modulation display system that expose separate ranges for use in LAF callbacks, giving developers full control over how modulation is visualised on knobs.

New properties available in the LAF obj:

modSelectedMinValue / modSelectedMaxValue — the range of the currently selected exclusive source only

modAccumulatedMinValue / modAccumulatedMaxValue — the combined range of all connected sources regardless of selection state

modAccumulatedLiveValue — the live modulation output of all sources combined (useful for a pointer/indicator that tracks total modulation rather than just the selected source)

The existing modMinValue / modMaxValue are untouched and continue to work as before.

Use case: When using exclusive source matrix mode, selecting a source previously caused all modulation display to reflect only that source. With these new properties you can independently draw arcs for the selected source range and the accumulated range simultaneously, giving users a clearer picture of what all modulators are doing while still highlighting the selected one.

Files modified:

hi_core/hi_core/MiscToolClasses.h — added new members to ModulationDisplayValue struct

hi_core/hi_core/MacroControlledComponents.cpp — populated new values in ModUpdater::timerCallback