### PR TITLE
Fix preset browser favourites filter across all expansions

### DIFF
--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -699,6 +699,127 @@ Point<int> PresetBrowser::getMouseHoverInformation() const
 	return p;
 }
 
+Array<File> PresetBrowser::getAllSearchRoots() const
+{
+	Array<File> roots;
+
+	if (currentlySelectedExpansion != nullptr)
+	{
+		auto userPresetsDir = currentlySelectedExpansion->getSubDirectory(FileHandlerBase::UserPresets);
+		if (userPresetsDir.isDirectory())
+			roots.add(userPresetsDir);
+		return roots;
+	}
+
+	if (defaultRoot.isDirectory())
+		roots.add(defaultRoot);
+
+	auto& handler = getMainController()->getExpansionHandler();
+
+	for (int i = 0; i < handler.getNumExpansions(); ++i)
+	{
+		if (auto e = handler.getExpansion(i))
+		{
+			auto userPresetsDir = e->getSubDirectory(FileHandlerBase::UserPresets);
+			if (userPresetsDir.isDirectory() && !roots.contains(userPresetsDir))
+				roots.add(userPresetsDir);
+		}
+	}
+
+	return roots;
+}
+
+void PresetBrowser::rebuildFavoritesCache() const
+{
+	cachedFavorites.clear();
+
+	// Always build the full cache across ALL roots, regardless of which
+	// expansion is currently selected in the browser column.  The selection
+	// only determines which subset callers receive (see getAllFavoritePresets).
+	Array<File> allRoots;
+
+	if (defaultRoot.isDirectory())
+		allRoots.add(defaultRoot);
+
+	auto& handler = getMainController()->getExpansionHandler();
+
+	for (int i = 0; i < handler.getNumExpansions(); ++i)
+	{
+		if (auto e = handler.getExpansion(i))
+		{
+			auto userPresetsDir = e->getSubDirectory(FileHandlerBase::UserPresets);
+			if (userPresetsDir.isDirectory() && !allRoots.contains(userPresetsDir))
+				allRoots.add(userPresetsDir);
+		}
+	}
+
+	for (auto& rootDir : allRoots)
+	{
+		var db;
+
+		if (rootDir == rootFile)
+		{
+			// Use the in-memory database for the currently loaded root so that
+			// changes made since the last save (e.g. a just-toggled favourite)
+			// are reflected immediately without requiring a round-trip to disk.
+			db = presetDatabase;
+		}
+		else
+		{
+			auto dbFile = rootDir.getChildFile("db.json");
+
+			if (dbFile.existsAsFile())
+			{
+				db = JSON::parse(dbFile.loadFileAsString());
+				if (!db.isObject())
+					db = new DynamicObject();
+			}
+			else
+				db = new DynamicObject();
+		}
+
+		Array<File> presets;
+		rootDir.findChildFiles(presets, File::findFiles, true);
+		DataBaseHelpers::cleanFileList(const_cast<MainController*>(getMainController()), presets);
+
+		for (auto& preset : presets)
+		{
+			if (DataBaseHelpers::isFavorite(db, preset))
+				cachedFavorites.add(preset);
+		}
+	}
+
+	favoritesCacheDirty = false;
+}
+
+bool PresetBrowser::isFavoriteInAnyDatabase(const File& presetFile) const
+{
+	if (favoritesCacheDirty)
+		rebuildFavoritesCache();
+
+	return cachedFavorites.contains(presetFile);
+}
+
+Array<File> PresetBrowser::getAllFavoritePresets()
+{
+	if (favoritesCacheDirty)
+		rebuildFavoritesCache();
+
+	if (currentlySelectedExpansion == nullptr)
+		return cachedFavorites;
+
+	// Return only the favourites belonging to the selected expansion.
+	auto expansionRoot = currentlySelectedExpansion->getSubDirectory(FileHandlerBase::UserPresets);
+	Array<File> filtered;
+
+	for (auto& f : cachedFavorites)
+		if (f.isAChildOf(expansionRoot))
+			filtered.add(f);
+
+	return filtered;
+}
+
+
 void PresetBrowser::presetChanged(const File& newPreset)
 {
 	// After we switched the expansions we need to make sure to run this logic so that it ca
@@ -909,37 +1030,40 @@ void PresetBrowser::resized()
 	if (tagList->isActive())
 		tagList->setBounds(listArea.removeFromTop(30));
 
+	const int folderOffset = expansionColumn != nullptr ? 1 : 0;
+	const int numColumnsToShow = jlimit(1, 4, numColumns + folderOffset);
+	int columnWidths[4] = { 0, 0, 0, 0 };
+	auto w = (double)getWidth();
+
+	if (columnWidthRatios.size() == numColumnsToShow)
+	{
+		for (int i = 0; i < numColumnsToShow; i++)
+		{
+			auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
+			columnWidths[i] = roundToInt(w * r);
+		}
+	}
+	else
+	{
+		// column amount mismatch, use equal spacing...
+		const int columnWidth = roundToInt(w / (double)numColumnsToShow);
+
+		for (int i = 0; i < numColumnsToShow; i++)
+			columnWidths[i] = columnWidth;
+	}
+
 	if (showOnlyPresets)
 	{
 		if (expansionColumn != nullptr)
-			listArea.removeFromLeft(expansionColumn->getWidth() + 4);
+		{
+			expansionColumn->setVisible(true);
+			expansionColumn->setBounds(listArea.removeFromLeft(columnWidths[0]).reduced(2, 2));
+		}
 
 		presetColumn->setBounds(listArea.reduced(2));
 	}
 	else
 	{
-		const int folderOffset = expansionColumn != nullptr ? 1 : 0;
-		const int numColumnsToShow = jlimit(1, 4, numColumns + folderOffset);
-		int columnWidths[4] = { 0, 0, 0, 0 };
-		auto w = (double)getWidth();
-
-		if (columnWidthRatios.size() == numColumnsToShow)
-		{
-			for (int i = 0; i < numColumnsToShow; i++)
-			{
-				auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
-				columnWidths[i] = roundToInt(w * r);
-			}
-		}
-		else
-		{
-			// column amount mismatch, use equal spacing...
-			const int columnWidth = roundToInt(w / (double)numColumnsToShow);
-
-			for (int i = 0; i < numColumnsToShow; i++)
-				columnWidths[i] = columnWidth;
-		}
-
 		if(expansionColumn != nullptr)
 			expansionColumn->setBounds(listArea.removeFromLeft(columnWidths[0]).reduced(2, 2));
 
@@ -1015,7 +1139,7 @@ void PresetBrowser::labelTextChanged(Label* l)
 	{
 		showOnlyPresets = !currentTagSelection.isEmpty() || l->getText().isNotEmpty() || favoriteButton->getToggleState();
 
-		if (showOnlyPresets)
+		if (l->getText().isNotEmpty())
 			currentWildcard = "*" + l->getText() + "*";
 		else
 			currentWildcard = "*";
@@ -1037,6 +1161,12 @@ void PresetBrowser::updateFavoriteButton()
 
 	if (presetColumn == nullptr)
 		return;
+
+	// Invalidate the cache when the filter is turned on so that any changes
+	// made by another plugin instance (written to disk but not reflected in
+	// this instance's in-memory cache) are picked up immediately.
+	if (on)
+		invalidateFavoritesCache();
 
 	presetColumn->setShowFavoritesOnly(on);
 
@@ -1349,14 +1479,20 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		currentBankFile = File();
 		currentCategoryFile = File();
 		currentlyLoadedPreset = 0;
-		
+
+		// Save any pending favourite changes for the current root before we
+		// switch to a different one (loadPresetDatabase below would overwrite
+		// the in-memory state otherwise).
+		if (rootFile.isDirectory())
+			savePresetDatabase(rootFile);
+
 		if (file == File())
 		{
 			if (FullInstrumentExpansion::isEnabled(getMainController()))
 				rootFile = File();
 			else
 				rootFile = defaultRoot;
-				
+
 			currentlySelectedExpansion = nullptr;
 		}
 		else
@@ -1376,15 +1512,27 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		bankColumn->setNewRootDirectory(rootFile);
 		categoryColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 1, this), rootFile);
 		categoryColumn->setNewRootDirectory(currentCategoryFile);
-		presetColumn->setNewRootDirectory(File());
-		
-		auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
-		pc->setDisplayDirectories(false);
-		presetColumn->setModel(pc, rootFile);
-		
 		loadPresetDatabase(rootFile);
-		presetColumn->setDatabase(getDataBase());
 		rebuildAllPresets();
+
+		if (showOnlyPresets)
+		{
+			// Keep the existing model so the search wildcard is preserved; just
+			// refresh the list — getAllSearchRoots() now returns the new expansion.
+			presetColumn->setNewRootDirectory(rootFile);
+		}
+		else
+		{
+			presetColumn->setNewRootDirectory(File());
+
+			auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
+			pc->setDisplayDirectories(false);
+			presetColumn->setModel(pc, rootFile);
+		}
+
+		// Set the database after the model may have been replaced above so the
+		// active model always has a valid database reference.
+		presetColumn->setDatabase(getDataBase());
 	}
 
 	if (columnIndex == 0)

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -191,6 +191,8 @@ public:
 
 	void loadPresetDatabase(const File& rootDirectory);
 	void savePresetDatabase(const File& rootDirectory);
