### PR TITLE
Pass viewport colour properties to drawScrollbar look and feel function

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.h
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.h
@@ -296,6 +296,8 @@ public:
 		return getMainController()->getFontFromString(fontName, fontSize);
 	}
 
+	String getFontName() const { return fontName; }
+
 	/** This returns the title that is supposed to be displayed. */
     String getBestTitle() const;
 	

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -979,6 +979,8 @@ PresetBrowserPanel::PresetBrowserPanel(FloatingTile* parent) :
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::black.withAlpha(0.97f));
     setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 	setDefaultPanelColour(PanelColourId::itemColour1, Colour(SIGNAL_COLOUR));
+	setDefaultPanelColour(PanelColourId::itemColour2, Colours::black.withAlpha(0.7f));
+	setDefaultPanelColour(PanelColourId::itemColour3, Colours::white.withAlpha(0.6f));
 
 	addAndMakeVisible(presetBrowser = new PresetBrowser(getMainController()));
 	
@@ -1098,9 +1100,12 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.showFavoriteIcons = getPropertyWithDefault(object, SpecialPanelIds::ShowFavoriteIcon);
 	options.backgroundColour = findPanelColour(PanelColourId::bgColour);
 	options.highlightColour = findPanelColour(PanelColourId::itemColour1);
+	options.modalBackgroundColour = findPanelColour(PanelColourId::itemColour2);
+	options.itemColour3 = findPanelColour(PanelColourId::itemColour3);
 	options.textColour = findPanelColour(PanelColourId::textColour);
 	options.font = getFont();
-	
+	options.fontName = getFontName();
+
 	presetBrowser->setOptions(options);
 }
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1656,20 +1656,10 @@ juce::String MidiLearnPanel::getCellText(int rowNumber, int columnId) const
 TableFloatingTileBase::InvertedButton::InvertedButton(TableFloatingTileBase &owner_) :
 	owner(owner_)
 {
-	laf.setFontForAll(owner.font);
-
-	addAndMakeVisible(t = new TextButton("Inverted"));
-	t->setButtonText("Inverted");
-	t->setLookAndFeel(&laf);
-	t->setConnectedEdges(Button::ConnectedOnLeft | Button::ConnectedOnRight);
+	addAndMakeVisible(t = new ToggleButton("Inverted"));
+	t->setButtonText("Normal");
 	t->addListener(this);
 	t->setTooltip("Invert the range of the macro control for this parameter.");
-	t->setColour(TextButton::buttonColourId, Colour(0x88000000));
-	t->setColour(TextButton::buttonOnColourId, Colour(0x88FFFFFF));
-	t->setColour(TextButton::textColourOnId, Colour(0xaa000000));
-	t->setColour(TextButton::textColourOffId, Colour(0x99ffffff));
-
-	t->setClickingTogglesState(true);
 }
 
 void TableFloatingTileBase::InvertedButton::resized()
@@ -1696,9 +1686,6 @@ TableFloatingTileBase::ValueSliderColumn::ValueSliderColumn(TableFloatingTileBas
 {
 	addAndMakeVisible(slider = new RangeSlider());
 
-	laf.setFontForAll(table.font);
-
-	slider->setLookAndFeel(&laf);
 	slider->setSliderStyle(Slider::LinearBar);
 	slider->setTextBoxStyle(Slider::TextBoxLeft, true, 80, 20);
 	slider->setColour(Slider::backgroundColourId, Colour(0x38ffffff));
@@ -1737,6 +1724,33 @@ void TableFloatingTileBase::ValueSliderColumn::sliderValueChanged(Slider *)
 		slider->setValue(actualValue, dontSendNotification);
 }
 
+void TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (rowIsSelected)
+		g.fillAll(Colours::white.withAlpha(0.2f));
+}
+
+void TableFloatingTileBase::LookAndFeelMethods::drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	g.setColour(d.textColour);
+	g.setFont(d.f);
+	g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+}
+
+TableFloatingTileBase::LookAndFeelData TableFloatingTileBase::getLookAndFeelData() const
+{
+	LookAndFeelData d;
+	d.f = font;
+	d.fontName = getFontName();
+	d.textColour = textColour;
+	d.bgColour = findPanelColour(FloatingTileContent::PanelColourId::bgColour);
+	d.itemColour1 = itemColour1;
+	d.itemColour2 = itemColour2;
+	d.itemColour3 = findPanelColour(FloatingTileContent::PanelColourId::itemColour3);
+	d.parentType = getIdentifierForBaseClass().toString();
+	return d;
+}
+
 TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 	FloatingTileContent(parent),
 	font(GLOBAL_FONT())
@@ -1746,6 +1760,8 @@ TableFloatingTileBase::TableFloatingTileBase(FloatingTile* parent) :
 
 void TableFloatingTileBase::initTable(bool addChannelColumn)
 {
+	hasChannelColumn = addChannelColumn;
+
 	// Create our table component and add it to this component..
 	addAndMakeVisible(table);
 	table.setModel(this);
@@ -1783,9 +1799,9 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 		table.getHeader().addColumn("Channel", Channel, fWidth, 30, -1, TableHeaderComponent::visible);
 
 	table.getHeader().addColumn("Parameter", ParameterName, 70, 30, -1);
-	table.getHeader().addColumn("Inverted", Inverted, 70, 70, 70);
-	table.getHeader().addColumn("Min", Minimum, 70, 70, 70);
-	table.getHeader().addColumn("Max", Maximum, 70, 70, 70);
+	table.getHeader().addColumn("Inverted", Inverted, 70, 30, -1);
+	table.getHeader().addColumn("Min", Minimum, 70, 30, -1);
+	table.getHeader().addColumn("Max", Maximum, 70, 30, -1);
 	table.getHeader().setStretchToFitActive(true);
 }
 
