### PR TITLE
Popup menu laf colours and font

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -296,6 +296,8 @@ public:
 		return getMainController()->getFontFromString(fontName, fontSize);
 	}
 
+	String getFontName() const { return fontName; }
+
 	/** This returns the title that is supposed to be displayed. */
     String getBestTitle() const;
 	

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1656,20 +1656,10 @@ juce::String MidiLearnPanel::getCellText(int rowNumber, int columnId) const
 TableFloatingTileBase::InvertedButton::InvertedButton(TableFloatingTileBase &owner_) :
 	owner(owner_)
 {
-	laf.setFontForAll(owner.font);
-
-	addAndMakeVisible(t = new TextButton("Inverted"));
-	t->setButtonText("Inverted");
-	t->setLookAndFeel(&laf);
-	t->setConnectedEdges(Button::ConnectedOnLeft | Button::ConnectedOnRight);
+	addAndMakeVisible(t = new ToggleButton("Inverted"));
+	t->setButtonText("Normal");
 	t->addListener(this);
 	t->setTooltip("Invert the range of the macro control for this parameter.");
-	t->setColour(TextButton::buttonColourId, Colour(0x88000000));
-	t->setColour(TextButton::buttonOnColourId, Colour(0x88FFFFFF));
-	t->setColour(TextButton::textColourOnId, Colour(0xaa000000));
-	t->setColour(TextButton::textColourOffId, Colour(0x99ffffff));
-
-	t->setClickingTogglesState(true);
 }
 
 void TableFloatingTileBase::InvertedButton::resized()
@@ -1696,9 +1686,6 @@ TableFloatingTileBase::ValueSliderColumn::ValueSliderColumn(TableFloatingTileBas
 {
 	addAndMakeVisible(slider = new RangeSlider());
 
-	laf.setFontForAll(table.font);
-
-	slider->setLookAndFeel(&laf);
 	slider->setSliderStyle(Slider::LinearBar);
 	slider->setTextBoxStyle(Slider::TextBoxLeft, true, 80, 20);
 	slider->setColour(Slider::backgroundColourId, Colour(0x38ffffff));
@@ -1737,6 +1724,33 @@ void TableFloatingTileBase::ValueSliderColumn::sliderValueChanged(Slider *)
 		slider->setValue(actualValue, dontSendNotification);
 }
 
+void TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (rowIsSelected)
+		g.fillAll(Colours::white.withAlpha(0.2f));
+}
+
+void TableFloatingTileBase::LookAndFeelMethods::drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	g.setColour(d.textColour);
+	g.setFont(d.f);
+	g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+}
+
+TableFloatingTileBase::LookAndFeelData TableFloatingTileBase::getLookAndFeelData() const
+{
+	LookAndFeelData d;
+	d.f = font;
+	d.fontName = getFontName();
+	d.textColour = textColour;
+	d.bgColour = findPanelColour(FloatingTileContent::PanelColourId::bgColour);
+	d.itemColour1 = itemColour1;
+	d.itemColour2 = itemColour2;
+	d.itemColour3 = findPanelColour(FloatingTileContent::PanelColourId::itemColour3);
+	d.parentType = getIdentifierForBaseClass().toString();
+	return d;
+}
+
 TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 	FloatingTileContent(parent),
 	font(GLOBAL_FONT())
@@ -1746,6 +1760,8 @@ TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 
 void TableFloatingTileBase::initTable(bool addChannelColumn)
 {
+	hasChannelColumn = addChannelColumn;
+
 	// Create our table component and add it to this component..
 	addAndMakeVisible(table);
 	table.setModel(this);
@@ -1783,9 +1799,9 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 		table.getHeader().addColumn("Channel", Channel, fWidth, 30, -1, TableHeaderComponent::visible);
 
 	table.getHeader().addColumn("Parameter", ParameterName, 70, 30, -1);
-	table.getHeader().addColumn("Inverted", Inverted, 70, 70, 70);
-	table.getHeader().addColumn("Min", Minimum, 70, 70, 70);
-	table.getHeader().addColumn("Max", Maximum, 70, 70, 70);
+	table.getHeader().addColumn("Inverted", Inverted, 70, 30, -1);
+	table.getHeader().addColumn("Min", Minimum, 70, 30, -1);
+	table.getHeader().addColumn("Max", Maximum, 70, 30, -1);
 	table.getHeader().setStretchToFitActive(true);
 }
 
@@ -1794,9 +1810,44 @@ void TableFloatingTileBase::updateContent()
 	table.updateContent();
 }
 
+var TableFloatingTileBase::toDynamicObject() const
+{
+	auto obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, SpecialPanelIds::ColumnWidthRatio, var(columnWidthRatios));
+	return obj;
+}
+
+Identifier TableFloatingTileBase::getDefaultablePropertyId(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultablePropertyId(index);
+
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnWidthRatio, "ColumnWidthRatio");
+
+	return {};
+}
+
+var TableFloatingTileBase::getDefaultProperty(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultProperty(index);
+
+	Array<var> defaultRatios;
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ColumnWidthRatio, var(defaultRatios));
+
+	return {};
+}
+
 void TableFloatingTileBase::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
+
+	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
+	if (ratios.isArray())
+	{
+		columnWidthRatios.clear();
+		columnWidthRatios.addArray(*ratios.getArray());
+	}
 
 	table.setColour(ListBox::backgroundColourId, findPanelColour(FloatingTileContent::PanelColourId::bgColour));
 
