### PR TITLE
Fix Linux build error: DELETE macro conflicts with RestServer::Method…

### DIFF
--- a/hi_backend/backend/ai_tools/RestServer.cpp
+++ b/hi_backend/backend/ai_tools/RestServer.cpp
@@ -41,6 +41,13 @@
 #undef Rectangle
 #endif
 
+// On Linux, resolv.h (included transitively by httplib.h) defines DELETE as
+// ns_uop_delete (= 0), which collides with the RestServer::Method::DELETE enum
+// value in switch statements. Undefine it here after all system headers are done.
+#ifdef DELETE
+#undef DELETE
+#endif
+
 namespace hise { using namespace juce;
 
 //==============================================================================


### PR DESCRIPTION
… enum

On Linux, resolv.h (included transitively via httplib.h's resolv.h pull-in when __linux__ is defined) defines DELETE as ns_uop_delete which equals 0. This collides with the RestServer::Method::DELETE enum value in switch statements, causing "duplicate case value" errors since GET also equals 0.

Undefine DELETE after all system headers are included in RestServer.cpp.

https://claude.ai/code/session_0136KCbr58YCTnir9yWDX7jW