### PR TITLE
Allow popup menu background to be transparent

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -874,6 +874,9 @@ void ScriptCreatedComponentWrapper::updatePopupPosition()
 
 		p.applyTransform(currentPopup->getTransform().inverted());
 
+		if (currentPopup->drawShadow)
+			p -= Point<int>(ValuePopup::shadowMargin, ValuePopup::shadowMargin);
+
 		currentPopup->setTopLeftPosition(p);
 	}
 }
@@ -3435,7 +3438,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		if(!area.isEmpty())
 		{
-			shadow = nullptr;
+			drawShadow = false;
 			currentText = thisText;
 			setSize(area.getWidth(), area.getHeight());
 			repaint();
@@ -3451,9 +3454,9 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		int margin = (int)p->getLayoutData().margin;
 
-		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5;
+		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5 + 2 * shadowMargin;
 
-		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin);
+		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin + 2 * shadowMargin);
 
 
 		repaint();
@@ -3470,15 +3473,21 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 	Properties::Ptr p = parent.contentComponent->getValuePopupProperties();
 
-	
-
 	if (p != nullptr)
 	{
 		auto l = p->getLayoutData();
 
-		auto ar = getLocalBounds().toFloat().reduced(l.lineThickness * 0.5f);
+		auto contentArea = getLocalBounds().toFloat().reduced((float)shadowMargin);
+		auto ar = contentArea.reduced(l.lineThickness * 0.5f);
 
-		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f, 
+		if (drawShadow)
+		{
+			Path shadowPath;
+			shadowPath.addRoundedRectangle(ar, l.radius);
+			shadow.drawForPath(g, shadowPath);
+		}
+
+		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f,
 										 p->getColour(Properties::itemColour2), 0.0f, (float)getHeight(), false));
 
 		g.fillRoundedRectangle(ar, l.radius);
@@ -3488,7 +3497,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 		g.setFont(p->getFont());
 		g.setColour(p->getColour(Properties::textColour));
-		g.drawText(currentText, getLocalBounds(), Justification::centred);
+		g.drawText(currentText, contentArea.toNearestInt(), Justification::centred);
 	}
 
 	

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.h
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.h
@@ -276,14 +276,14 @@ public:
 			JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Properties);
 		};
 
+		static constexpr int shadowMargin = 5;
+
 		ValuePopup(ScriptCreatedComponentWrapper& p):
 			parent(p),
-			shadow(new DropShadower({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }}))
+			shadow({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }})
 		{
 			f = GLOBAL_BOLD_FONT();
 
-			shadow->setOwner(this);
-			
 			updateText();
 			startTimer(30);
 		}
@@ -314,7 +314,8 @@ public:
 
 		ScriptCreatedComponentWrapper& parent;
 
-		ScopedPointer<DropShadower> shadow;
+		DropShadow shadow;
+		bool drawShadow = true;
 	};
 
 	struct AdditionalMouseCallback;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4448,6 +4448,20 @@ hise::MarkdownLayout::StyleData ScriptingObjects::ScriptedLookAndFeel::Laf::getA
 	return s;
 }
 
+void ScriptingObjects::ScriptedLookAndFeel::Laf::preparePopupMenuWindow(Component& newWindow)
+{
+	// Force the component to be non-opaque so it doesn't fill with white before drawing
+	if (functionDefined("drawPopupMenuBackground"))
+	{
+		newWindow.setOpaque(false);
+	}
+}
+int ScriptingObjects::ScriptedLookAndFeel::Laf::getMenuWindowFlags()
+{
+    return LookAndFeel_V2::getMenuWindowFlags()
+           & ~ComponentPeer::windowHasDropShadow;
+}
+
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphics& g_, int width, int height)
 {
 	if (functionDefined("drawPopupMenuBackground"))

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -856,6 +856,9 @@ namespace ScriptingObjects
 
 			MarkdownLayout::StyleData getAlertWindowMarkdownStyleData() override;
 
+			void preparePopupMenuWindow(Component& newWindow) override;
+			int getMenuWindowFlags();
+
 			void drawPopupMenuBackground(Graphics& g_, int width, int height) override;
 
 			void drawPopupMenuItem(Graphics& g, const Rectangle<int>& area,


### PR DESCRIPTION
This brings together three previous PRs.

Closes #805 

Remove drop shadow from popup menus using custom laf on Windows

Fix square background behind rounded value popup

Replace DropShadower with manually-painted DropShadow using a rounded rectangle path. The DropShadower rendered shadow based on rectangular component bounds, causing a visible square background when itemColour and itemColour2 were set to transparent. Now the shadow follows the rounded shape defined by borderRadius, allowing truly rounded popups.

https://claude.ai/code/session_01V2DtUFT6hpxSYF9aozG2z6