+	/** Flush the in-memory favourite database for the currently loaded root to disk. */
+	void saveCurrentDatabase() { savePresetDatabase(rootFile); }
 	var getDataBase() { return presetDatabase; }
 	const var getDataBase() const { return presetDatabase; }
 
@@ -232,6 +234,16 @@ public:
 	}
 
 	Point<int> getMouseHoverInformation() const;
+
+	Array<File> getAllSearchRoots() const;
+	Array<File> getAllFavoritePresets();
+	bool isFavoriteInAnyDatabase(const File& presetFile) const;
+
+	/** Mark the favourites cache as stale so it is rebuilt on next access.
+	    Call this whenever the favourite state of any preset changes or
+	    whenever the set of visible roots changes (e.g. expansion switch). */
+	void invalidateFavoritesCache() { favoritesCacheDirty = true; }
+
 
 	Component* getColumn(int columnIndex)
 	{
@@ -312,6 +324,16 @@ private:
 	WeakReference<Expansion> currentlySelectedExpansion;
 
 	var presetDatabase;
+
+	// Cached list of favourite files.  Rebuilt lazily whenever
+	// favoritesCacheDirty is true (on first access after a favourite toggle
+	// or expansion switch).  mutable so it can be populated from const
+	// query methods.
+	mutable Array<File> cachedFavorites;
+	mutable bool favoritesCacheDirty = true;
+
+	// Rebuild cachedFavorites from disk/in-memory databases.
+	void rebuildFavoritesCache() const;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PresetBrowser);
 

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -227,30 +227,28 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 {
 	if (wildcard.isEmpty() && currentlyActiveTags.isEmpty())
 	{
-		const File& rootToUse = showFavoritesOnly ? totalRoot : root;
+		if (showFavoritesOnly && index == 2)
+		{
+			// Search across all expansion roots and check each file against its own database.
+			// getAllFavoritePresets() respects the current expansion selection: when an expansion
+			// is selected getAllSearchRoots() returns only that expansion, so only its favourites
+			// are returned; when no expansion is selected all roots are searched.
+			entries = parent->getAllFavoritePresets();
+			entries.sort();
+			empty = entries.isEmpty();
+			return entries.size();
+		}
 
-		if (!rootToUse.isDirectory())
+		if (!root.isDirectory())
 		{
 			entries.clear();
 			return 0;
 		}
 
 		entries.clear();
-		rootToUse.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch || showFavoritesOnly);
+		root.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch);
 
 		PresetBrowser::DataBaseHelpers::cleanFileList(parent->getMainController(), entries);