@@ -1814,42 +1865,46 @@ void TableFloatingTileBase::paintRowBackground(Graphics& g, int rowNumber, int w
 {
 	using namespace simple_css;
 
-	if(auto rootDialog = CSSRootComponent::find(*this))
+	auto& rootDialog = *CSSRootComponent::find(*this);
+
+	if(auto ss = rootDialog.css.getWithAllStates(this, (Selector(ElementType::TableRow))))
 	{
-		if(auto ss = rootDialog->css.getWithAllStates(this, (Selector(ElementType::TableRow))))
+		Renderer r(nullptr, rootDialog.stateWatcher);
+
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		int flags = 0;
+
+		if(rowNumber == hoverRow)
 		{
-			Renderer r(nullptr, rootDialog->stateWatcher);
+			flags |= (int)PseudoClassType::Hover;
 
-			auto point = table.getMouseXYRelative();
-			auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
-
-			int flags = 0;
-
-			if(rowNumber == hoverRow)
+			if(isMouseButtonDownAnywhere())
 			{
-				flags |= (int)PseudoClassType::Hover;
-
-				if(isMouseButtonDownAnywhere())
-				{
-					flags |= (int)PseudoClassType::Active;
-				}
+				flags |= (int)PseudoClassType::Active;
 			}
-
-			if(rowIsSelected)
-				flags |= (int)PseudoClassType::Focus;
-
-			r.setPseudoClassState(flags);
-			r.drawBackground(g, {0.0f, 0.0f, (float)width, (float)height}, ss);
-
-			return;
 		}
+
+		if(rowIsSelected)
+			flags |= (int)PseudoClassType::Focus;
+
+		r.setPseudoClassState(flags);
+		r.drawBackground(g, {0.0f, 0.0f, (float)width, (float)height}, ss);
+	}
+	else
+	{
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		lafToUse->drawTableRowBackground(g, getLookAndFeelData(), rowNumber, width, height, rowIsSelected, rowNumber == hoverRow);
 	}
 
-	if (rowIsSelected)
-	{
-		g.fillAll(Colours::white.withAlpha(0.2f));
-	}
-	
 }
 
 void TableFloatingTileBase::resized()
@@ -1867,6 +1922,8 @@ void TableFloatingTileBase::resized()
 
 			if (root->css.getWithAllStates(this, simple_css::Selector("th")) != nullptr)
 				table.getHeader().setLookAndFeel(css_laf);
+			else if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+				table.getHeader().setLookAndFeel(&getLookAndFeel());
 			else
 				table.getHeader().setLookAndFeel(laf);
 		}
@@ -1950,9 +2007,34 @@ void TableFloatingTileBase::resized()
 
 	}
 
-	
-	
+	if (css_laf == nullptr)
+	{
+		if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+			table.getHeader().setLookAndFeel(&getLookAndFeel());
+		else
+			table.getHeader().setLookAndFeel(laf);
+	}
+
 	table.setBounds(getLocalBounds());
+
+	if (columnWidthRatios.size() > 0)
+	{
+		auto numCols = table.getHeader().getNumColumns(true);
+
+		if (columnWidthRatios.size() == numCols)
+		{
+			table.getHeader().setStretchToFitActive(false);
+			auto w = (double)getWidth();
+
+			for (int i = 0; i < numCols; i++)
+			{
+				auto id = table.getHeader().getColumnIdOfIndex(i, true);
+				auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
+				auto colWidth = roundToInt(w * r);
+				table.getHeader().setColumnWidth(id, colWidth);
+			}
+		}
+	}
 }
 
 double TableFloatingTileBase::setRangeValue(int row, ColumnId column, double newRangeValue)
@@ -2043,15 +2125,14 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 		{
 			slider = new ValueSliderColumn(*this);
 
-			if(auto root = simple_css::CSSRootComponent::find(*this))
+			auto& root = *simple_css::CSSRootComponent::find(*this);
+
+			if(auto ss = root.css.getWithAllStates(this, simple_css::Selector(".range-slider")))
 			{
-				if(auto ss = root->css.getWithAllStates(this, simple_css::Selector(".range-slider")))
-				{
-					simple_css::FlexboxComponent::Helpers::writeClassSelectors(*slider->slider, { simple_css::Selector(".range-slider")}, true);
-					slider->slider->setLookAndFeel(css_laf.get());
-					slider->slider->setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
-					slider->slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
-				}
+				simple_css::FlexboxComponent::Helpers::writeClassSelectors(*slider->slider, { simple_css::Selector(".range-slider")}, true);
+				slider->slider->setLookAndFeel(css_laf.get());
+				slider->slider->setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
+				slider->slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
 			}
 		}
 		
@@ -2062,10 +2143,11 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 
 		slider->slider->setDoubleClickReturnValue(true, columnId == Maximum ? fullRange.end : fullRange.start);
 
+		slider->slider->setComponentID(columnId == Maximum ? "max" : "min");
 		slider->slider->setColour(Slider::ColourIds::backgroundColourId, Colours::transparentBlack);
 		slider->slider->setColour(Slider::ColourIds::thumbColourId, itemColour1);
 		slider->slider->setColour(Slider::ColourIds::textBoxTextColourId, textColour);
-		
+
 		slider->setRowAndColumn(rowNumber, (ColumnId)columnId, value, fullRange);
 
 		ValueToTextConverter vtc = getValueToTextConverter(rowNumber);
@@ -2083,18 +2165,16 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 		if (b == nullptr)
 			b = new InvertedButton(*this);
 
-		if(auto root = simple_css::CSSRootComponent::find(*this))
+		auto& root = *simple_css::CSSRootComponent::find(*this);
+
+		if(css_laf != nullptr && root.css.getWithAllStates(this, simple_css::Selector("button")))
 		{
-			if(css_laf != nullptr && root->css.getWithAllStates(this, simple_css::Selector("button")))
-			{
-				b->t->setLookAndFeel(css_laf.get());
-			}
+			b->t->setLookAndFeel(css_laf.get());
 		}
 		
-		b->t->setColour(TextButton::buttonOnColourId, itemColour1);
-		b->t->setColour(TextButton::textColourOnId, textColour);
-		b->t->setColour(TextButton::buttonColourId, Colours::transparentBlack);
-		b->t->setColour(TextButton::textColourOffId, textColour);
+		b->t->setColour(ToggleButton::textColourId, textColour);
+		b->t->setColour(ToggleButton::tickColourId, itemColour1);
+		b->t->setColour(ToggleButton::tickDisabledColourId, textColour);
 
 		b->setRowAndColumn(rowNumber, isInverted(rowNumber));
 
@@ -2112,31 +2192,36 @@ void TableFloatingTileBase::paintCell(Graphics& g, int rowNumber, int columnId, 
 {
 	using namespace simple_css;
 
+	auto& rootDialog = *CSSRootComponent::find(*this);
 	auto text = getCellText(rowNumber, columnId);
 
-	if(auto rootDialog = CSSRootComponent::find(*this))
+	if(auto ss = rootDialog.css.getWithAllStates(this, Selector(ElementType::TableCell)))
 	{
-		if(auto ss = rootDialog->css.getWithAllStates(this, Selector(ElementType::TableCell)))
-		{
-			Renderer r(nullptr, rootDialog->stateWatcher);
-			auto state = r.getPseudoClassFromComponent(this);
-                
-			if(rowIsSelected)
-				state |= (int)PseudoClassType::Focus;
+		Renderer r(nullptr, rootDialog.stateWatcher);
+		auto state = r.getPseudoClassFromComponent(this);
 
-			Rectangle<float> b(0.0, 0.0, (float)width, (float)height);
+		if(rowIsSelected)
+			state |= (int)PseudoClassType::Focus;
 
-			r.setPseudoClassState(state);
-			r.drawBackground(g, b, ss);
-			r.renderText(g, b, text, ss);
+		Rectangle<float> b(0.0, 0.0, (float)width, (float)height);
 
-			return;
-		}
+		r.setPseudoClassState(state);
+		r.drawBackground(g, b, ss);
+		r.renderText(g, b, text, ss);
 	}
+	else
+	{
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
 
-	g.setColour(textColour);
-	g.setFont(font);
-	g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		auto visualIndex = table.getHeader().getIndexOfColumnId(columnId, true);
+		lafToUse->drawTableCell(g, getLookAndFeelData(), text, rowNumber, visualIndex, width, height, rowIsSelected, false, rowNumber == hoverRow);
+	}
 }
 
 } // namespace hise

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -827,14 +827,8 @@ int Note::getFixedHeight() const
 PerformanceLabelPanel::PerformanceLabelPanel(FloatingTile* parent) :
 	FloatingTileContent(parent)
 {
-	addAndMakeVisible(statisticLabel = new Label());
-	statisticLabel->setEditable(false, false);
-	statisticLabel->setColour(Label::ColourIds::textColourId, Colours::white);
-
 	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::transparentBlack);
