### PR TITLE
Fix colour values from external variables in Content.setValuePopupData

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.h
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.h
@@ -251,13 +251,13 @@ public:
 			{
 				switch (id)
 				{
-				case bgColour: return getColourFrom(bg);
-				case itemColour: return getColourFrom(item);
-				case itemColour2: return getColourFrom(item2);
-				case textColour: return getColourFrom(text);
+				case bgColour: return ApiHelpers::getColourFromVar(bg.getValue());
+				case itemColour: return ApiHelpers::getColourFromVar(item.getValue());
+				case itemColour2: return ApiHelpers::getColourFromVar(item2.getValue());
+				case textColour: return ApiHelpers::getColourFromVar(text.getValue());
                 default: break;
 				}
-					
+
 				jassertfalse;
 				return Colours::transparentBlack;
 			}

--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -229,6 +229,8 @@ Colour ApiHelpers::getColourFromVar(const var& value)
 
 	if (value.isInt64() || value.isInt())
 		colourValue = (int64)value;
+	else if (value.isDouble())
+		colourValue = (int64)(double)value;
 	else if (value.isString())
 	{
 		auto string = value.toString();

--- a/hi_scripting/scripting/scriptnode/api/Properties.cpp
+++ b/hi_scripting/scripting/scriptnode/api/Properties.cpp
@@ -789,6 +789,8 @@ void ExpressionPropertyComponent::Comp::Display::mouseDown(const MouseEvent& )
 
 		if (value.isInt64() || value.isInt())
 			colourValue = (int64)value;
+		else if (value.isDouble())
+			colourValue = (int64)(double)value;
 		else if (value.isString())
 		{
 			auto string = value.toString();


### PR DESCRIPTION
When using Content.setValuePopupData I wanted to use colours and other properties that are stored in variables or retrieved using functions.

ValuePopup::Properties::getColour used ObjectWithDefaultProperties::getColourFrom which does a simple cast chain (uint32)(int64)(var) that doesn't properly handle all var types. Switch to ApiHelpers::getColourFromVar which is the canonical colour conversion used throughout HISE and correctly handles int, int64, and string types.

Also add double handling to both ApiHelpers::getColourFromVar and scriptnode::PropertyHelpers::getColourFromVar so colour values that have been through JSON serialization (which converts large integers to doubles) are handled correctly.

https://claude.ai/code/session_01K4LR9ibEig4BHFCipQKYDQ