-
-		if (showFavoritesOnly && index == 2)
-		{
-			for (int i = 0; i < entries.size(); i++)
-			{
-				if (!PresetBrowser::DataBaseHelpers::isFavorite(database, entries[i]))
-				{
-					entries.remove(i--);
-					continue;
-				}
-			}
-		}
 
 		entries.sort();
 		empty = entries.isEmpty();
@@ -303,11 +301,8 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		{
 			for (int i = 0; i < entries.size(); i++)
 			{
-				if (!PresetBrowser::DataBaseHelpers::isFavorite(database, entries[i]))
-				{
+				if (!parent->isFavoriteInAnyDatabase(entries[i]))
 					entries.remove(i--);
-					continue;
-				}
 			}
 		}
 
@@ -394,9 +389,51 @@ void PresetBrowserColumn::ColumnListModel::paintListBoxItem(int rowNumber, Graph
 		auto column = parent->getColumn(index);
 		jassert(dynamic_cast<ListBox*>(column)->getModel() == this);
 		
-    if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
-			itemName = entries[rowNumber].getRelativePathFrom(totalRoot);
-    
+		if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
+		{
+			const auto& f = entries[rowNumber];
+			const auto searchRoots = parent->getAllSearchRoots();
+
+			// Default to a simple relative path from the current total root.
+			itemName = f.getRelativePathFrom(totalRoot);
+
+			// Find the specific root this file belongs to.  Expansion roots
+			// (index > 0) are prefixed with the expansion folder name so the
+			// user can tell them apart, mirroring the full-path search behaviour.
+			for (int i = 0; i < searchRoots.size(); ++i)
+			{
+				if (f.isAChildOf(searchRoots[i]))
+				{
+					auto rel = f.getRelativePathFrom(searchRoots[i]);
+					itemName = (i > 0) ? searchRoots[i].getParentDirectory().getFileName() + File::getSeparatorString() + rel
+					                   : rel;
+					break;
+				}
+			}
+		}
+
+		if (!wildcard.isEmpty() && parent.getComponent()->shouldShowFullPathSearch())
+		{
+			const auto& f = entries[rowNumber];
+			const auto searchRoots = parent->getAllSearchRoots();
+
+			// Index 0 is the project root; expansions start at index 1 and are
+			// prefixed with their folder name so the user can tell them apart.
+			itemName = f.getRelativePathFrom(totalRoot);
+
+			for (int i = 0; i < searchRoots.size(); ++i)
+			{
+				if (f.isAChildOf(searchRoots[i]))
+				{
+					auto rel = f.getRelativePathFrom(searchRoots[i]);
+					itemName = (i > 0) ? searchRoots[i].getParentDirectory().getFileName() + File::getSeparatorString() + rel
+					                   : rel;
+					break;
+				}
+			}
+		}
+
+
 		getPresetBrowserLookAndFeel().drawListItem(g, *column, index, rowNumber, itemName, position, rowIsSelected, deleteOnClick, isMouseHover(rowNumber));
 	}
 }