@@ -1794,9 +1810,44 @@ void TableFloatingTileBase::updateContent()
 	table.updateContent();
 }
 
+var TableFloatingTileBase::toDynamicObject() const
+{
+	auto obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, SpecialPanelIds::ColumnWidthRatio, var(columnWidthRatios));
+	return obj;
+}
+
+Identifier TableFloatingTileBase::getDefaultablePropertyId(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultablePropertyId(index);
+
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnWidthRatio, "ColumnWidthRatio");
+
+	return {};
+}
+
+var TableFloatingTileBase::getDefaultProperty(int index) const
+{
+	if (index < (int)PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultProperty(index);
+
+	Array<var> defaultRatios;
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ColumnWidthRatio, var(defaultRatios));
+
+	return {};
+}
+
 void TableFloatingTileBase::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
+
+	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
+	if (ratios.isArray())
+	{
+		columnWidthRatios.clear();
+		columnWidthRatios.addArray(*ratios.getArray());
+	}
 
 	table.setColour(ListBox::backgroundColourId, findPanelColour(FloatingTileContent::PanelColourId::bgColour));
 
@@ -1814,42 +1865,46 @@ void TableFloatingTileBase::paintRowBackground(Graphics& g, int rowNumber, int w
 {
 	using namespace simple_css;
 
-	if(auto rootDialog = CSSRootComponent::find(*this))
+	auto& rootDialog = *CSSRootComponent::find(*this);
+
+	if(auto ss = rootDialog.css.getWithAllStates(this, (Selector(ElementType::TableRow))))
 	{
-		if(auto ss = rootDialog->css.getWithAllStates(this, (Selector(ElementType::TableRow))))
+		Renderer r(nullptr, rootDialog.stateWatcher);
+
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		int flags = 0;
+
+		if(rowNumber == hoverRow)
 		{
-			Renderer r(nullptr, rootDialog->stateWatcher);
+			flags |= (int)PseudoClassType::Hover;
 
-			auto point = table.getMouseXYRelative();
-			auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
-
-			int flags = 0;
-
-			if(rowNumber == hoverRow)
+			if(isMouseButtonDownAnywhere())
 			{
-				flags |= (int)PseudoClassType::Hover;
-
-				if(isMouseButtonDownAnywhere())
-				{
-					flags |= (int)PseudoClassType::Active;
-				}
+				flags |= (int)PseudoClassType::Active;
 			}
-
-			if(rowIsSelected)
-				flags |= (int)PseudoClassType::Focus;
-
-			r.setPseudoClassState(flags);
-			r.drawBackground(g, {0.0f, 0.0f, (float)width, (float)height}, ss);
-
-			return;
 		}
+
+		if(rowIsSelected)
+			flags |= (int)PseudoClassType::Focus;
+
+		r.setPseudoClassState(flags);
+		r.drawBackground(g, {0.0f, 0.0f, (float)width, (float)height}, ss);
+	}
+	else
+	{
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
+
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		lafToUse->drawTableRowBackground(g, getLookAndFeelData(), rowNumber, width, height, rowIsSelected, rowNumber == hoverRow);
 	}
 
-	if (rowIsSelected)
-	{
-		g.fillAll(Colours::white.withAlpha(0.2f));
-	}
-	
 }
 
 void TableFloatingTileBase::resized()
@@ -1867,6 +1922,8 @@ void TableFloatingTileBase::resized()
 
 			if (root->css.getWithAllStates(this, simple_css::Selector("th")) != nullptr)
 				table.getHeader().setLookAndFeel(css_laf);
+			else if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+				table.getHeader().setLookAndFeel(&getLookAndFeel());
 			else
 				table.getHeader().setLookAndFeel(laf);
 		}
@@ -1950,9 +2007,34 @@ void TableFloatingTileBase::resized()
 
 	}
 
-	
-	
+	if (css_laf == nullptr)
+	{
+		if (dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+			table.getHeader().setLookAndFeel(&getLookAndFeel());
+		else
+			table.getHeader().setLookAndFeel(laf);
+	}
+
 	table.setBounds(getLocalBounds());
+
+	if (columnWidthRatios.size() > 0)
+	{
+		auto numCols = table.getHeader().getNumColumns(true);
+
+		if (columnWidthRatios.size() == numCols)
+		{
+			table.getHeader().setStretchToFitActive(false);
+			auto w = (double)getWidth();
+
+			for (int i = 0; i < numCols; i++)
+			{
+				auto id = table.getHeader().getColumnIdOfIndex(i, true);
+				auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
+				auto colWidth = roundToInt(w * r);
+				table.getHeader().setColumnWidth(id, colWidth);
+			}
+		}
+	}
 }
 
 double TableFloatingTileBase::setRangeValue(int row, ColumnId column, double newRangeValue)
@@ -2043,15 +2125,14 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 		{
 			slider = new ValueSliderColumn(*this);
 
-			if(auto root = simple_css::CSSRootComponent::find(*this))
+			auto& root = *simple_css::CSSRootComponent::find(*this);
+
+			if(auto ss = root.css.getWithAllStates(this, simple_css::Selector(".range-slider")))
 			{
-				if(auto ss = root->css.getWithAllStates(this, simple_css::Selector(".range-slider")))
-				{
-					simple_css::FlexboxComponent::Helpers::writeClassSelectors(*slider->slider, { simple_css::Selector(".range-slider")}, true);
-					slider->slider->setLookAndFeel(css_laf.get());
-					slider->slider->setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
-					slider->slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
-				}
+				simple_css::FlexboxComponent::Helpers::writeClassSelectors(*slider->slider, { simple_css::Selector(".range-slider")}, true);
+				slider->slider->setLookAndFeel(css_laf.get());
+				slider->slider->setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
+				slider->slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
 			}
 		}
 		
