### PR TITLE
Add getImageSize() to ScriptedLookAndFeel scripting API

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2506,6 +2506,7 @@ struct ScriptingObjects::ScriptedLookAndFeel::Wrapper
 	API_VOID_METHOD_WRAPPER_2(ScriptedLookAndFeel, loadImage);
 	API_VOID_METHOD_WRAPPER_0(ScriptedLookAndFeel, unloadAllImages);
 	API_METHOD_WRAPPER_1(ScriptedLookAndFeel, isImageLoaded);
+	API_METHOD_WRAPPER_1(ScriptedLookAndFeel, getImageSize);
 	API_VOID_METHOD_WRAPPER_1(ScriptedLookAndFeel, setInlineStyleSheet);
 	API_VOID_METHOD_WRAPPER_1(ScriptedLookAndFeel, setStyleSheet);
 	API_VOID_METHOD_WRAPPER_3(ScriptedLookAndFeel, setStyleSheetProperty);
@@ -2524,6 +2525,7 @@ ScriptingObjects::ScriptedLookAndFeel::ScriptedLookAndFeel(ProcessorWithScriptin
 	ADD_API_METHOD_2(loadImage);
 	ADD_API_METHOD_0(unloadAllImages);
 	ADD_API_METHOD_1(isImageLoaded);
+	ADD_API_METHOD_1(getImageSize);
 	ADD_API_METHOD_1(setInlineStyleSheet);
 	ADD_API_METHOD_1(setStyleSheet);
 	ADD_API_METHOD_3(setStyleSheetProperty);
@@ -6164,8 +6166,14 @@ bool ScriptingObjects::ScriptedLookAndFeel::isImageLoaded(String prettyName)
 		if (img.prettyName == prettyName)
 			return true;
 	}
-	
+
 	return false;
+}
+
+var ScriptingObjects::ScriptedLookAndFeel::getImageSize(String imageName)
+{
+	Image img = getLoadedImage(imageName);
+	return Array<var>(img.getWidth(), img.getHeight());
 }
 
 ScriptingObjects::ScriptedLookAndFeel::LocalLaf::LocalLaf(ScriptedLookAndFeel* l) :

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -1439,6 +1439,9 @@ namespace ScriptingObjects
 		/** Checks if the image has been loaded into the look and feel obkect */
 		bool isImageLoaded(String prettyName);
 
+		/** Returns the size of a loaded image as an array [width, height]. */
+		var getImageSize(String imageName);
+
 		// ========================================================================================
 
 		bool isUsingCSS() const { return !currentStyleSheet.isEmpty(); }


### PR DESCRIPTION
Exposes getImageSize(imageName) on look and feel objects, mirroring the same function already available (in an open [PR](https://github.com/christophhart/HISE/pull/403)) on panel paint routines. Returns an array [width, height] for a previously loaded image.

https://claude.ai/code/session_01WApaB6WbpPKZFxL2g2TJMU