@@ -414,15 +451,44 @@ const juce::Array<PresetBrowserColumn::ColumnListModel::CachedTag>& PresetBrowse
 
 Component* PresetBrowserColumn::ColumnListModel::refreshComponentForRow(int rowNumber, bool /*isRowSelected*/, Component* existingComponentToUpdate)
 {
+	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton())
+	{
+		// Reuse the existing overlay rather than destroying and recreating it.
+		// Recreating causes a brief gap between deletion and first paint of the
+		// new component, which produces a visible flicker on the star icon
+		// (most noticeable when the periodic timer calls updateContent()).
+		//
+		// IMPORTANT: only reuse an overlay whose parent reference points to
+		// *this* model.  When setModel() replaces the ColumnListModel, JUCE
+		// keeps the old RowComponents (and their FavoriteOverlay children) in
+		// a "spare" cache.  If we reused such an overlay its parent member
+		// would be a dangling reference to the already-destroyed old model,
+		// causing an instant segfault when refreshShape() is called.
+		if (auto* existing = dynamic_cast<FavoriteOverlay*>(existingComponentToUpdate))
+		{
+			if (&existing->parent == this)
+			{
+				existing->refreshIndex(rowNumber);
+				existing->refreshShape();
+				return existing;
+			}
+
+			// Belongs to a different (now-destroyed) model — fall through and
+			// create a fresh overlay that references the current model.
+			delete existing;
+			existingComponentToUpdate = nullptr;
+		}
+
+		if (existingComponentToUpdate != nullptr)
+			delete existingComponentToUpdate;
+
+		return new FavoriteOverlay(*this, rowNumber);
+	}
+
 	if (existingComponentToUpdate != nullptr)
 		delete existingComponentToUpdate;
 
-	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton())
-	{
-		return new FavoriteOverlay(*this, rowNumber);
-	}
-	else
-		return nullptr;
+	return nullptr;
 }
 
 void PresetBrowserColumn::ColumnListModel::sendRowChangeMessage(int row)
@@ -460,7 +526,12 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::refreshShape()
 {
 	auto f = parent.getFileForIndex(index);
 
-	const bool on = PresetBrowser::DataBaseHelpers::isFavorite(parent.database, f);
+	// Use isFavoriteInAnyDatabase rather than checking parent.database directly.
+	// When no expansion is selected the favourites list spans multiple roots,
+	// each with its own database.  Checking only parent.database (the default
+	// root's database) returns false for every expansion-owned favourite,
+	// leaving all star buttons appearing un-toggled.
+	const bool on = parent.isFavoriteInAnyDatabase(f);
 
 	auto path = parent.getPresetBrowserLookAndFeel().createPresetBrowserIcons(on ? "favorite_on" : "favorite_off");
 
@@ -481,6 +552,14 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::refreshShape()
 }
 
 
