### PR TITLE
Preserve font style information in preset browser LAF callbacks

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -296,6 +296,8 @@ public:
 		return getMainController()->getFontFromString(fontName, fontSize);
 	}
 
+	String getFontName() const { return fontName; }
+
 	/** This returns the title that is supposed to be displayed. */
     String getBestTitle() const;
 	

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1093,7 +1093,8 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.highlightColour = findPanelColour(PanelColourId::itemColour1);
 	options.textColour = findPanelColour(PanelColourId::textColour);
 	options.font = getFont();
-	
+	options.fontName = getFontName();
+
 	presetBrowser->setOptions(options);
 }
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1291,6 +1291,7 @@ void PresetBrowser::setOptions(const Options& newOptions)
 
 	setHighlightColourAndFont(newOptions.highlightColour, newOptions.backgroundColour, newOptions.font);
 
+	getPresetBrowserLookAndFeel().fontName = newOptions.fontName;
 	getPresetBrowserLookAndFeel().textColour = newOptions.textColour;
 	setNumColumns(newOptions.numColumns);
 	columnWidthRatios.clear();

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -70,6 +70,7 @@ public:
 		Colour backgroundColour;
 		Colour textColour;
 		Font font;
+		String fontName;
 
 		int numColumns = 3;
 		Array<var> columnWidthRatios;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4732,7 +4732,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPresetBrowserBackground(Gra
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserBackground", var(obj), p))
@@ -4754,7 +4754,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawColumnBackground(Graphics& 
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserColumnBackground", var(obj), nullptr))
@@ -4779,7 +4779,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawListItem(Graphics& g_, Comp
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserListItem", var(obj), nullptr))
@@ -4799,7 +4799,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawSearchBar(Graphics& g_, Com
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		auto p = new ScriptingObjects::PathObject(get()->getScriptProcessor());
@@ -5973,7 +5973,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTag(Graphics& g_, Component
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserTag", var(obj), nullptr))
@@ -5996,7 +5996,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawModalOverlay(Graphics& g_, 
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (l->callWithGraphics(g_, "drawPresetBrowserDialog", var(obj), nullptr))

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -332,6 +332,7 @@ public:
 	Colour textColour;
 	Colour modalBackgroundColour;
 	Font font;
+	String fontName;
 };
 
 class DefaultPresetBrowserLookAndFeel : public LookAndFeel_V3,


### PR DESCRIPTION
The font property passed to preset browser LAF functions (drawPresetBrowserBackground, drawPresetBrowserColumnBackground, drawPresetBrowserListItem, etc.) was only using getTypefaceName() which strips style info like Bold/Medium. Now the original fontName string from the floating tile property is passed through directly, matching how MainController::getFontFromString() expects to parse font names.

https://claude.ai/code/session_015A3HusUqWAtmFB2sr4UqSf