@@ -2062,10 +2143,11 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 
 		slider->slider->setDoubleClickReturnValue(true, columnId == Maximum ? fullRange.end : fullRange.start);
 
+		slider->slider->setComponentID(columnId == Maximum ? "max" : "min");
 		slider->slider->setColour(Slider::ColourIds::backgroundColourId, Colours::transparentBlack);
 		slider->slider->setColour(Slider::ColourIds::thumbColourId, itemColour1);
 		slider->slider->setColour(Slider::ColourIds::textBoxTextColourId, textColour);
-		
+
 		slider->setRowAndColumn(rowNumber, (ColumnId)columnId, value, fullRange);
 
 		ValueToTextConverter vtc = getValueToTextConverter(rowNumber);
@@ -2083,18 +2165,16 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 		if (b == nullptr)
 			b = new InvertedButton(*this);
 
-		if(auto root = simple_css::CSSRootComponent::find(*this))
+		auto& root = *simple_css::CSSRootComponent::find(*this);
+
+		if(css_laf != nullptr && root.css.getWithAllStates(this, simple_css::Selector("button")))
 		{
-			if(css_laf != nullptr && root->css.getWithAllStates(this, simple_css::Selector("button")))
-			{
-				b->t->setLookAndFeel(css_laf.get());
-			}
+			b->t->setLookAndFeel(css_laf.get());
 		}
 		
-		b->t->setColour(TextButton::buttonOnColourId, itemColour1);
-		b->t->setColour(TextButton::textColourOnId, textColour);
-		b->t->setColour(TextButton::buttonColourId, Colours::transparentBlack);
-		b->t->setColour(TextButton::textColourOffId, textColour);
+		b->t->setColour(ToggleButton::textColourId, textColour);
+		b->t->setColour(ToggleButton::tickColourId, itemColour1);
+		b->t->setColour(ToggleButton::tickDisabledColourId, textColour);
 
 		b->setRowAndColumn(rowNumber, isInverted(rowNumber));
 
@@ -2112,31 +2192,36 @@ void TableFloatingTileBase::paintCell(Graphics& g, int rowNumber, int columnId, 
 {
 	using namespace simple_css;
 
+	auto& rootDialog = *CSSRootComponent::find(*this);
 	auto text = getCellText(rowNumber, columnId);
 
-	if(auto rootDialog = CSSRootComponent::find(*this))
+	if(auto ss = rootDialog.css.getWithAllStates(this, Selector(ElementType::TableCell)))
 	{
-		if(auto ss = rootDialog->css.getWithAllStates(this, Selector(ElementType::TableCell)))
-		{
-			Renderer r(nullptr, rootDialog->stateWatcher);
-			auto state = r.getPseudoClassFromComponent(this);
-                
-			if(rowIsSelected)
-				state |= (int)PseudoClassType::Focus;
+		Renderer r(nullptr, rootDialog.stateWatcher);
+		auto state = r.getPseudoClassFromComponent(this);
 
-			Rectangle<float> b(0.0, 0.0, (float)width, (float)height);
+		if(rowIsSelected)
+			state |= (int)PseudoClassType::Focus;
 
-			r.setPseudoClassState(state);
-			r.drawBackground(g, b, ss);
-			r.renderText(g, b, text, ss);
+		Rectangle<float> b(0.0, 0.0, (float)width, (float)height);
 
-			return;
-		}
+		r.setPseudoClassState(state);
+		r.drawBackground(g, b, ss);
+		r.renderText(g, b, text, ss);
 	}
+	else
+	{
+		auto point = table.getMouseXYRelative();
+		auto hoverRow = table.getRowContainingPosition(point.getX(), point.getY());
 
-	g.setColour(textColour);
-	g.setFont(font);
-	g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
+
+		if (lafToUse == nullptr)
+			lafToUse = &fallbackLaf;
+
+		auto visualIndex = table.getHeader().getIndexOfColumnId(columnId, true);
+		lafToUse->drawTableCell(g, getLookAndFeelData(), text, rowNumber, visualIndex, width, height, rowIsSelected, false, rowNumber == hoverRow);
+	}
 }
 
 } // namespace hise

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -827,14 +827,8 @@ int Note::getFixedHeight() const
 PerformanceLabelPanel::PerformanceLabelPanel(FloatingTile* parent) :
 	FloatingTileContent(parent)
 {
-	addAndMakeVisible(statisticLabel = new Label());
-	statisticLabel->setEditable(false, false);
-	statisticLabel->setColour(Label::ColourIds::textColourId, Colours::white);
-
 	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::transparentBlack);
-
-	statisticLabel->setFont(GLOBAL_BOLD_FONT());
 
 	startTimer(200);
 }
@@ -843,9 +837,8 @@ void PerformanceLabelPanel::timerCallback()
 {
 	auto mc = getMainController();
 
-	const int cpuUsage = (int)mc->getCpuUsage();
-	const int voiceAmount = mc->getNumActiveVoices();
-
+	cpuUsage = mc->getCpuUsage();
+	voiceAmount = mc->getNumActiveVoices();
 
 	auto bytes = mc->getSampleManager().getModulatorSamplerSoundPool2()->getMemoryUsageForAllSamples();
 
@@ -856,30 +849,44 @@ void PerformanceLabelPanel::timerCallback()
 		bytes += handler.getExpansion(i)->pool->getSamplePool()->getMemoryUsageForAllSamples();
 	}
 
