### PR TITLE
Add transparent backgrounds and margin support for custom alert windows

### DIFF
--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -544,6 +544,34 @@ void PresetHandler::copyProcessorToClipboard(Processor *p)
 
 void* PresetHandler::currentController = nullptr;
 
+static void applyAlertWindowMargin(AlertWindow* window, LookAndFeel* laf)
+{
+	if (auto alertLaf = dynamic_cast<AlertWindowLookAndFeel*>(laf))
+	{
+		int margin = alertLaf->getAlertWindowMargin();
+
+		if (margin > 0)
+		{
+			// Save current child positions before resize triggers updateLayout
+			struct ChildPos { Component* comp; int x, y; };
+			Array<ChildPos> positions;
+
+			for (int i = 0; i < window->getNumChildComponents(); i++)
+			{
+				auto* child = window->getChildComponent(i);
+				positions.add({ child, child->getX(), child->getY() });
+			}
+
+			window->setSize(window->getWidth() + margin * 2,
+			                window->getHeight() + margin * 2);
+
+			// Restore original positions offset by the margin
+			for (auto& p : positions)
+				p.comp->setTopLeftPosition(p.x + margin, p.y + margin);
+		}
+	}
+}
+
 String PresetHandler::getCustomName(const String &typeName, const String& thisMessage/*=String()*/)
 {
 	String message;
@@ -568,7 +596,7 @@ String PresetHandler::getCustomName(const String &typeName, const String& thisMe
 
     ScopedPointer<AlertWindow> nameWindow = new AlertWindow(useCustomMessage ? ("Enter " + typeName) : ("Enter name for " + typeName), "", AlertWindow::AlertIconType::NoIcon);
 
-
+	nameWindow->setOpaque(false);
 	nameWindow->setLookAndFeel(laf);
 
 	nameWindow->addCustomComponent(comp);
@@ -589,9 +617,11 @@ String PresetHandler::getCustomName(const String &typeName, const String& thisMe
 	nameWindow->getTextEditor("Name")->setSelectAllWhenFocused(true);
 	nameWindow->getTextEditor("Name")->grabKeyboardFocusAsync();
 
+	applyAlertWindowMargin(nameWindow, laf);
+
 	if(nameWindow->runModalLoop()) return nameWindow->getTextEditorContents("Name");
 	else return String();
-    
+
 };
 
 bool PresetHandler::showYesNoWindow(const String &title, const String &message, PresetHandler::IconType type)
@@ -620,14 +650,17 @@ bool PresetHandler::showYesNoWindow(const String &title, const String &message, 
 	
 	ScopedPointer<AlertWindow> nameWindow = new AlertWindow(title, "", AlertWindow::AlertIconType::NoIcon);
 
+	nameWindow->setOpaque(false);
 	nameWindow->setLookAndFeel(laf);
 	nameWindow->addCustomComponent(comp);
-	
+
 	nameWindow->addButton("OK", 1, KeyPress(KeyPress::returnKey));
 	nameWindow->addButton("Cancel", 0, KeyPress(KeyPress::escapeKey));
 
+	applyAlertWindowMargin(nameWindow, laf);
+
 	return (nameWindow->runModalLoop() == 1);
-    
+
 #endif
 };
 
@@ -667,9 +700,12 @@ void PresetHandler::showMessageWindow(const String &title, const String &message
 		ScopedPointer<MessageWithIcon> comp = new MessageWithIcon(type, laf, message);
 		ScopedPointer<AlertWindow> nameWindow = new AlertWindow(title, "", AlertWindow::AlertIconType::NoIcon);
 
+		nameWindow->setOpaque(false);
 		nameWindow->setLookAndFeel(laf);
 		nameWindow->addCustomComponent(comp);
 		nameWindow->addButton("OK", 1, KeyPress(KeyPress::returnKey));
+
+		applyAlertWindowMargin(nameWindow, laf);
 
 		nameWindow->runModalLoop();
 #endif

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4077,7 +4077,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawAlertBox(Graphics& g_, Aler
 	{
 		auto obj = new DynamicObject();
 
-		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, w.getLocalBounds().toFloat()));
+		auto fullArea = w.getLocalBounds().toFloat();
+		auto margin = (float)getAlertWindowMargin();
+		auto contentArea = fullArea.reduced(margin);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, contentArea));
+		obj->setProperty("bounds", ApiHelpers::getVarRectangle(useRectangleClass, fullArea));
 		obj->setProperty("title", w.getName());
 
 		addParentFloatingTile(w, obj);
@@ -4087,6 +4092,14 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawAlertBox(Graphics& g_, Aler
 	}
 
 	GlobalHiseLookAndFeel::drawAlertBox(g_, w, ta, tl);
+}
+
+int ScriptingObjects::ScriptedLookAndFeel::Laf::getAlertWindowMargin()
+{
+	if (functionDefined("drawAlertWindow"))
+		return 50;
+
+	return 0;
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::getIdealPopupMenuItemSize(const String &text, bool isSeparator, int standardMenuItemHeight, int &idealWidth, int &idealHeight)

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -847,6 +847,8 @@ namespace ScriptingObjects
 
 			void drawAlertBox(Graphics&, AlertWindow&, const Rectangle<int>& textArea, TextLayout&) override;
 
+			int getAlertWindowMargin() override;
+
 			Font getAlertWindowMessageFont() override;
 			Font getAlertWindowTitleFont() override;
 			Font getTextButtonFont(TextButton &, int) override;

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -511,6 +511,9 @@ public:
 
 	void drawAlertBox (Graphics &g, AlertWindow &alert, const Rectangle< int > &textArea, juce::TextLayout &textLayout) override;;
 
+	/** Override this to add extra margin around the alert window for custom drop shadows. */
+	virtual int getAlertWindowMargin() { return 0; }
+
 	Colour dark, bright, special;
 };
 


### PR DESCRIPTION
Support transparent backgrounds and shadow margins for custom alert windows

Make AlertWindow non-opaque and expand it by 50px when drawAlertWindow
is defined, so scripted look-and-feel overrides can render rounded
corners and drop shadows. Pass both obj.area (content region,
backwards-compatible) and obj.bounds (full window including margin)
to the LAF callback. Default appearance is unchanged.