-
-	statisticLabel->setFont(GLOBAL_BOLD_FONT());
 
 	startTimer(200);
 }
@@ -843,9 +837,8 @@ void PerformanceLabelPanel::timerCallback()
 {
 	auto mc = getMainController();
 
-	const int cpuUsage = (int)mc->getCpuUsage();
-	const int voiceAmount = mc->getNumActiveVoices();
-
+	cpuUsage = mc->getCpuUsage();
+	voiceAmount = mc->getNumActiveVoices();
 
 	auto bytes = mc->getSampleManager().getModulatorSamplerSoundPool2()->getMemoryUsageForAllSamples();
 
@@ -856,30 +849,44 @@ void PerformanceLabelPanel::timerCallback()
 		bytes += handler.getExpansion(i)->pool->getSamplePool()->getMemoryUsageForAllSamples();
 	}
 
-	const double ramUsage = (double)bytes / 1024.0 / 1024.0;
+	ramUsage = (int64)bytes;
 
-	//const bool midiFlag = mc->checkAndResetMidiInputFlag();
-
-	//activityLed->setOn(midiFlag);
-
-	String stats = "CPU: ";
-	stats << String(cpuUsage) << "%, RAM: " << String(ramUsage, 1) << "MB , Voices: " << String(voiceAmount);
-	statisticLabel->setText(stats, dontSendNotification);
+	repaint();
 }
 
 
+
+void PerformanceLabelPanel::LookAndFeelMethods::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
+}
+
+void PerformanceLabelPanel::paint(Graphics& g)
+{
+	g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
+
+	if (auto laf = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+		laf->drawPerformanceLabel(g, *this, cpuUsage, ramUsage, voiceAmount);
+	else
+	{
+		g.setColour(findPanelColour(FloatingTileContent::PanelColourId::textColour));
+		g.setFont(getFont());
+		String stats = "CPU: " + String(cpuUsage, 1) + "%, RAM: " + String((double)ramUsage / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voiceAmount);
+		g.drawText(stats, getLocalBounds(), Justification::centredLeft);
+	}
+}
 
 void PerformanceLabelPanel::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
-
-	statisticLabel->setColour(Label::ColourIds::textColourId, findPanelColour(PanelColourId::textColour));
-	statisticLabel->setFont(getFont());
 }
 
 void PerformanceLabelPanel::resized()
 {
-	statisticLabel->setBounds(getLocalBounds());
 }
 
 bool PerformanceLabelPanel::showTitleInPresentationMode() const

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -425,6 +425,13 @@ class PerformanceLabelPanel : public Component,
 {
 public:
 
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {};
+		virtual void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+		                                  float cpu, int64 ram, int voices);
+	};
+
 	PerformanceLabelPanel(FloatingTile* parent);
 
 	SET_PANEL_NAME("PerformanceLabel");
@@ -433,15 +440,13 @@ public:
 	void fromDynamicObject(const var& object) override;
 	void resized() override;
 	bool showTitleInPresentationMode() const override;
-
-	void paint(Graphics& g) override
-	{
-		g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
-	}
+	void paint(Graphics& g) override;
 
 private:
 
-	ScopedPointer<Label> statisticLabel;
+	float cpuUsage = 0.0f;
+	int voiceAmount = 0;
+	int64 ramUsage = 0;
 };
 
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -713,9 +713,33 @@ public:
 		Inverted,
 		Minimum,
 		Maximum,
-		numColumns,
-		columnWidthRatio
+		numColumns
 	};
+
+	enum SpecialPanelIds
+	{
+		ColumnWidthRatio = (int)FloatingTileContent::PanelPropertyId::numPropertyIds,
+		numSpecialPanelIds
+	};
+
+	struct LookAndFeelData
+	{
+		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
+		String parentType;
+	};
+
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {}
+
+		virtual void drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered);
+
+		virtual void drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered);
+	};
+
+	LookAndFeelData getLookAndFeelData() const;
 
 	TableFloatingTileBase(FloatingTile* parent);
 	void initTable(bool addChannelColumn=false);
@@ -723,7 +747,13 @@ public:
 	virtual ~TableFloatingTileBase() {};
 
 	void updateContent();
-	void fromDynamicObject(const var& object);
+
+	int getNumDefaultableProperties() const override { return (int)SpecialPanelIds::numSpecialPanelIds; }
+	Identifier getDefaultablePropertyId(int index) const override;
+	var getDefaultProperty(int index) const override;
+	var toDynamicObject() const override;
+	void fromDynamicObject(const var& object) override;
+
 	void paintRowBackground(Graphics& g, int /*rowNumber*/, int /*width*/, int /*height*/, bool rowIsSelected) override;
 
 	//==============================================================================
@@ -822,8 +852,6 @@ protected:
 	private:
 		TableFloatingTileBase &owner;
 
-		HiPropertyPanelLookAndFeel laf;
-
 		int row;
 		int columnId;
 
@@ -840,7 +868,7 @@ protected:
 		void setRowAndColumn(const int newRow, bool value);
 		void buttonClicked(Button *b);;
 
-		ScopedPointer<TextButton> t;
+		ScopedPointer<ToggleButton> t;
 
 	private:
 
@@ -854,8 +882,11 @@ protected:
 	TableListBox table;     // the table component itself
 	Font font;
 	int numRows;            // The number of rows of data we've got
+	Array<var> columnWidthRatios;
+	bool hasChannelColumn = false;
 	ScopedPointer<TableHeaderLookAndFeel> laf;
 	ScopedPointer<simple_css::StyleSheetLookAndFeel> css_laf;
