### PR TITLE
Fix square background behind rounded value popup

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -874,6 +874,9 @@ void ScriptCreatedComponentWrapper::updatePopupPosition()
 
 		p.applyTransform(currentPopup->getTransform().inverted());
 
+		if (currentPopup->drawShadow)
+			p -= Point<int>(ValuePopup::shadowMargin, ValuePopup::shadowMargin);
+
 		currentPopup->setTopLeftPosition(p);
 	}
 }
@@ -3435,7 +3438,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		if(!area.isEmpty())
 		{
-			shadow = nullptr;
+			drawShadow = false;
 			currentText = thisText;
 			setSize(area.getWidth(), area.getHeight());
 			repaint();
@@ -3451,9 +3454,9 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		int margin = (int)p->getLayoutData().margin;
 
-		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5;
+		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5 + 2 * shadowMargin;
 
-		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin);
+		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin + 2 * shadowMargin);
 
 
 		repaint();
@@ -3470,15 +3473,21 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 	Properties::Ptr p = parent.contentComponent->getValuePopupProperties();
 
-	
-
 	if (p != nullptr)
 	{
 		auto l = p->getLayoutData();
 
-		auto ar = getLocalBounds().toFloat().reduced(l.lineThickness * 0.5f);
+		auto contentArea = getLocalBounds().toFloat().reduced((float)shadowMargin);
+		auto ar = contentArea.reduced(l.lineThickness * 0.5f);
 
-		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f, 
+		if (drawShadow)
+		{
+			Path shadowPath;
+			shadowPath.addRoundedRectangle(ar, l.radius);
+			shadow.drawForPath(g, shadowPath);
+		}
+
+		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f,
 										 p->getColour(Properties::itemColour2), 0.0f, (float)getHeight(), false));
 
 		g.fillRoundedRectangle(ar, l.radius);
@@ -3488,7 +3497,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 		g.setFont(p->getFont());
 		g.setColour(p->getColour(Properties::textColour));
-		g.drawText(currentText, getLocalBounds(), Justification::centred);
+		g.drawText(currentText, contentArea.toNearestInt(), Justification::centred);
 	}
 
 	

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.h
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.h
@@ -276,14 +276,14 @@ public:
 			JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Properties);
 		};
 
+		static constexpr int shadowMargin = 5;
+
 		ValuePopup(ScriptCreatedComponentWrapper& p):
 			parent(p),
-			shadow(new DropShadower({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }}))
+			shadow({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }})
 		{
 			f = GLOBAL_BOLD_FONT();
 
-			shadow->setOwner(this);
-			
 			updateText();
 			startTimer(30);
 		}
@@ -314,7 +314,8 @@ public:
 
 		ScriptCreatedComponentWrapper& parent;
 
-		ScopedPointer<DropShadower> shadow;
+		DropShadow shadow;
+		bool drawShadow = true;
 	};
 
 	struct AdditionalMouseCallback;


### PR DESCRIPTION
Replace DropShadower with manually-painted DropShadow using a rounded rectangle path. The DropShadower rendered shadow based on rectangular component bounds, causing a visible square background. Now the shadow follows the rounded shape defined by borderRadius, allowing rounded value popups.

https://claude.ai/code/session_01V2DtUFT6hpxSYF9aozG2z6