### PR TITLE
Add font and fontSize to drawWhiteNote/drawBlackNote LAF callback obj

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -296,6 +296,8 @@ public:
 		return getMainController()->getFontFromString(fontName, fontSize);
 	}
 
+	String getFontName() const { return fontName; }
+
 	/** This returns the title that is supposed to be displayed. */
     String getBestTitle() const;
 	

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5387,6 +5387,13 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawWhiteNote(CustomKeyboardSta
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
 
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			auto f = kp->getFont();
+			obj->setProperty("font", f.getTypefaceName());
+			obj->setProperty("fontSize", f.getHeight());
+		}
+
 		if (get()->callWithGraphics(g_, "drawWhiteNote", var(obj), c))
 			return;
 	}
@@ -5407,6 +5414,13 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawBlackNote(CustomKeyboardSta
 		obj->setProperty("hover", isOver);
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
+
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			auto f = kp->getFont();
+			obj->setProperty("font", f.getTypefaceName());
+			obj->setProperty("fontSize", f.getHeight());
+		}
 
 		if (get()->callWithGraphics(g_, "drawBlackNote", var(obj), c))
 			return;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5389,9 +5389,8 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawWhiteNote(CustomKeyboardSta
 
 		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
 		{
-			auto f = kp->getFont();
-			obj->setProperty("font", f.getTypefaceName());
-			obj->setProperty("fontSize", f.getHeight());
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
 		}
 
 		if (get()->callWithGraphics(g_, "drawWhiteNote", var(obj), c))
@@ -5417,9 +5416,8 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawBlackNote(CustomKeyboardSta
 
 		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
 		{
-			auto f = kp->getFont();
-			obj->setProperty("font", f.getTypefaceName());
-			obj->setProperty("fontSize", f.getHeight());
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
 		}
 
 		if (get()->callWithGraphics(g_, "drawBlackNote", var(obj), c))

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -1246,6 +1246,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             },
@@ -1271,6 +1279,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             }


### PR DESCRIPTION
Exposes the keyboard floating tile's Font and FontSize panel properties in the obj passed to drawWhiteNote and drawBlackNote scripted LAF callbacks, allowing script authors to use the configured font when drawing custom key labels.

https://claude.ai/code/session_01PemsiopLqyqjZb35AWzTZx