### PR TITLE
Pass floating tile colours to drawToggleButton LAF

### DIFF
--- a/hi_core/hi_components/plugin_components/PanelTypes.cpp
+++ b/hi_core/hi_components/plugin_components/PanelTypes.cpp
@@ -203,6 +203,10 @@ MidiChannelPanel::MidiChannelPanel(FloatingTile* parent) :
 	FloatingTileContent(parent)
 {
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::black);
+	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
+	setDefaultPanelColour(PanelColourId::itemColour1, Colour(0x00000000));
+	setDefaultPanelColour(PanelColourId::itemColour2, Colour(0x00000000));
+	setDefaultPanelColour(PanelColourId::itemColour3, Colour(0x00000000));
 
 	StringArray channelNames;
 	channelNames.add("All Channels");
@@ -216,8 +220,6 @@ MidiChannelPanel::MidiChannelPanel(FloatingTile* parent) :
 	viewport->setViewedComponent(channelList);
 
 	viewport->setScrollBarsShown(true, false, true, false);
-
-	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 
 	if (getMainController()->getCurrentScriptLookAndFeel() != nullptr)
 	{
@@ -264,18 +266,27 @@ void MidiChannelPanel::resized()
 
 	channelList->setSize(getParentShell()->getContentBounds().getWidth() - 5 - delta, channelList->getHeight());
 	channelList->setColourAndFont(findPanelColour(PanelColourId::textColour), getFont());
+	channelList->setColoursForPanel(findPanelColour(PanelColourId::bgColour),
+	                                findPanelColour(PanelColourId::textColour),
+	                                findPanelColour(PanelColourId::itemColour1),
+	                                findPanelColour(PanelColourId::itemColour2),
+	                                findPanelColour(PanelColourId::itemColour3));
 }
 
 MidiSourcePanel::MidiSourcePanel(FloatingTile* parent) :
 	FloatingTileContent(parent)
 {
 	setDefaultPanelColour(PanelColourId::bgColour, Colours::black);
+	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
+	setDefaultPanelColour(PanelColourId::itemColour1, Colour(0x00000000));
+	setDefaultPanelColour(PanelColourId::itemColour2, Colour(0x00000000));
+	setDefaultPanelColour(PanelColourId::itemColour3, Colour(0x00000000));
 
     StringArray midiInputs;
-    
+
 #if HISE_IOS || IS_STANDALONE_APP
     if(!parent->getMainController()->isFlakyThreadingAllowed())
-        midiInputs = MidiInput::getDevices();	
+        midiInputs = MidiInput::getDevices();
 #endif
 
 	numMidiDevices = midiInputs.size();
@@ -283,8 +294,6 @@ MidiSourcePanel::MidiSourcePanel(FloatingTile* parent) :
 	addAndMakeVisible(viewport = new Viewport());
 
 	midiInputList = new ToggleButtonList(midiInputs, this);
-
-	setDefaultPanelColour(PanelColourId::textColour, Colours::white);
 
 	viewport->setViewedComponent(midiInputList);
 
@@ -316,6 +325,11 @@ void MidiSourcePanel::resized()
 	midiInputList->setSize(getParentShell()->getContentBounds().getWidth() - 5 - delta, midiInputList->getHeight());
 
 	midiInputList->setColourAndFont(findPanelColour(PanelColourId::textColour), getFont());
+	midiInputList->setColoursForPanel(findPanelColour(PanelColourId::bgColour),
+	                                  findPanelColour(PanelColourId::textColour),
+	                                  findPanelColour(PanelColourId::itemColour1),
+	                                  findPanelColour(PanelColourId::itemColour2),
+	                                  findPanelColour(PanelColourId::itemColour3));
 }
 
 void MidiSourcePanel::periodicCheckCallback(ToggleButtonList* list)

--- a/hi_core/hi_components/plugin_components/PanelTypes.h
+++ b/hi_core/hi_components/plugin_components/PanelTypes.h
@@ -136,7 +136,11 @@ A list with all MIDI channels that can be enabled or disabled.
 
 | ID | Description |
 | --- | --- |
+`ColourData::bgColour`  | the background colour
 `ColourData::textColour`  | the text colour
+`ColourData::itemColour1`  | the first item colour
+`ColourData::itemColour2`  | the second item colour
+`ColourData::itemColour3`  | the third item colour
 
 ### Example JSON
 
@@ -183,7 +187,11 @@ A list with all available MIDI devices that can be enabled / disabled (similar t
 
 | ID | Description |
 | --- | --- |
+`ColourData::bgColour`  | the background colour
 `ColourData::textColour`  | the text colour
+`ColourData::itemColour1`  | the first item colour
+`ColourData::itemColour2`  | the second item colour
+`ColourData::itemColour3`  | the third item colour
 
 ### Example JSON
 

--- a/hi_core/hi_components/plugin_components/StandalonePopupComponents.h
+++ b/hi_core/hi_components/plugin_components/StandalonePopupComponents.h
@@ -74,6 +74,23 @@ public:
 		btblaf.f = f;
 	}
 
+	enum ColourIds
+	{
+		ItemColour3 = 0x1003500
+	};
+
+	void setColoursForPanel(Colour bgColour, Colour textColour, Colour itemColour1, Colour itemColour2, Colour itemColour3)
+	{
+		for (auto* b : buttons)
+		{
+			b->setColour(HiseColourScheme::ComponentOutlineColourId, bgColour);
+			b->setColour(HiseColourScheme::ComponentTextColourId, textColour);
+			b->setColour(HiseColourScheme::ComponentFillTopColourId, itemColour1);
+			b->setColour(HiseColourScheme::ComponentFillBottomColourId, itemColour2);
+			b->setColour(ItemColour3, itemColour3);
+		}
+	}
+
 private:
 
 	


### PR DESCRIPTION
Ensure toggle buttons in MidiSources and MidiChannelList floating tiles propagate their panel colour properties (bgColour, itemColour1, itemColour2, textColour) to the drawToggleButton LAF callback. Adds setColoursForPanel() to apply HiseColourScheme colours to child buttons and registers default colours.

Also add support for the floating-tile-specific itemColour3 property via a custom ColourId, passing it to the LAF callback only when the button belongs to a floating tile.