### PR TITLE
Fix group name validation failing before group names are set

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -729,14 +729,9 @@ void ScriptingApi::Content::ScriptComponent::setScriptObjectPropertyWithChangeMe
 	}
 	else if (id == getIdFor(pluginParameterGroup))
 	{
-#if USE_BACKEND
-		auto groupName = newValue.toString();
-
-		auto ok = getScriptProcessor()->getMainController_()->getUserPresetHandler().checkPluginParameterGroupName(groupName);
-
-		if(!ok.wasOk())
-			logErrorAndContinue(ok.getErrorMessage());
-#endif
+		// Defer validation until after initialization completes (see endInitialization)
+		// because setPluginParameterGroupNames may not have been called yet and was leading
+		// to validation error: Plugin:! ParamName is not a valid group name
 	}
 	else if (id == getIdFor(parentComponent))
 	{
@@ -8023,7 +8018,43 @@ void ScriptingApi::Content::endInitialization()
 	allowAsyncFunctions = true;
 
 	updateWatcher = new ValueTreeUpdateWatcher(contentPropertyData, this);
+
+#if USE_BACKEND
+	validatePluginParameterGroupNames();
+#endif
 }
+
+#if USE_BACKEND
+void ScriptingApi::Content::validatePluginParameterGroupNames()
+{
+	// Validate all plugin parameter group names after initialization completes
+	// This ensures setPluginParameterGroupNames has been called before validation
+	if (auto processor = getScriptProcessor())
+	{
+		if (auto mc = processor->getMainController_())
+		{
+			auto& uph = mc->getUserPresetHandler();
+
+			for (int i = 0; i < components.size(); i++)
+			{
+				auto sc = components[i];
+				if (sc->getScriptObjectProperty(ScriptComponent::Properties::isPluginParameter))
+				{
+					auto groupName = sc->getScriptObjectProperty(ScriptComponent::Properties::pluginParameterGroup).toString();
+
+					if (!groupName.isEmpty())
+					{
+						auto ok = uph.checkPluginParameterGroupName(groupName);
+
+						if (!ok.wasOk())
+							logErrorAndContinue(ok.getErrorMessage());
+					}
+				}
+			}
+		}
+	}
+}
+#endif
 
 
 void ScriptingApi::Content::beginInitialization()

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -3128,6 +3128,10 @@ public:
 
 	void beginInitialization();
 
+#if USE_BACKEND
+	void validatePluginParameterGroupNames();
+#endif
+
 	ValueTree exportAsValueTree() const override;
 	void restoreFromValueTree(const ValueTree &v) override;
 


### PR DESCRIPTION
Potential fix for #889 

Group names are being validation during initialisation, before setPluginParameterGroupNames is called. Therefore the group names don't exist and trigger a console message.

Claude suggested this fix. It feels a bit ick to me, moving the group name validation to the end of initialisation.

It does fix the validation failure issue though.

@christoph-hart probably has a better option to stop this validation failing? 🙏