-	const double ramUsage = (double)bytes / 1024.0 / 1024.0;
+	ramUsage = (int64)bytes;
 
-	//const bool midiFlag = mc->checkAndResetMidiInputFlag();
-
-	//activityLed->setOn(midiFlag);
-
-	String stats = "CPU: ";
-	stats << String(cpuUsage) << "%, RAM: " << String(ramUsage, 1) << "MB , Voices: " << String(voiceAmount);
-	statisticLabel->setText(stats, dontSendNotification);
+	repaint();
 }
 
 
+
+void PerformanceLabelPanel::LookAndFeelMethods::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
+}
+
+void PerformanceLabelPanel::paint(Graphics& g)
+{
+	g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
+
+	if (auto laf = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel()))
+		laf->drawPerformanceLabel(g, *this, cpuUsage, ramUsage, voiceAmount);
+	else
+	{
+		g.setColour(findPanelColour(FloatingTileContent::PanelColourId::textColour));
+		g.setFont(getFont());
+		String stats = "CPU: " + String(cpuUsage, 1) + "%, RAM: " + String((double)ramUsage / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voiceAmount);
+		g.drawText(stats, getLocalBounds(), Justification::centredLeft);
+	}
+}
 
 void PerformanceLabelPanel::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
-
-	statisticLabel->setColour(Label::ColourIds::textColourId, findPanelColour(PanelColourId::textColour));
-	statisticLabel->setFont(getFont());
 }
 
 void PerformanceLabelPanel::resized()
 {
-	statisticLabel->setBounds(getLocalBounds());
 }
 
 bool PerformanceLabelPanel::showTitleInPresentationMode() const

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -425,6 +425,13 @@ class PerformanceLabelPanel : public Component,
 {
 public:
 
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {};
+		virtual void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+		                                  float cpu, int64 ram, int voices);
+	};
+
 	PerformanceLabelPanel(FloatingTile* parent);
 
 	SET_PANEL_NAME("PerformanceLabel");
@@ -433,15 +440,13 @@ public:
 	void fromDynamicObject(const var& object) override;
 	void resized() override;
 	bool showTitleInPresentationMode() const override;
-
-	void paint(Graphics& g) override
-	{
-		g.fillAll(findPanelColour(FloatingTileContent::PanelColourId::bgColour));
-	}
+	void paint(Graphics& g) override;
 
 private:
 
-	ScopedPointer<Label> statisticLabel;
+	float cpuUsage = 0.0f;
+	int voiceAmount = 0;
+	int64 ramUsage = 0;
 };
 
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -713,9 +713,33 @@ public:
 		Inverted,
 		Minimum,
 		Maximum,
-		numColumns,
-		columnWidthRatio
+		numColumns
 	};
+
+	enum SpecialPanelIds
+	{
+		ColumnWidthRatio = (int)FloatingTileContent::PanelPropertyId::numPropertyIds,
+		numSpecialPanelIds
+	};
+
+	struct LookAndFeelData
+	{
+		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
+		String parentType;
+	};
+
+	struct LookAndFeelMethods
+	{
+		virtual ~LookAndFeelMethods() {}
+
+		virtual void drawTableRowBackground(Graphics& g, const LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered);
+
+		virtual void drawTableCell(Graphics& g, const LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered);
+	};
+
+	LookAndFeelData getLookAndFeelData() const;
 
 	TableFloatingTileBase(FloatingTile* parent);
 	void initTable(bool addChannelColumn=false);
@@ -723,7 +747,13 @@ public:
 	virtual ~TableFloatingTileBase() {};
 
 	void updateContent();
-	void fromDynamicObject(const var& object);
+
+	int getNumDefaultableProperties() const override { return (int)SpecialPanelIds::numSpecialPanelIds; }
+	Identifier getDefaultablePropertyId(int index) const override;
+	var getDefaultProperty(int index) const override;
+	var toDynamicObject() const override;
+	void fromDynamicObject(const var& object) override;
+
 	void paintRowBackground(Graphics& g, int /*rowNumber*/, int /*width*/, int /*height*/, bool rowIsSelected) override;
 
 	//==============================================================================
@@ -822,8 +852,6 @@ protected:
 	private:
 		TableFloatingTileBase &owner;
 
-		HiPropertyPanelLookAndFeel laf;
-
 		int row;
 		int columnId;
 
@@ -840,7 +868,7 @@ protected:
 		void setRowAndColumn(const int newRow, bool value);
 		void buttonClicked(Button *b);;
 
-		ScopedPointer<TextButton> t;
+		ScopedPointer<ToggleButton> t;
 
 	private:
 
@@ -854,8 +882,11 @@ protected:
 	TableListBox table;     // the table component itself
 	Font font;
 	int numRows;            // The number of rows of data we've got
+	Array<var> columnWidthRatios;
+	bool hasChannelColumn = false;
 	ScopedPointer<TableHeaderLookAndFeel> laf;
 	ScopedPointer<simple_css::StyleSheetLookAndFeel> css_laf;
+	LookAndFeelMethods fallbackLaf;
 };
 
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1291,7 +1291,10 @@ void PresetBrowser::setOptions(const Options& newOptions)
 
 	setHighlightColourAndFont(newOptions.highlightColour, newOptions.backgroundColour, newOptions.font);
 