+	LookAndFeelMethods fallbackLaf;
 };
 
 

--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -2192,6 +2192,7 @@ HiComboBox::HiComboBox(const String& name):
 {
 	addChildComponent(numberTag);
 	font = GLOBAL_FONT();
+	fontName = "Default";
 
 	addListener(this);
 

--- a/hi_core/hi_core/MacroControlledComponents.h
+++ b/hi_core/hi_core/MacroControlledComponents.h
@@ -465,10 +465,11 @@ public:
 
 
 	bool customPopup = false;
-    
+
 	NormalisableRange<double> getRange() const override;;
-	
+
 	Font font;
+	String fontName;
 };
 
 class MomentaryToggleButton: public ToggleButton

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1188,33 +1188,35 @@ void ScriptCreatedComponentWrappers::ComboBoxWrapper::updateFont(ScriptComponent
 	const String fontStyle = cb->getScriptObjectProperty(ScriptingApi::Content::ScriptComboBox::FontStyle).toString();
 	const float fontSize = (float)cb->getScriptObjectProperty(ScriptingApi::Content::ScriptComboBox::FontSize);
 
+	Font f;
+
 	if (fontName == "Oxygen" || fontName == "Default")
 	{
 		if (fontStyle == "Bold")
-			plaf.setComboBoxFont(GLOBAL_BOLD_FONT().withHeight(fontSize));
+			f = GLOBAL_BOLD_FONT().withHeight(fontSize);
 		else
-		{
-			plaf.setComboBoxFont(GLOBAL_FONT().withHeight(fontSize));
-		}
+			f = GLOBAL_FONT().withHeight(fontSize);
 	}
 	else if (fontName == "Source Code Pro")
 	{
-		plaf.setComboBoxFont(GLOBAL_MONOSPACE_FONT().withHeight(fontSize));
+		f = GLOBAL_MONOSPACE_FONT().withHeight(fontSize);
 	}
 	else
 	{
 		const juce::Typeface::Ptr typeface = dynamic_cast<const Processor*>(contentComponent->getScriptProcessor())->getMainController()->getFont(fontName);
 
 		if (typeface != nullptr)
-		{
-			Font font = Font(typeface).withHeight(fontSize);
-			plaf.setComboBoxFont(font);
-		}
+			f = Font(typeface).withHeight(fontSize);
 		else
-		{
-			Font font(fontName, fontStyle, fontSize);
-			plaf.setComboBoxFont(font);
-		}
+			f = Font(fontName, fontStyle, fontSize);
+	}
+
+	plaf.setComboBoxFont(f);
+
+	if (auto hcb = dynamic_cast<HiComboBox*>(getComponent()))
+	{
+		hcb->font = f;
+		hcb->fontName = fontName;
 	}
 
 	getComponent()->resized();
@@ -2301,6 +2303,12 @@ void ScriptCreatedComponentWrappers::PanelWrapper::updateColourAndBorder(BorderP
 	bpc->borderColour = GET_OBJECT_COLOUR(textColour);
 	bpc->borderRadius = getScriptComponent()->getScriptObjectProperty(ScriptingApi::Content::ScriptPanel::borderRadius);
 	bpc->borderSize = getScriptComponent()->getScriptObjectProperty(ScriptingApi::Content::ScriptPanel::borderSize);
+
+	bpc->setColour(HiseColourScheme::ComponentOutlineColourId, GET_OBJECT_COLOUR(bgColour));
+	bpc->setColour(HiseColourScheme::ComponentFillTopColourId, GET_OBJECT_COLOUR(itemColour));
+	bpc->setColour(HiseColourScheme::ComponentFillBottomColourId, GET_OBJECT_COLOUR(itemColour2));
+	bpc->setColour(HiseColourScheme::ComponentTextColourId, GET_OBJECT_COLOUR(textColour));
+
 	bpc->repaint();
 };
 

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -874,6 +874,9 @@ void ScriptCreatedComponentWrapper::updatePopupPosition()
 
 		p.applyTransform(currentPopup->getTransform().inverted());
 
+		if (currentPopup->drawShadow)
+			p -= Point<int>(ValuePopup::shadowMargin, ValuePopup::shadowMargin);
+
 		currentPopup->setTopLeftPosition(p);
 	}
 }
@@ -3435,7 +3438,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		if(!area.isEmpty())
 		{
-			shadow = nullptr;
+			drawShadow = false;
 			currentText = thisText;
 			setSize(area.getWidth(), area.getHeight());
 			repaint();
@@ -3451,9 +3454,9 @@ void ScriptCreatedComponentWrapper::ValuePopup::updateText()
 
 		int margin = (int)p->getLayoutData().margin;
 
-		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5;
+		int newWidth = p->getFont().getStringWidth(currentText) + 2 * margin + 5 + 2 * shadowMargin;
 
-		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin);
+		setSize(newWidth, (int)p->getFont().getHeight() + 2*margin + 2 * shadowMargin);
 
 
 		repaint();
@@ -3470,15 +3473,21 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 	Properties::Ptr p = parent.contentComponent->getValuePopupProperties();
 
-	
-
 	if (p != nullptr)
 	{
 		auto l = p->getLayoutData();
 
-		auto ar = getLocalBounds().toFloat().reduced(l.lineThickness * 0.5f);
+		auto contentArea = getLocalBounds().toFloat().reduced((float)shadowMargin);
+		auto ar = contentArea.reduced(l.lineThickness * 0.5f);
 
-		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f, 
+		if (drawShadow)
+		{
+			Path shadowPath;
+			shadowPath.addRoundedRectangle(ar, l.radius);
+			shadow.drawForPath(g, shadowPath);
+		}
+
+		g.setGradientFill(ColourGradient(p->getColour(Properties::itemColour), 0.0f, 0.0f,
 										 p->getColour(Properties::itemColour2), 0.0f, (float)getHeight(), false));
 
 		g.fillRoundedRectangle(ar, l.radius);
@@ -3488,7 +3497,7 @@ void ScriptCreatedComponentWrapper::ValuePopup::paint(Graphics& g)
 
 		g.setFont(p->getFont());
 		g.setColour(p->getColour(Properties::textColour));
-		g.drawText(currentText, getLocalBounds(), Justification::centred);
+		g.drawText(currentText, contentArea.toNearestInt(), Justification::centred);
 	}
 
 	

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.h
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.h
@@ -276,14 +276,14 @@ public:
 			JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Properties);
 		};
 
+		static constexpr int shadowMargin = 5;
+
 		ValuePopup(ScriptCreatedComponentWrapper& p):
 			parent(p),
