### PR TITLE
Draw note font

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -296,6 +296,8 @@ public:
 		return getMainController()->getFontFromString(fontName, fontSize);
 	}
 
+	String getFontName() const { return fontName; }
+
 	/** This returns the title that is supposed to be displayed. */
     String getBestTitle() const;
 	

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -827,14 +827,8 @@ int Note::getFixedHeight() const
 PerformanceLabelPanel::PerformanceLabelPanel(FloatingTile* parent) :
 	FloatingTileContent(parent)
 {
-	addAndMakeVisible(statisticLabel = new Label());
-	statisticLabel->setEditable(false, false);
-	statisticLabel->setColour(Label::ColourIds::textColourId, Colours::white);
-
 	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::transparentBlack);
-
-	statisticLabel->setFont(GLOBAL_BOLD_FONT());
 
 	startTimer(200);
 }
@@ -843,9 +837,8 @@ void PerformanceLabelPanel::timerCallback()
 {
 	auto mc = getMainController();
 
-	const int cpuUsage = (int)mc->getCpuUsage();
-	const int voiceAmount = mc->getNumActiveVoices();
-
+	cpuUsage = mc->getCpuUsage();
+	voiceAmount = mc->getNumActiveVoices();
 
 	auto bytes = mc->getSampleManager().getModulatorSamplerSoundPool2()->getMemoryUsageForAllSamples();
 
@@ -856,30 +849,44 @@ void PerformanceLabelPanel::timerCallback()
 		bytes += handler.getExpansion(i)->pool->getSamplePool()->getMemoryUsageForAllSamples();
 	}
 
-	const double ramUsage = (double)bytes / 1024.0 / 1024.0;
+	ramUsage = (int64)bytes;
 
-	//const bool midiFlag = mc->checkAndResetMidiInputFlag();
-
-	//activityLed->setOn(midiFlag);
-
-	String stats = "CPU: ";
-	stats << String(cpuUsage) << "%, RAM: " << String(ramUsage, 1) << "MB , Voices: " << String(voiceAmount);
-	statisticLabel->setText(stats, dontSendNotification);
+	repaint();
 }
 
 
+
+void PerformanceLabelPanel::LookAndFeelMethods::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
+}
+
+void PerformanceLabelPanel::paint(Graphics& g)
+{
+	g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
+
+	if (auto laf = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+		laf->drawPerformanceLabel(g, *this, cpuUsage, ramUsage, voiceAmount);
+	else
+	{
+		g.setColour(findPanelColour(FloatingTileContent::PanelColourId::textColour));
+		g.setFont(getFont());
+		String stats = "CPU: " + String(cpuUsage, 1) + "%, RAM: " + String((double)ramUsage / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voiceAmount);
+		g.drawText(stats, getLocalBounds(), Justification::centredLeft);
+	}
+}
 
 void PerformanceLabelPanel::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
-
-	statisticLabel->setColour(Label::ColourIds::textColourId, findPanelColour(PanelColourId::textColour));
-	statisticLabel->setFont(getFont());
 }
 
 void PerformanceLabelPanel::resized()
 {
-	statisticLabel->setBounds(getLocalBounds());
 }
 
 bool PerformanceLabelPanel::showTitleInPresentationMode() const

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -425,6 +425,13 @@ class PerformanceLabelPanel : public Component,
 {
 public:
 
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {};
+		virtual void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+		                                  float cpu, int64 ram, int voices);
+	};
+
 	PerformanceLabelPanel(FloatingTile* parent);
 
 	SET_PANEL_NAME("PerformanceLabel");
@@ -433,15 +440,13 @@ public:
 	void fromDynamicObject(const var& object) override;
 	void resized() override;
 	bool showTitleInPresentationMode() const override;
-
-	void paint(Graphics& g) override
-	{
-		g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
-	}
+	void paint(Graphics& g) override;
 
 private:
 
-	ScopedPointer<Label> statisticLabel;
+	float cpuUsage = 0.0f;
+	int voiceAmount = 0;
+	int64 ramUsage = 0;
 };
 
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2729,7 +2729,8 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
 		"drawFlexAhdsrFullPath",
 		"drawFlexAhdsrPosition",
 		"drawFlexAhdsrSegment",
-		"drawFlexAhdsrText"
+		"drawFlexAhdsrText",
+		"drawPerformanceLabel"
 	};
 
 	return sa;