+	getPresetBrowserLookAndFeel().fontName = newOptions.fontName;
 	getPresetBrowserLookAndFeel().textColour = newOptions.textColour;
+	getPresetBrowserLookAndFeel().modalBackgroundColour = newOptions.modalBackgroundColour;
+	getPresetBrowserLookAndFeel().itemColour3 = newOptions.itemColour3;
 	setNumColumns(newOptions.numColumns);
 	columnWidthRatios.clear();
 	columnWidthRatios.addArray(newOptions.columnWidthRatios);

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -69,7 +69,10 @@ public:
 		Colour highlightedTextColour;
 		Colour backgroundColour;
 		Colour textColour;
+		Colour modalBackgroundColour;
+		Colour itemColour3;
 		Font font;
+		String fontName;
 
 		int numColumns = 3;
 		Array<var> columnWidthRatios;

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1875,7 +1875,19 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateComponent()
 		auto vp = dynamic_cast<Viewport*>(component.get());
 
 		vp->setScrollBarThickness(vpc->getScriptObjectProperty(ScriptingApi::Content::ScriptedViewport::Properties::scrollbarThickness));
-		vp->setColour(ScrollBar::ColourIds::thumbColourId, GET_OBJECT_COLOUR(itemColour));
+
+		auto bgColour = GET_OBJECT_COLOUR(bgColour);
+		auto itemColour1 = GET_OBJECT_COLOUR(itemColour);
+		auto itemColour2 = GET_OBJECT_COLOUR(itemColour2);
+		auto tc = GET_OBJECT_COLOUR(textColour);
+
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		vp->getProperties().set("textColour", (int64)tc.getARGB());
 	}
 	else
 	{
@@ -1926,7 +1938,35 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateComponent(int proper
 		switch (propertyIndex)
 		{
 			PROPERTY_CASE::ScriptedViewport::Properties::scrollbarThickness: vp->setScrollBarThickness(newValue); break;
-			PROPERTY_CASE::ScriptComponent::itemColour: vp->setColour(ScrollBar::ColourIds::thumbColourId, GET_OBJECT_COLOUR(itemColour)); break;
+			PROPERTY_CASE::ScriptComponent::bgColour:
+			{
+				auto c = GET_OBJECT_COLOUR(bgColour);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::itemColour:
+			{
+				auto c = GET_OBJECT_COLOUR(itemColour);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::itemColour2:
+			{
+				auto c = GET_OBJECT_COLOUR(itemColour2);
+				vp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, c);
+				vp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, c);
+				break;
+			}
+			PROPERTY_CASE::ScriptComponent::textColour:
+			{
+				auto c = GET_OBJECT_COLOUR(textColour);
+				vp->getProperties().set("textColour", (int64)c.getARGB());
+				vp->getVerticalScrollBar().repaint();
+				vp->getHorizontalScrollBar().repaint();
+				break;
+			}
 		}
 	}
 }
@@ -2038,7 +2078,14 @@ void ScriptCreatedComponentWrappers::ViewportWrapper::updateColours()
 			tableModel->setColours(textColour, bgColour, itemColour1, itemColour2);
 		}
 
-		listBox->getViewport()->setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		auto lbvp = listBox->getViewport();
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		lbvp->getVerticalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::backgroundColourId, bgColour);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, itemColour1);
+		lbvp->getHorizontalScrollBar().setColour(ScrollBar::ColourIds::trackColourId, itemColour2);
+		lbvp->getProperties().set("textColour", (int64)textColour.getARGB());
 
 		listBox->setColour(ListBox::ColourIds::backgroundColourId, bgColour);
 		listBox->setColour(ListBox::ColourIds::outlineColourId, itemColour2);

--- a/hi_scripting/scripting/api/ScriptTableListModel.cpp
+++ b/hi_scripting/scripting/api/ScriptTableListModel.cpp
@@ -714,8 +714,22 @@ ScriptTableListModel::LookAndFeelData ScriptTableListModel::LookAndFeelMethods::
 		{
 			return st->d;
 		}
+
+		if (auto ft = dynamic_cast<TableFloatingTileBase*>(table->getModel()))
+		{
+			auto ftd = ft->getLookAndFeelData();
+			LookAndFeelData d;
+			d.f = ftd.f;
+			d.fontName = ftd.fontName;
+			d.textColour = ftd.textColour;
+			d.bgColour = ftd.bgColour;
+			d.itemColour1 = ftd.itemColour1;
+			d.itemColour2 = ftd.itemColour2;
+			d.itemColour3 = ftd.itemColour3;
+			return d;
+		}
 	}
-	
+
 	return {};
 }
 

--- a/hi_scripting/scripting/api/ScriptTableListModel.h
+++ b/hi_scripting/scripting/api/ScriptTableListModel.h
@@ -75,8 +75,9 @@ struct ScriptTableListModel : public juce::TableListBoxModel,
 		bool sortForward = true;
 
 		Font f = GLOBAL_BOLD_FONT();
+		String fontName;
 		Justification c = Justification::centredLeft;
