### PR TITLE
Add Engine.showMessageBoxWithCallback and refactor message handling

### DIFF
--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -646,23 +646,23 @@ bool PresetHandler::showYesNoWindowIfMessageThread(const String &title, const St
 
 void PresetHandler::showMessageWindow(const String &title, const String &message, PresetHandler::IconType type)
 {
-	if (MessageManager::getInstanceWithoutCreating()->isThisTheMessageThread())
-	{
-#if USE_BACKEND
-		if (CompileExporter::isExportingFromCommandLine())
-		{
-			std::cout << title << ": " << message << std::endl;
-			return;
-		}
-
+#if HISE_HEADLESS
+	return;
 #endif
 
+#if USE_BACKEND
+	if (CompileExporter::isExportingFromCommandLine())
+	{
+		std::cout << title << ": " << message << std::endl;
+		return;
+	}
+#endif
+
+	if (MessageManager::getInstanceWithoutCreating()->isThisTheMessageThread())
+	{
 #if HISE_IOS
-
 		NativeMessageBox::showMessageBox(AlertWindow::AlertIconType::NoIcon, title, message);
-
 #else
-
 		ScopedPointer<LookAndFeel> laf = createAlertWindowLookAndFeel();
 		ScopedPointer<MessageWithIcon> comp = new MessageWithIcon(type, laf, message);
 		ScopedPointer<AlertWindow> nameWindow = new AlertWindow(title, "", AlertWindow::AlertIconType::NoIcon);
@@ -673,8 +673,6 @@ void PresetHandler::showMessageWindow(const String &title, const String &message
 
 		nameWindow->runModalLoop();
 #endif
-
-		return;
 	}
 	else
 	{
@@ -683,7 +681,7 @@ void PresetHandler::showMessageWindow(const String &title, const String &message
 			showMessageWindow(title, message, type);
 		});
 	}
-};
+}
 
 struct CountedProcessorId
 {

--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -1264,6 +1264,7 @@ struct ScriptingApi::Engine::Wrapper
 	API_METHOD_WRAPPER_0(Engine, createMacroHandler);
 	API_METHOD_WRAPPER_0(Engine, getWavetableList);
 	API_VOID_METHOD_WRAPPER_3(Engine, showYesNoWindow);
+	API_VOID_METHOD_WRAPPER_4(Engine, showMessageBoxWithCallback);
 	API_VOID_METHOD_WRAPPER_1(Engine, addModuleStateToUserPreset);
 	API_VOID_METHOD_WRAPPER_0(Engine, rebuildCachedPools);
 	API_VOID_METHOD_WRAPPER_1(Engine, extendTimeOut);
@@ -1443,6 +1444,7 @@ parentMidiProcessor(dynamic_cast<ScriptBaseMidiProcessor*>(p))
 	ADD_API_METHOD_0(createExpansionHandler);
 	ADD_API_METHOD_1(createModulationMatrix);
 	ADD_API_METHOD_3(showYesNoWindow);
+	ADD_API_METHOD_4(showMessageBoxWithCallback);
 	ADD_API_METHOD_3(showMessageBox);
 	ADD_API_METHOD_1(getSystemTime);
 	ADD_API_METHOD_0(createLicenseUnlocker);
@@ -2014,6 +2016,30 @@ void ScriptingApi::Engine::showMessageBox(String title, String markdownMessage, 
 	});
 }
 
+void ScriptingApi::Engine::showMessageBoxWithCallback(String title, String markdownMessage, int type, var callback)
+{
+	static bool isMessageBoxOpen = false;
+
+	if (isMessageBoxOpen)
+		return;
+
+	isMessageBoxOpen = true;
+
+	auto p = getScriptProcessor();
+
+	WeakCallbackHolder cb(p, this, callback, 0);
+	cb.incRefCount();
+
+	auto f = [markdownMessage, title, cb, type]() mutable
+	{
+		PresetHandler::showMessageWindow(title, markdownMessage, (PresetHandler::IconType)type);
+		cb.call({});
+		isMessageBoxOpen = false;
+	};
+	
+	MessageManager::callAsync(f);	
+}
+
 void ScriptingApi::Engine::showYesNoWindow(String title, String markdownMessage, var callback)
 {
 	//auto p = dynamic_cast<JavascriptProcessor*>(getScriptProcessor());
@@ -2032,8 +2058,6 @@ void ScriptingApi::Engine::showYesNoWindow(String title, String markdownMessage,
 
 	MessageManager::callAsync(f);
 }
-
-
 
 String ScriptingApi::Engine::decodeBase64ValueTree(const String& b64Data)
 {

--- a/hi_scripting/scripting/api/ScriptingApi.h
+++ b/hi_scripting/scripting/api/ScriptingApi.h
@@ -456,6 +456,9 @@ public:
 		/** Shows a message box with an OK button and a icon defined by the type variable. */
 		void showMessageBox(String title, String markdownMessage, int type);
 
+		/** Shows a message box with an OK button and calls the callback after the user clicks OK. */
+		void showMessageBoxWithCallback(String title, String markdownMessage, int type, var callback);
+
 		/** Returns the millisecond value for the supplied tempo (HINT: Use "TempoSync" mode from Slider!) */
 		double getMilliSecondsForTempo(int tempoIndex) const;;
 


### PR DESCRIPTION
Introduce Engine.showMessageBoxWithCallback for scriptable message dialogs with a completion callback. Refactor PresetHandler::showMessageWindow for clearer control flow, correct return paths, and more idiomatic use of callAsync, removing unnecessary return logic and unused variables.