-			shadow(new DropShadower({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }}))
+			shadow({Colours::black.withAlpha(0.4f), 5,{ 0, 0 }})
 		{
 			f = GLOBAL_BOLD_FONT();
 
-			shadow->setOwner(this);
-			
 			updateText();
 			startTimer(30);
 		}
@@ -314,7 +314,8 @@ public:
 
 		ScriptCreatedComponentWrapper& parent;
 
-		ScopedPointer<DropShadower> shadow;
+		DropShadow shadow;
+		bool drawShadow = true;
 	};
 
 	struct AdditionalMouseCallback;

--- a/hi_scripting/scripting/api/ScriptTableListModel.cpp
+++ b/hi_scripting/scripting/api/ScriptTableListModel.cpp
@@ -714,8 +714,22 @@ ScriptTableListModel::LookAndFeelData ScriptTableListModel::LookAndFeelMethods::
 		{
 			return st->d;
 		}
+
+		if (auto ft = dynamic_cast<TableFloatingTileBase*>(table->getModel()))
+		{
+			auto ftd = ft->getLookAndFeelData();
+			LookAndFeelData d;
+			d.f = ftd.f;
+			d.fontName = ftd.fontName;
+			d.textColour = ftd.textColour;
+			d.bgColour = ftd.bgColour;
+			d.itemColour1 = ftd.itemColour1;
+			d.itemColour2 = ftd.itemColour2;
+			d.itemColour3 = ftd.itemColour3;
+			return d;
+		}
 	}
-	
+
 	return {};
 }
 

--- a/hi_scripting/scripting/api/ScriptTableListModel.h
+++ b/hi_scripting/scripting/api/ScriptTableListModel.h
@@ -75,8 +75,9 @@ struct ScriptTableListModel : public juce::TableListBoxModel,
 		bool sortForward = true;
 
 		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
 		Justification c = Justification::centredLeft;
-		Colour textColour, bgColour, itemColour1, itemColour2;
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
 	};
 
 	struct LookAndFeelMethods

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4541,12 +4541,26 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawToggleButton(Graphics &g_, 
 		obj->setProperty("down", b.isMouseButtonDown(true));
 		obj->setProperty("value", b.getToggleState());
 
-		setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
-		setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
-		setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
-		setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
-
-		addParentFloatingTile(b, obj);
+		if (auto ft = b.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.fontName);
+		}
+		else
+		{
+			setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
+			setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
+			setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
+			setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
+			addParentFloatingTile(b, obj);
+		}
 
 		if (get()->callWithGraphics(g_, "drawToggleButton", var(obj), &b))
 			return;
@@ -4665,7 +4679,25 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawLinearSlider(Graphics &g, i
 			setColourOrBlack(obj, "textColour", *parentPack, Slider::trackColourId);
 		}
 
-		addParentFloatingTile(slider, obj);
+		if (auto ft = slider.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.fontName);
+
+			slider.setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
+			slider.setTextBoxStyle(Slider::NoTextBox, true, 0, 0);
+		}
+		else
+		{
+			addParentFloatingTile(slider, obj);
+		}
 
 		if (get()->callWithGraphics(g, "drawLinearSlider", var(obj), &slider))
 			return;
@@ -5081,6 +5113,14 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 		setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
 		setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
 		setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+
+		if (auto ft = scrollbar.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("font", d.fontName);
+			obj->setProperty("fontSize", d.f.getHeight());
+		}
 
 		addParentFloatingTile(scrollbar, obj);
 
@@ -5549,7 +5589,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("rowIndex", rowNumber);
 		obj->setProperty("selected", rowIsSelected);
@@ -5575,7 +5618,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, con
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", text);
 		obj->setProperty("rowIndex", rowNumber);