-		Colour textColour, bgColour, itemColour1, itemColour2;
+		Colour textColour, bgColour, itemColour1, itemColour2, itemColour3;
 	};
 
 	struct LookAndFeelMethods

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4541,12 +4541,26 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawToggleButton(Graphics &g_, 
 		obj->setProperty("down", b.isMouseButtonDown(true));
 		obj->setProperty("value", b.getToggleState());
 
-		setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
-		setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
-		setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
-		setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
-
-		addParentFloatingTile(b, obj);
+		if (auto ft = b.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.fontName);
+		}
+		else
+		{
+			setColourOrBlack(obj, "bgColour", b, HiseColourScheme::ComponentOutlineColourId);
+			setColourOrBlack(obj, "itemColour1", b, HiseColourScheme::ComponentFillTopColourId);
+			setColourOrBlack(obj, "itemColour2", b, HiseColourScheme::ComponentFillBottomColourId);
+			setColourOrBlack(obj, "textColour", b, HiseColourScheme::ComponentTextColourId);
+			addParentFloatingTile(b, obj);
+		}
 
 		if (get()->callWithGraphics(g_, "drawToggleButton", var(obj), &b))
 			return;
@@ -4665,7 +4679,25 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawLinearSlider(Graphics &g, i
 			setColourOrBlack(obj, "textColour", *parentPack, Slider::trackColourId);
 		}
 
-		addParentFloatingTile(slider, obj);
+		if (auto ft = slider.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("fontSize", d.f.getHeight());
+			obj->setProperty("font", d.fontName);
+
+			slider.setColour(Slider::textBoxOutlineColourId, Colours::transparentBlack);
+			slider.setTextBoxStyle(Slider::NoTextBox, true, 0, 0);
+		}
+		else
+		{
+			addParentFloatingTile(slider, obj);
+		}
 
 		if (get()->callWithGraphics(g, "drawLinearSlider", var(obj), &slider))
 			return;
@@ -5081,6 +5113,14 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 		setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
 		setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
 		setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+
+		if (auto ft = scrollbar.findParentComponentOfClass<TableFloatingTileBase>())
+		{
+			auto d = ft->getLookAndFeelData();
+			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+			obj->setProperty("font", d.fontName);
+			obj->setProperty("fontSize", d.f.getHeight());
+		}
 
 		addParentFloatingTile(scrollbar, obj);
 
@@ -5549,7 +5589,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("rowIndex", rowNumber);
 		obj->setProperty("selected", rowIsSelected);
@@ -5575,7 +5618,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, con
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", text);
 		obj->setProperty("rowIndex", rowNumber);
@@ -5606,10 +5652,15 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderBackground(Graph
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		auto a = h.getLocalBounds();
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		addParentFloatingTile(h, obj);
 
 		if (get()->callWithGraphics(g_, "drawTableHeaderBackground", var(obj), &h))
 			return;
@@ -5629,10 +5680,13 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 		obj->setProperty("bgColour", d.bgColour.getARGB());
 		obj->setProperty("itemColour", d.itemColour1.getARGB());
 		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
 		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
 
 		obj->setProperty("text", columnName);
-		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("columnIndex", h.getIndexOfColumnId(columnId, true));
 		obj->setProperty("hover", isMouseOver);
 		obj->setProperty("down", isMouseDown);
 
@@ -5643,11 +5697,76 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableHeaderColumn(Graphics&
 
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
 
+		addParentFloatingTile(h, obj);
+
 		if (get()->callWithGraphics(g_, "drawTableHeaderColumn", var(obj), &h))
 			return;
 	}
 
 	drawDefaultTableHeaderColumn(g_, h, columnName, columnId, width, height, isMouseOver, isMouseDown, columnFlags);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableRowBackground(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered)
+{
+	if (functionDefined("drawTableRowBackground"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("hover", rowIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableRowBackground", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableRowBackground(g_, d, rowNumber, width, height, rowIsSelected, rowIsHovered);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTableCell(Graphics& g_, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered)
+{
+	if (functionDefined("drawTableCell"))
+	{
+		auto obj = new DynamicObject();
+
+		obj->setProperty("bgColour", d.bgColour.getARGB());
+		obj->setProperty("itemColour", d.itemColour1.getARGB());
+		obj->setProperty("itemColour2", d.itemColour2.getARGB());
+		obj->setProperty("itemColour3", d.itemColour3.getARGB());
+		obj->setProperty("textColour", d.textColour.getARGB());
+		obj->setProperty("font", d.fontName);
+		obj->setProperty("fontSize", d.f.getHeight());
+
+		obj->setProperty("text", text);
+		obj->setProperty("rowIndex", rowNumber);
+		obj->setProperty("columnIndex", columnId);
+		obj->setProperty("selected", rowIsSelected);
+		obj->setProperty("clicked", cellIsClicked);
+		obj->setProperty("hover", cellIsHovered);
+		obj->setProperty("parentType", d.parentType);
+
+		Rectangle<int> a(0, 0, width, height);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, a.toFloat()));
+
+		if (get()->callWithGraphics(g_, "drawTableCell", var(obj), nullptr))
+			return;
+	}
+
+	TableFloatingTileBase::LookAndFeelMethods::drawTableCell(g_, d, text, rowNumber, columnId, width, height, rowIsSelected, cellIsClicked, cellIsHovered);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawMatrixPeakMeter(Graphics& g_, float* peakValues, float* maxPeaks, int numChannels, bool isVertical, float segmentSize, float paddingSize, Component* c)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2729,7 +2729,8 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
 		"drawFlexAhdsrFullPath",
 		"drawFlexAhdsrPosition",
 		"drawFlexAhdsrSegment",
-		"drawFlexAhdsrText"
+		"drawFlexAhdsrText",
+		"drawPerformanceLabel"
 	};
 
 	return sa;
@@ -6014,6 +6015,40 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrText(Graphics& g_,
     }
 
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrText(g_, graph, text);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPerformanceLabel(
+	Graphics& g, PerformanceLabelPanel& panel, float cpu, int64 ram, int voices)
+{
+	if (functionDefined("drawPerformanceLabel"))
+	{
+		auto obj = new DynamicObject();
+
+		writeId(obj, &panel);
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, panel.getLocalBounds().toFloat()));
+
+		obj->setProperty("bgColour",     (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::bgColour).getARGB());
+		obj->setProperty("textColour",   (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::textColour).getARGB());
+		obj->setProperty("itemColour1",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour1).getARGB());
+		obj->setProperty("itemColour2",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour2).getARGB());
+		obj->setProperty("itemColour3",  (int64)panel.findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
+
+		obj->setProperty("font",     panel.getFontName());
+		obj->setProperty("fontSize", panel.getFont().getHeight());
+
+		obj->setProperty("cpu",    cpu);
+		obj->setProperty("ram",    ram);
+		obj->setProperty("voices", voices);
+
+		if (get()->callWithGraphics(g, "drawPerformanceLabel", var(obj), &panel))
+			return;
+	}
+
+	// Default fallback
+	g.setColour(panel.findPanelColour(FloatingTileContent::PanelColourId::textColour));
+	g.setFont(panel.getFont());
+	String stats = "CPU: " + String(cpu, 1) + "%, RAM: " + String((double)ram / 1024.0 / 1024.0, 1) + "MB , Voices: " + String(voices);
+	g.drawText(stats, panel.getLocalBounds(), Justification::centredLeft);
 }
 
 juce::Image ScriptingObjects::ScriptedLookAndFeel::Laf::createIcon(PresetHandler::IconType type)

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5388,6 +5388,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawWhiteNote(CustomKeyboardSta
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
 
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
+
 		if (get()->callWithGraphics(g_, "drawWhiteNote", var(obj), c))
 			return;
 	}
