### PR TITLE
Fix g.drawFittedText "function not found" by registering it in Graphi…

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -1749,6 +1749,7 @@ ScriptingObjects::GraphicsObject::GraphicsObject(ProcessorWithScriptingContent *
 	ADD_API_METHOD_2_DEPRECATED(drawText,       "use drawAlignedText for better placement");
 	ADD_API_METHOD_3(drawAlignedText);			CHECK_FONT_AND_COLOUR(drawAlignedText);
 	ADD_API_METHOD_4(drawAlignedTextShadow);	CHECK_FONT_AND_COLOUR(drawAlignedTextShadow)
+	ADD_API_METHOD_5(drawFittedText);			CHECK_FONT_AND_COLOUR(drawFittedText)
 	ADD_API_METHOD_5(drawMultiLineText);		CHECK_FONT_AND_COLOUR(drawMultiLineText)
 	ADD_API_METHOD_1(drawMarkdownText);
     ADD_API_METHOD_3(drawSVG);


### PR DESCRIPTION
…csObject

ADD_API_METHOD_5(drawFittedText) was missing from the GraphicsObject constructor, so the scripting engine never exposed the method on the g object. The wrapper macro, implementation, and draw action all existed but the registration call was simply absent.

https://claude.ai/code/session_017qLJ1sg8e2m9KV4gHL22UB