@@ -5606,10 +5652,15 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderBackground(Graph
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		auto a = h.getLocalBounds();
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		addParentFloatingTile(h, obj);
 
 		if (get()->callWithGraphics(g_, "drawTableHeaderBackground", var(obj), &h))
 			return;
@@ -5629,10 +5680,13 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", columnName);
-		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("columnIndex", h.getIndexOfColumnId(columnId, true));
 		obj->setProperty("hover", isMouseOver);
 		obj->setProperty("down", isMouseDown);
 
@@ -5643,11 +5697,76 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
 
+		addParentFloatingTile(h, obj);
+
 		if (get()->callWithGraphics(g_, "drawTableHeaderColumn", var(obj), &h))
 			return;
 	}
 
 	drawDefaultTableHeaderColumn(g_, h, columnName, columnId, width, height, isMouseOver, isMouseDown, columnFlags);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (functionDefined("drawTableRowBackground"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("hover", rowIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableRowBackground", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(g_, d, rowNumber, width, height, rowIsSelected, rowIsHovered);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	if (functionDefined("drawTableCell"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("text", text);
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("clicked", cellIsClicked);
+		obj->setProperty("hover", cellIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableCell", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableCell(g_, d, text, rowNumber, columnId, width, height, rowIsSelected, cellIsClicked, cellIsHovered);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawMatrixPeakMeter(Graphics& g_, float* peakValues, float* maxPeaks, int numChannels, bool isVertical, float segmentSize, float paddingSize, Component* c)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2729,7 +2729,8 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
 		"drawFlexAhdsrFullPath",
 		"drawFlexAhdsrPosition",
 		"drawFlexAhdsrSegment",
-		"drawFlexAhdsrText"
+		"drawFlexAhdsrText",
+		"drawPerformanceLabel"
 	};
 
 	return sa;
@@ -6014,6 +6015,40 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrText(Graphics& g_,
     }
 
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrText(g_, graph, text);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	if (functionDefined("drawPerformanceLabel"))
+	{
+		auto obj = new DynamicObject();
+
+		writeId(obj, &panel);
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, panel.getLocalBounds().toFloat()));
+
+		obj->setProperty("bgColour",     (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+		obj->setProperty("textColour",   (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+		obj->setProperty("itemColour1",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+		obj->setProperty("itemColour2",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+		obj->setProperty("itemColour3",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+
+		obj->setProperty("font",     panel.getFontName());
+		obj->setProperty("fontSize", panel.getFont().getHeight());
+
+		obj->setProperty("cpu",    cpu);
+		obj->setProperty("ram",    ram);
+		obj->setProperty("voices", voices);
+
+		if (get()->callWithGraphics(g, "drawPerformanceLabel", var(obj), &panel))
+			return;
+	}
+
+	// Default fallback
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
 }
 
 juce::Image ScriptingObjects::ScriptedLookAndFeel::Laf::createIcon(PresetHandler::IconType type)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4449,6 +4449,20 @@ hise::MarkdownLayout::StyleData ScriptingObjects::ScriptedLookAndFeel::Laf::getA
 	return s;
 }
 
+void ScriptingObjects::ScriptedLookAndFeel::Laf::preparePopupMenuWindow(Component& newWindow)
+{
+	// Force the component to be non-opaque so it doesn't fill with white before drawing
+	if (functionDefined("drawPopupMenuBackground"))
+	{
+		newWindow.setOpaque(false);
+	}
+}
+int ScriptingObjects::ScriptedLookAndFeel::Laf::getMenuWindowFlags()
+{
+    return LookAndFeel_V2::getMenuWindowFlags()
+           & ~ComponentPeer::windowHasDropShadow;
+}
+
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphics& g_, int width, int height)
 {
 	if (functionDefined("drawPopupMenuBackground"))

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5388,6 +5388,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawWhiteNote(CustomKeyboardSta
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
 
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
+
 		if (get()->callWithGraphics(g_, "drawWhiteNote", var(obj), c))
 			return;
 	}
@@ -5408,6 +5414,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawBlackNote(CustomKeyboardSta
 		obj->setProperty("hover", isOver);
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
+
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
 
 		if (get()->callWithGraphics(g_, "drawBlackNote", var(obj), c))
 			return;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2553,6 +2553,7 @@ void ScriptingObjects::ScriptedLookAndFeel::registerFunction(var functionName, v
 void ScriptingObjects::ScriptedLookAndFeel::setGlobalFont(const String& fontName, float fontSize)
 {
 	f = getScriptProcessor()->getMainController_()->getFontFromString(fontName, fontSize);
+	this->fontName = fontName;
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::setInlineStyleSheet(const String& cssCode)
@@ -4090,6 +4091,13 @@ Font ScriptingObjects::ScriptedLookAndFeel::Laf::getFont()
 		return GLOBAL_BOLD_FONT();
 }
 
+String ScriptingObjects::ScriptedLookAndFeel::Laf::getFontName()
+{
+	if (auto l = get())
+		return l->fontName;
+	return "Default";
+}
+
 Font ScriptingObjects::ScriptedLookAndFeel::Laf::getAlertWindowMessageFont()
 { return getFont(); }
 
@@ -4463,7 +4471,7 @@ int ScriptingObjects::ScriptedLookAndFeel::Laf::getMenuWindowFlags()
            & ~ComponentPeer::windowHasDropShadow;
 }
 
-void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphics& g_, int width, int height)
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackgroundWithOptions(Graphics& g_, int width, int height, const PopupMenu::Options& options)
 {
 	if (functionDefined("drawPopupMenuBackground"))
 	{
@@ -4473,30 +4481,68 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuBackground(Graphic
 		obj->setProperty("width", width);
 		obj->setProperty("height", height);
 
+		auto* tc = options.getTargetComponent();
+
+		if (tc != nullptr)
+		{
+			writeId(obj, tc);
+
+			if (auto ft = tc->findParentComponentOfClass<TableFloatingTileBase>())
+			{
+				auto d = ft->getLookAndFeelData();
+				obj->setProperty("bgColour", d.bgColour.getARGB());
+				obj->setProperty("itemColour1", d.itemColour1.getARGB());
+				obj->setProperty("itemColour2", d.itemColour2.getARGB());
+				obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+				obj->setProperty("textColour", d.textColour.getARGB());
+				obj->setProperty("parentType", d.parentType);
+			}
+			else if (tc->isColourSpecified(HiseColourScheme::ComponentOutlineColourId))
+			{
+				setColourOrBlack(obj, "bgColour",    *tc, HiseColourScheme::ComponentOutlineColourId);
+				setColourOrBlack(obj, "itemColour1", *tc, HiseColourScheme::ComponentFillTopColourId);
+				setColourOrBlack(obj, "itemColour2", *tc, HiseColourScheme::ComponentFillBottomColourId);
+				setColourOrBlack(obj, "textColour",  *tc, HiseColourScheme::ComponentTextColourId);
+				addParentFloatingTile(*tc, obj);
+			}
+			else if (auto ft = tc->findParentComponentOfClass<FloatingTile>())
+			{
+				if (auto panel = ft->getCurrentFloatingPanel())
+				{
+					obj->setProperty("bgColour", panel->findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+					obj->setProperty("itemColour1", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+					obj->setProperty("itemColour2", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+					obj->setProperty("itemColour3", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+					obj->setProperty("textColour", panel->findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+					obj->setProperty("parentType", panel->getIdentifierForBaseClass().toString());
+				}
+			}
+		}
+
 		if (get()->callWithGraphics(g_, "drawPopupMenuBackground", var(obj), nullptr))
 			return;
 	}
 
-	GlobalHiseLookAndFeel::drawPopupMenuBackground(g_, width, height);
+	GlobalHiseLookAndFeel::drawPopupMenuBackgroundWithOptions(g_, width, height, options);
 }
 
-void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuItem(Graphics& g_, const Rectangle<int>& area, bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu, const String& text, const String& shortcutKeyText, const Drawable* icon, const Colour* textColourToUse)
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuItemWithOptions(Graphics& g_, const Rectangle<int>& area, bool isHighlighted, const PopupMenu::Item& item, const PopupMenu::Options& options)
 {
 	if (functionDefined("drawPopupMenuItem"))
 	{
 		auto obj = new DynamicObject();
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, area.toFloat()));
-		obj->setProperty("isSeparator", isSeparator);
-        obj->setProperty("isSectionHeader", false);
-		obj->setProperty("isActive", isActive);
+		obj->setProperty("isSeparator", item.isSeparator);
+        obj->setProperty("isSectionHeader", item.isSectionHeader);
+		obj->setProperty("isActive", item.isEnabled);
 		obj->setProperty("isHighlighted", isHighlighted);
-		obj->setProperty("isTicked", isTicked);
-		obj->setProperty("hasSubMenu", hasSubMenu);
-		obj->setProperty("text", text);
+		obj->setProperty("isTicked", item.isTicked);
+		obj->setProperty("hasSubMenu", item.subMenu != nullptr);
+		obj->setProperty("text", item.text);
 
 		var keeper;
 
-		if (auto p = dynamic_cast<const DrawablePath*>(icon))
+		if (auto p = dynamic_cast<const DrawablePath*>(item.image.get()))
 		{
 			auto sp = new ScriptingObjects::PathObject(get()->getScriptProcessor());
 			sp->getPath() = p->getPath();
@@ -4505,14 +4551,69 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuItem(Graphics& g_,
 
 		obj->setProperty("path", keeper);
 
+		auto* tc = options.getTargetComponent();
+
+		if (tc != nullptr)
+		{
+			writeId(obj, tc);
+
+			if (auto ft = tc->findParentComponentOfClass<TableFloatingTileBase>())
+			{
+				auto d = ft->getLookAndFeelData();
+				obj->setProperty("bgColour", d.bgColour.getARGB());
+				obj->setProperty("itemColour1", d.itemColour1.getARGB());
+				obj->setProperty("itemColour2", d.itemColour2.getARGB());
+				obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+				obj->setProperty("textColour", d.textColour.getARGB());
+				obj->setProperty("parentType", d.parentType);
+				obj->setProperty("font", ft->getFontName());
+				obj->setProperty("fontSize", d.f.getHeight());
+			}
+			else if (tc->isColourSpecified(HiseColourScheme::ComponentOutlineColourId))
+			{
+				setColourOrBlack(obj, "bgColour",    *tc, HiseColourScheme::ComponentOutlineColourId);
+				setColourOrBlack(obj, "itemColour1", *tc, HiseColourScheme::ComponentFillTopColourId);
+				setColourOrBlack(obj, "itemColour2", *tc, HiseColourScheme::ComponentFillBottomColourId);
+				setColourOrBlack(obj, "textColour",  *tc, HiseColourScheme::ComponentTextColourId);
+				addParentFloatingTile(*tc, obj);
+
+				if (auto cb = dynamic_cast<const HiComboBox*>(tc))
+				{
+					obj->setProperty("font", cb->fontName);
+					obj->setProperty("fontSize", cb->font.getHeight());
+				}
+				else
+				{
+					auto f = getFont();
+					obj->setProperty("font", getFontName());
+					obj->setProperty("fontSize", f.getHeight());
+				}
+			}
+			else if (auto ft = tc->findParentComponentOfClass<FloatingTile>())
+			{
+				if (auto panel = ft->getCurrentFloatingPanel())
+				{
+					obj->setProperty("bgColour", panel->findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+					obj->setProperty("itemColour1", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+					obj->setProperty("itemColour2", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+					obj->setProperty("itemColour3", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+					obj->setProperty("textColour", panel->findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+					obj->setProperty("parentType", panel->getIdentifierForBaseClass().toString());
+
+					obj->setProperty("font", panel->getFontName());
+					obj->setProperty("fontSize", panel->getFont().getHeight());
+				}
+			}
+		}
+
 		if (get()->callWithGraphics(g_, "drawPopupMenuItem", var(obj), nullptr))
 			return;
 	}
 
-	GlobalHiseLookAndFeel::drawPopupMenuItem(g_, area, isSeparator, isActive, isHighlighted, isTicked, hasSubMenu, text, shortcutKeyText, icon, textColourToUse);
+	GlobalHiseLookAndFeel::drawPopupMenuItemWithOptions(g_, area, isHighlighted, item, options);
 }
 
-void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuSectionHeader (Graphics& g_, const Rectangle<int>& area, const String& sectionName)
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuSectionHeaderWithOptions(Graphics& g_, const Rectangle<int>& area, const String& sectionName, const PopupMenu::Options& options)
 {
     if (functionDefined("drawPopupMenuItem"))
     {
@@ -4526,11 +4627,66 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPopupMenuSectionHeader (Gra
         obj->setProperty("hasSubMenu", false);
         obj->setProperty("text", sectionName);
 
+        auto* tc = options.getTargetComponent();
+
+        if (tc != nullptr)
+        {
+            writeId(obj, tc);
+
+            if (auto ft = tc->findParentComponentOfClass<TableFloatingTileBase>())
+            {
+                auto d = ft->getLookAndFeelData();
+                obj->setProperty("bgColour", d.bgColour.getARGB());
+                obj->setProperty("itemColour1", d.itemColour1.getARGB());
+                obj->setProperty("itemColour2", d.itemColour2.getARGB());
+                obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+                obj->setProperty("textColour", d.textColour.getARGB());
+                obj->setProperty("parentType", d.parentType);
+                obj->setProperty("font", ft->getFontName());
+                obj->setProperty("fontSize", d.f.getHeight());
+            }
+            else if (tc->isColourSpecified(HiseColourScheme::ComponentOutlineColourId))
+            {
+                setColourOrBlack(obj, "bgColour",    *tc, HiseColourScheme::ComponentOutlineColourId);
+                setColourOrBlack(obj, "itemColour1", *tc, HiseColourScheme::ComponentFillTopColourId);
+                setColourOrBlack(obj, "itemColour2", *tc, HiseColourScheme::ComponentFillBottomColourId);
+                setColourOrBlack(obj, "textColour",  *tc, HiseColourScheme::ComponentTextColourId);
+                addParentFloatingTile(*tc, obj);
+
+                if (auto cb = dynamic_cast<const HiComboBox*>(tc))
+                {
+                    obj->setProperty("font", cb->fontName);
+                    obj->setProperty("fontSize", cb->font.getHeight());
+                }
+                else
+                {
+                    auto f = getFont();
+                    obj->setProperty("font", getFontName());
+                    obj->setProperty("fontSize", f.getHeight());
+                }
+            }
+            else if (auto ft = tc->findParentComponentOfClass<FloatingTile>())
+            {
+                if (auto panel = ft->getCurrentFloatingPanel())
+                {
+                    obj->setProperty("bgColour", panel->findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+                    obj->setProperty("itemColour1", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+                    obj->setProperty("itemColour2", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+                    obj->setProperty("itemColour3", panel->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+                    obj->setProperty("textColour", panel->findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+                    obj->setProperty("parentType", panel->getIdentifierForBaseClass().toString());
+
+                    obj->setProperty("font", panel->getFontName());
+                    obj->setProperty("fontSize", panel->getFont().getHeight());
+                }
+            }
+        }
+
         if (get()->callWithGraphics(g_, "drawPopupMenuItem", var(obj), nullptr))
             return;
     }
 
-    GlobalHiseLookAndFeel::drawPopupMenuSectionHeader(g_, area, sectionName);
+    GlobalHiseLookAndFeel::drawPopupMenuSectionHeaderWithOptions(g_, area, sectionName, options);
 }
 
 void setColourOrBlack(DynamicObject* obj, const Identifier& id, Component& c, int colourId)

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -835,7 +835,8 @@ namespace ScriptingObjects
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
-			public HiSlider::HoverPopupLookandFeel
+			public HiSlider::HoverPopupLookandFeel,
+			public PerformanceLabelPanel::LookAndFeelMethods
 		{
 			Laf(MainController* mc);
 
@@ -965,6 +966,9 @@ namespace ScriptingObjects
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 			void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
+
+			void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+			                         float cpu, int64 ram, int voices) override;
 
 			Image createIcon(PresetHandler::IconType type) override;
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -844,6 +844,7 @@ namespace ScriptingObjects
 			virtual ~Laf();;
 			
 			Font getFont();
+			String getFontName();
 
 			ScriptedLookAndFeel* get() override;
 
@@ -861,18 +862,17 @@ namespace ScriptingObjects
 			void preparePopupMenuWindow(Component& newWindow) override;
 			int getMenuWindowFlags();
 
-			void drawPopupMenuBackground(Graphics& g_, int width, int height) override;
+			void drawPopupMenuBackgroundWithOptions(Graphics& g_, int width, int height, const PopupMenu::Options& options) override;
 
-			void drawPopupMenuItem(Graphics& g, const Rectangle<int>& area,
-				bool isSeparator, bool isActive,
-				bool isHighlighted, bool isTicked,
-				bool hasSubMenu, const String& text,
-				const String& shortcutKeyText,
-				const Drawable* icon, const Colour* textColourToUse);
+			void drawPopupMenuItemWithOptions(Graphics& g, const Rectangle<int>& area,
+				bool isHighlighted,
+				const PopupMenu::Item& item,
+				const PopupMenu::Options& options) override;
 
-            void drawPopupMenuSectionHeader (Graphics& g,
+            void drawPopupMenuSectionHeaderWithOptions(Graphics& g,
                                              const Rectangle<int>& area,
-                                             const String& sectionName);
+                                             const String& sectionName,
+                                             const PopupMenu::Options& options) override;
             
 			void drawToggleButton(Graphics &g, ToggleButton &b, bool isMouseOverButton, bool /*isButtonDown*/) override;
 
@@ -1483,6 +1483,7 @@ namespace ScriptingObjects
 
         
 		Font f = GLOBAL_BOLD_FONT();
+		String fontName = "Default";
         
         struct GraphicsWithComponent
         {

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -834,6 +834,7 @@ namespace ScriptingObjects
 			public CustomKeyboardLookAndFeelBase,
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
+			public TableFloatingTileBase::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
 			public HiSlider::HoverPopupLookandFeel,
 			public PerformanceLabelPanel::LookAndFeelMethods
@@ -938,6 +939,10 @@ namespace ScriptingObjects
 			void drawTableHeaderBackground(Graphics& g, TableHeaderComponent& h) override;
 
 			void drawTableHeaderColumn(Graphics& g, TableHeaderComponent&, const String& columnName, int columnId, int width, int height, bool isMouseOver, bool isMouseDown, int columnFlags) override;
+
+			void drawTableRowBackground(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered) override;
+
+			void drawTableCell(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered) override;
 
             void getIdealPopupMenuItemSize(const String &text, bool isSeparator, int standardMenuItemHeight, int &idealWidth, int &idealHeight) override;
             

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -858,6 +858,9 @@ namespace ScriptingObjects
 
 			MarkdownLayout::StyleData getAlertWindowMarkdownStyleData() override;
 
+			void preparePopupMenuWindow(Component& newWindow) override;
+			int getMenuWindowFlags();
+
 			void drawPopupMenuBackground(Graphics& g_, int width, int height) override;
 
 			void drawPopupMenuItem(Graphics& g, const Rectangle<int>& area,

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -2695,6 +2695,63 @@
               }
             }
           }
+        },
+        "PerformanceLabel": {
+          "lafFunctions": {
+            "drawPerformanceLabel": {
+              "description": "Draws the performance statistics floating tile (CPU usage, RAM usage, active voice count)",
+              "callbackProperties": {
+                "id": {
+                  "type": "String",
+                  "description": "The component's ID from getComponentID()"
+                },
+                "area": {
+                  "type": "Array[x, y, w, h]",
+                  "description": "The panel bounds"
+                },
+                "bgColour": {
+                  "type": "int (ARGB)",
+                  "description": "Background colour (ColourData::bgColour)"
+                },
+                "textColour": {
+                  "type": "int (ARGB)",
+                  "description": "Text colour (ColourData::textColour)"
+                },
+                "itemColour1": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 1 (ColourData::itemColour1)"
+                },
+                "itemColour2": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 2 (ColourData::itemColour2)"
+                },
+                "itemColour3": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 3 (ColourData::itemColour3)"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "Typeface name from the panel's Font setting"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "Font size from the panel's FontSize setting"
+                },
+                "cpu": {
+                  "type": "float",
+                  "description": "Current CPU usage as a percentage (0.0-100.0)"
+                },
+                "ram": {
+                  "type": "int64",
+                  "description": "Current RAM usage in bytes"
+                },
+                "voices": {
+                  "type": "int",
+                  "description": "Number of currently active voices"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -1246,6 +1246,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             },
@@ -1271,6 +1279,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             }


### PR DESCRIPTION
Depends on #915 and #919

[Fix popup menu colours: pass component and panel colours to LAF callbacks](https://github.com/davidhealey/HISE/commit/a28f0941c5e438e95a14bd7a4623550d2b80b5e4)
Route ComboBox and FloatingTile colour properties (bgColour, textColour,
itemColour1-3) through to drawPopupMenuBackground, drawPopupMenuItem, and
drawPopupMenuSectionHeader LAF callbacks. Also passes font/fontSize from
the ComboBox's configured font properties.

- Set HiseColourScheme colour IDs on BorderPanel for popup menu support
- Add FloatingTile and TableFloatingTileBase colour support
- Fix popup menu rendering by passing nullptr to callWithGraphics
- Read combo box font from HiComboBox::font (kept in sync via updateFont)

https://claude.ai/code/session_01MASkUkpwz1N9tJGdqrffmd

Fix popup menu font name always returning default typeface name
Store the configured font name string alongside the Font object in
ScriptedLookAndFeel, HiComboBox, and FloatingTileContent, so that the
drawPopupMenuItem LAF callback receives the user-configured name (e.g.
"Default" or a custom font ID) rather than the internal typeface name
(e.g. "Oxygen") obtained via getTypefaceName().
- Add getFontName() to FloatingTileContent returning fontName or
"Default"
- Add getFontName() to ScriptedLookAndFeel::Laf returning the stored
name
- Add fontName member to ScriptedLookAndFeel, set in setGlobalFont()
- Add fontName member to HiComboBox, set in
ComboBoxWrapper::updateFont()
- Use getFontName()/fontName in drawPopupMenuItemWithOptions and
  drawPopupMenuSectionHeaderWithOptions instead of getTypefaceName()
https://claude.ai/code/session_01MhDNx57De9NDH44TfzMYPE