@@ -5408,6 +5414,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawBlackNote(CustomKeyboardSta
 		obj->setProperty("hover", isOver);
 		obj->setProperty("down", isDown);
 		obj->setProperty("keyColour", state->getColourForSingleKey(midiNoteNumber).getARGB());
+
+		if (auto kp = c->findParentComponentOfClass<MidiKeyboardPanel>())
+		{
+			obj->setProperty("font", kp->getFontName());
+			obj->setProperty("fontSize", kp->getFont().getHeight());
+		}
 
 		if (get()->callWithGraphics(g_, "drawBlackNote", var(obj), c))
 			return;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4860,8 +4860,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawPresetBrowserBackground(Gra
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserBackground", var(obj), p))
@@ -4882,8 +4883,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawColumnBackground(Graphics& 
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserColumnBackground", var(obj), nullptr))
@@ -4907,8 +4909,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawListItem(Graphics& g_, Comp
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserListItem", var(obj), nullptr))
@@ -4927,8 +4930,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawSearchBar(Graphics& g_, Com
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		auto p = new ScriptingObjects::PathObject(get()->getScriptProcessor());
@@ -5110,19 +5114,39 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 		obj->setProperty("vertical", isScrollbarVertical);
 		obj->setProperty("over", isMouseOver);
 		obj->setProperty("down", isMouseDown);
-		setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
-		setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
-		setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
-
 		if (auto ft = scrollbar.findParentComponentOfClass<TableFloatingTileBase>())
 		{
 			auto d = ft->getLookAndFeelData();
+			obj->setProperty("bgColour", d.bgColour.getARGB());
+			obj->setProperty("itemColour1", d.itemColour1.getARGB());
+			obj->setProperty("itemColour2", d.itemColour2.getARGB());
 			obj->setProperty("itemColour3", ft->findPanelColour(FloatingTileContent::PanelColourId::itemColour3).getARGB());
-			obj->setProperty("font", d.fontName);
+			obj->setProperty("textColour", d.textColour.getARGB());
+			obj->setProperty("parentType", d.parentType);
+			obj->setProperty("font", d.f.getTypefaceName());
 			obj->setProperty("fontSize", d.f.getHeight());
 		}
+		else
+		{
+			static const Identifier pb("PresetBrowser");
 
-		addParentFloatingTile(scrollbar, obj);
+			if (getIdOfParentFloatingTile(scrollbar) == pb)
+			{
+				obj->setProperty("bgColour", backgroundColour.getARGB());
+				obj->setProperty("itemColour1", highlightColour.getARGB());
+				obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+				obj->setProperty("itemColour3", itemColour3.getARGB());
+				obj->setProperty("textColour", textColour.getARGB());
+				obj->setProperty("parentType", pb.toString());
+			}
+			else
+			{
+				setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
+				setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
+				setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+				addParentFloatingTile(scrollbar, obj);
+			}
+		}
 
 		if (get()->callWithGraphics(g_, "drawScrollbar", var(obj), &scrollbar))
 			return;
@@ -6234,8 +6258,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawTag(Graphics& g_, Component
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (get()->callWithGraphics(g_, "drawPresetBrowserTag", var(obj), nullptr))
@@ -6257,8 +6282,9 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawModalOverlay(Graphics& g_, 
 		obj->setProperty("bgColour", backgroundColour.getARGB());
 		obj->setProperty("itemColour", highlightColour.getARGB());
 		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("itemColour3", itemColour3.getARGB());
 		obj->setProperty("textColour", textColour.getARGB());
-		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("font", fontName);
 		obj->setProperty("fontSize", font.getHeight());
 
 		if (l->callWithGraphics(g_, "drawPresetBrowserDialog", var(obj), nullptr))

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5144,6 +5144,23 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawScrollbar(Graphics& g_, Scr
 				setColourOrBlack(obj, "bgColour",    scrollbar, ScrollBar::ColourIds::backgroundColourId);
 				setColourOrBlack(obj, "itemColour",  scrollbar, ScrollBar::ColourIds::thumbColourId);
 				setColourOrBlack(obj, "itemColour2", scrollbar, ScrollBar::ColourIds::trackColourId);
+
+				if (auto vp = scrollbar.findParentComponentOfClass<juce::Viewport>())
+				{
+					auto id = vp->getComponentID();
+
+					// For Viewport mode, the ID is on the Viewport itself.
+					// For List/Table mode, the ID is on the parent ListBox.
+					if (id.isEmpty() && vp->getParentComponent() != nullptr)
+						id = vp->getParentComponent()->getComponentID();
+
+					if (id.isNotEmpty())
+						obj->setProperty("id", id);
+
+					if (vp->getProperties().contains("textColour"))
+						obj->setProperty("textColour", (int64)vp->getProperties()["textColour"]);
+				}
+
 				addParentFloatingTile(scrollbar, obj);
 			}
 		}

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -835,7 +835,8 @@ namespace ScriptingObjects
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
-			public HiSlider::HoverPopupLookandFeel
+			public HiSlider::HoverPopupLookandFeel,
+			public PerformanceLabelPanel::LookAndFeelMethods
 		{
 			Laf(MainController* mc);
 
@@ -965,6 +966,9 @@ namespace ScriptingObjects
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 			void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
+
+			void drawPerformanceLabel(Graphics& g, PerformanceLabelPanel& panel,
+			                         float cpu, int64 ram, int voices) override;
 
 			Image createIcon(PresetHandler::IconType type) override;
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -834,6 +834,7 @@ namespace ScriptingObjects
 			public CustomKeyboardLookAndFeelBase,
 			public ScriptTableListModel::LookAndFeelMethods,
             public MatrixPeakMeter::LookAndFeelMethods,
+			public TableFloatingTileBase::LookAndFeelMethods,
 			public WaterfallComponent::LookAndFeelMethods,
 			public HiSlider::HoverPopupLookandFeel,
 			public PerformanceLabelPanel::LookAndFeelMethods
@@ -938,6 +939,10 @@ namespace ScriptingObjects
 			void drawTableHeaderBackground(Graphics& g, TableHeaderComponent& h) override;
 
 			void drawTableHeaderColumn(Graphics& g, TableHeaderComponent&, const String& columnName, int columnId, int width, int height, bool isMouseOver, bool isMouseDown, int columnFlags) override;
+
+			void drawTableRowBackground(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, int rowNumber, int width, int height, bool rowIsSelected, bool rowIsHovered) override;
+
+			void drawTableCell(Graphics& g, const TableFloatingTileBase::LookAndFeelData& d, const String& text, int rowNumber, int columnId, int width, int height, bool rowIsSelected, bool cellIsClicked, bool cellIsHovered) override;
 
             void getIdealPopupMenuItemSize(const String &text, bool isSeparator, int standardMenuItemHeight, int &idealWidth, int &idealHeight) override;
             

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -2695,6 +2695,63 @@
               }
             }
           }
+        },
+        "PerformanceLabel": {
+          "lafFunctions": {
+            "drawPerformanceLabel": {
+              "description": "Draws the performance statistics floating tile (CPU usage, RAM usage, active voice count)",
+              "callbackProperties": {
+                "id": {
+                  "type": "String",
+                  "description": "The component's ID from getComponentID()"
+                },
+                "area": {
+                  "type": "Array[x, y, w, h]",
+                  "description": "The panel bounds"
+                },
+                "bgColour": {
+                  "type": "int (ARGB)",
+                  "description": "Background colour (ColourData::bgColour)"
+                },
+                "textColour": {
+                  "type": "int (ARGB)",
+                  "description": "Text colour (ColourData::textColour)"
+                },
+                "itemColour1": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 1 (ColourData::itemColour1)"
+                },
+                "itemColour2": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 2 (ColourData::itemColour2)"
+                },
+                "itemColour3": {
+                  "type": "int (ARGB)",
+                  "description": "Item colour 3 (ColourData::itemColour3)"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "Typeface name from the panel's Font setting"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "Font size from the panel's FontSize setting"
+                },
+                "cpu": {
+                  "type": "float",
+                  "description": "Current CPU usage as a percentage (0.0-100.0)"
+                },
+                "ram": {
+                  "type": "int64",
+                  "description": "Current RAM usage in bytes"
+                },
+                "voices": {
+                  "type": "int",
+                  "description": "Number of currently active voices"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -1246,6 +1246,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             },
@@ -1271,6 +1279,14 @@
                 "keyColour": {
                   "type": "int (ARGB)",
                   "description": "Custom colour for the key"
+                },
+                "font": {
+                  "type": "String",
+                  "description": "The typeface name from the keyboard panel's Font property"
+                },
+                "fontSize": {
+                  "type": "float",
+                  "description": "The font size from the keyboard panel's FontSize property"
                 }
               }
             }

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -333,7 +333,9 @@ public:
 	Colour highlightColour;
 	Colour textColour;
 	Colour modalBackgroundColour;
+	Colour itemColour3;
 	Font font;
+	String fontName;
 };
 
 class DefaultPresetBrowserLookAndFeel : public LookAndFeel_V3,


### PR DESCRIPTION
Depends on #921 

When using drawScrollbar with a ScriptedViewport, the viewport's colour
properties (bgColour, itemColour1, itemColour2, textColour) and 
component
id are now available in the look and feel object. Previously only
itemColour (thumbColourId) was forwarded in Viewport mode and the
scrollbar had no way to identify its parent viewport.