### PR TITLE
Fix modulator chains on master chain effects being silently ignored (regression from #845)

### DIFF
--- a/hi_core/hi_dsp/modules/ModulatorChain.cpp
+++ b/hi_core/hi_dsp/modules/ModulatorChain.cpp
@@ -1216,7 +1216,8 @@ float ModulatorChain::ModChainWithBuffer::getModValueForVoiceWithOffset(int star
 
 float ModulatorChain::ModChainWithBuffer::getOneModulationValue(int startSample) const
 {
-	if(numActiveVoices == 0)
+	// Skip modulation only when no voices are active AND no data was calculated.
+	if(numActiveVoices == 0 && currentVoiceData == nullptr)
 	{
 		ModIterator<Modulator> iter(c);
 


### PR DESCRIPTION
Fix for #886 

Seems that LFO modulation of filters in the Master Chain has been broken since commit 840365a89ac14ce6b59d9017f066453ee0c6250c

This fix ensures that when modulation has been calculated (LFO is present in master chain) the modulation value is used instead of escaping early (when numVoices is zero - which fix 845 introduced).