@@ -6014,6 +6015,40 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrText(Graphics& g_,
     }
 
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrText(g_, graph, text);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	if (functionDefined("drawPerformanceLabel"))
+	{
+		auto obj = new DynamicObject();
+
+		writeId(obj, &panel);
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, panel.getLocalBounds().toFloat()));
+
+		obj->setProperty("bgColour",     (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+		obj->setProperty("textColour",   (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+		obj->setProperty("itemColour1",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+		obj->setProperty("itemColour2",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+		obj->setProperty("itemColour3",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+
+		obj->setProperty("font",     panel.getFontName());
+		obj->setProperty("fontSize", panel.getFont().getHeight());
+
+		obj->setProperty("cpu",    cpu);
+		obj->setProperty("ram",    ram);
+		obj->setProperty("voices", voices);
+
+		if (get()->callWithGraphics(g, "drawPerformanceLabel", var(obj), &panel))
+			return;
+	}
+
+	// Default fallback
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
 }
 
 juce::Image ScriptingObjects::ScriptedLookAndFeel::Laf::createIcon(PresetHandler::IconType type)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5388,6 +5388,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawWhiteNote(CustomKeyboardSta
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
 
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
+
 		if (get()->callWithGraphics(g_, "drawWhiteNote", var(obj), c))
 			return;
 	}
@@ -5408,6 +5414,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawBlackNote(CustomKeyboardSta
 		obj->setProperty("hover", isOver);
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
+
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
 
 		if (get()->callWithGraphics(g_, "drawBlackNote", var(obj), c))
 			return;

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -835,7 +835,8 @@ namespace ScriptingObjects
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
-			public HiSlider::HoverPopupLookandFeel
+			public HiSlider::HoverPopupLookandFeel,
+			public PerformanceLabelPanel::LookAndFeelMethods
 		{
 			Laf(MainController* mc);
 
@@ -965,6 +966,9 @@ namespace ScriptingObjects
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 			void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
+
+			void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+			                         float cpu, int64 ram, int voices) override;
 
 			Image createIcon(PresetHandler::IconType type) override;
 

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -2695,6 +2695,63 @@
               }
             }
           }
+        },
+        "PerformanceLabel": {
+          "lafFunctions": {
+            "drawPerformanceLabel": {
+              "description": "Draws the performance statistics floating tile (CPU usage, RAM usage, active voice count)",
+              "callbackProperties": {
+                "id": {
+                  "type": "String",
+                  "description": "The component's ID from getComponentID()"
+                },
+                "area": {
+                  "type": "Array[x, y, w, h]",
+                  "description": "The panel bounds"
+                },
+                "bgColour": {
+                  "type": "int (ARGB)",
+                  "description": "Background colour (ColourData::bgColour)"
+                },
+                "textColour": {
+                  "type": "int (ARGB)",
+                  "description": "Text colour (ColourData::textColour)"
+                },
+                "itemColour1": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 1 (ColourData::itemColour1)"
+                },
+                "itemColour2": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 2 (ColourData::itemColour2)"
+                },
+                "itemColour3": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 3 (ColourData::itemColour3)"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "Typeface name from the panel's Font setting"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "Font size from the panel's FontSize setting"
+                },
+                "cpu": {
+                  "type": "float",
+                  "description": "Current CPU usage as a percentage (0.0-100.0)"
+                },
+                "ram": {
+                  "type": "int64",
+                  "description": "Current RAM usage in bytes"
+                },
+                "voices": {
+                  "type": "int",
+                  "description": "Number of currently active voices"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -1246,6 +1246,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             },
@@ -1271,6 +1279,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             }


### PR DESCRIPTION
Depends on #917 

Exposes the keyboard floating tile's Font and FontSize panel properties
in the obj passed to drawWhiteNote and drawBlackNote scripted LAF
callbacks, allowing script authors to use the configured font when
drawing custom key labels.

https://claude.ai/code/session_01PemsiopLqyqjZb35AWzTZx

Fix font property in drawWhiteNote/drawBlackNote callbacks including style

getTypefaceName() returns only the family name ("Inter"), dropping the
style suffix. Add getFontName() getter to FloatingTileContent to expose
the raw fontName string ("Inter Bold", "Inter Medium", etc.) and use
that for the font callback property instead.

https://claude.ai/code/session_01PemsiopLqyqjZb35AWzTZx