+bool PresetBrowserColumn::ColumnListModel::isFavoriteInAnyDatabase(const File& f) const
+{
+	if (auto* pb = parent.getComponent())
+		return pb->isFavoriteInAnyDatabase(f);
+	return false;
+}
+
+
 void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::buttonClicked(Button*)
 {
 	const bool newValue = !b->getToggleState();
@@ -489,6 +568,14 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::buttonClicked(Button
 
 	PresetBrowser::DataBaseHelpers::setFavorite(parent.database, f, newValue);
 
+	// Persist immediately so the change survives expansion switches and
+	// is visible in the expansion's db.json without needing to close the browser.
+	// Invalidate the cache so the next query reflects the new state.
+	if (auto* pb = findParentComponentOfClass<PresetBrowser>())
+	{
+		pb->saveCurrentDatabase();
+		pb->invalidateFavoritesCache();
+	}
 
 	refreshShape();
 
@@ -731,7 +818,7 @@ void PresetBrowserColumn::paint(Graphics& g)
 
 	StringArray columnNames = { "Expansion", "Nothing", "Bank", "Column" };
 
-	if (currentRoot == File() && listModel->wildcard.isEmpty() && listModel->currentlyActiveTags.isEmpty())
+	if (currentRoot == File() && listModel->wildcard.isEmpty() && listModel->currentlyActiveTags.isEmpty() && !listModel->getShowFavoritesOnly())
 		emptyText = "Select a " + columnNames[jlimit(0, 3, index+1)];
 	else if (listModel->isEmpty())
 		emptyText = isResultBar ? "No results" : "Add a " + name;

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -310,10 +310,15 @@ public:
 			showFavoritesOnly = shouldShowFavoritesOnly;
 		}
 
+		bool getShowFavoritesOnly() const { return showFavoritesOnly; }
+
 		File getFileForIndex(int fileIndex) const
 		{
 			return entries[fileIndex];
 		};
+
+		// Defined in the .cpp where PresetBrowser is fully declared.
+		bool isFavoriteInAnyDatabase(const File& f) const;
 
 		int getIndexForFile(const File& f) const
 		{


### PR DESCRIPTION
New Feature: Favourites Filter Across All Expansions

When no expansion is selected, the favourites filter now searches all expansions and the project root simultaneously. A lazy cache (cachedFavorites) is built from every expansion's db.json and rebuilt whenever the favourite state changes or an expansion is switched. Previously it only searched the currently active root.
Bug Fixes

Empty search box left results column visible — currentWildcard was being set to "**" instead of "*" when the search box was cleared while favourites were active. Fixed by only updating currentWildcard when the search text is actually non-empty.

"Select a Column" shown instead of favourites — When in favourites mode with no expansion selected, the preset column showed a placeholder instead of the favourites list. Fixed by adding a getShowFavoritesOnly() getter and guarding the placeholder condition with it.

Star buttons appearing un-toggled — Favourite overlay buttons checked only the active expansion's database, so cross-expansion favourites always appeared off. Fixed by routing the check through the new multi-root cache.

Favourite state lost on expansion switch — Switching expansion would overwrite unsaved in-memory favourite changes. Fixed by flushing the current database to disk before loading the new expansion, and writing to disk immediately on every star toggle.

Star button flickering — The overlay component was destroyed and recreated on every list refresh. Fixed by reusing the existing component where safe (same model owner), only recreating when the model has changed.

- When no expansion is selected, enable the favourites filter to search across all expansions
- Fix results column remaining visible after toggling favourites off while the search box was focused but empty (currentWildcard was incorrectly set to "**" instead of "*")
- Fix "Select a Column" shown in the results column instead of favourites when no expansion is selected; add getShowFavoritesOnly() getter to ColumnListModel so the paint() condition can check it without accessing the protected member directly

https://claude.ai/code/session_01PEwMhvyEVEH2d8vgHfzZpC
https://forum.hise.audio/topic/14492/expansion-wide-preset-search