### PR TITLE
Fix build warnings on Linux

### DIFF
--- a/hi_backend/backend/ai_tools/RestHelpers.cpp
+++ b/hi_backend/backend/ai_tools/RestHelpers.cpp
@@ -1679,7 +1679,7 @@ RestServer::Response RestHelpers::handleScreenshot(MainController* mc, RestServe
 	 - Find the ScriptContentComponent (the actual UI component on screen)
 	 - Marshal to message thread for capture
 	 - Use Component::createComponentSnapshot(bounds, true, scale)
-	 - If componentId specified, crop to that component's bounds
+	 - If componentId specified, crop to that component bounds
 	 - 1 second timeout - return error if exceeded
 	 - Handle case where UI is mid-compilation gracefully
 	

--- a/hi_core/hi_core/UtilityClasses.h
+++ b/hi_core/hi_core/UtilityClasses.h
@@ -489,7 +489,7 @@ public:
 
 private:
 
-	Colour noteColours[127];
+	Colour noteColours[128];
 	int lowestKey;
 
 };

--- a/hi_core/hi_sampler/sampler/ModulatorSampler.cpp
+++ b/hi_core/hi_sampler/sampler/ModulatorSampler.cpp
@@ -1530,7 +1530,7 @@ void ModulatorSampler::preHiseEventCallback(HiseEvent &m)
 
 		if (m.isNoteOn())
 		{
-			samplerDisplayValues.currentNotes[m.getNoteNumber() + m.getTransposeAmount()] = m.getVelocity();
+			samplerDisplayValues.currentNotes[jlimit(0, 127, m.getNoteNumber() + m.getTransposeAmount())] = m.getVelocity();
 		}
 		else
 		{
@@ -1538,7 +1538,7 @@ void ModulatorSampler::preHiseEventCallback(HiseEvent &m)
 			getSampleEditHandler()->noteBroadcaster.sendMessage(sendNotificationAsync, m.getNoteNumber(), 0);
 #endif
 
-            samplerDisplayValues.currentNotes[m.getNoteNumber() + m.getTransposeAmount()] = 0;
+            samplerDisplayValues.currentNotes[jlimit(0, 127, m.getNoteNumber() + m.getTransposeAmount())] = 0;
 		}
 		
         sendOtherChangeMessage(dispatch::library::ProcessorChangeEvent::Custom, dispatch::sendNotificationAsync);

--- a/hi_dsp_library/node_api/nodes/duplicate.h
+++ b/hi_dsp_library/node_api/nodes/duplicate.h
@@ -169,7 +169,7 @@ template <typename T> struct cloned_node_reference
             auto& p = src->getParameter();
             auto& dst = obj[i];
 
-            p.connect<P>(dst);
+            p.template connect<P>(dst);
         }
 	}
 

--- a/hi_lac/hlac/CompressionHelpers.cpp
+++ b/hi_lac/hlac/CompressionHelpers.cpp
@@ -450,7 +450,7 @@ uint8 CompressionHelpers::getBitReductionForDifferential(AudioBufferInt16& b)
 {
 	AudioBufferInt16 copy(b.size);
 
-	memcpy(copy.getWritePointer(), b.getReadPointer(), 2*b.size);
+	memcpy(copy.getWritePointer(), b.getReadPointer(), 2 * (size_t)b.size);
 
 	Diff::downSampleBuffer(copy);
 

--- a/hi_rlottie/src/vector/stb/stb_image.h
+++ b/hi_rlottie/src/vector/stb/stb_image.h
@@ -4774,7 +4774,7 @@ static void stbi__de_iphone(stbi__png *z)
 static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
    stbi_uc palette[1024], pal_img_n=0;
-   stbi_uc has_trans=0, tc[3];
+   stbi_uc has_trans=0, tc[4];
    stbi__uint16 tc16[3];
    stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
    int first=1,k,interlace=0, color=0, is_iphone=0;

--- a/hi_snex/snex_jit/snex_jit_OperationsBase.h
+++ b/hi_snex/snex_jit/snex_jit_OperationsBase.h
@@ -261,7 +261,7 @@ namespace Operations
 			jassert(currentPass == p);
 		}
 
-		void throwError(const juce::String& errorMessage) const;
+		[[noreturn]] void throwError(const juce::String& errorMessage) const;
 		void logOptimisationMessage(const juce::String& m);
 		void logWarning(const juce::String& m);
 		void logMessage(BaseCompiler* compiler, BaseCompiler::MessageType type, const juce::String& message);

--- a/hi_snex/snex_mir/src/mir-gen.c
+++ b/hi_snex/snex_mir/src/mir-gen.c
@@ -138,6 +138,9 @@ static int64_t gen_int_log2 (int64_t i);
 #define MIR_GEN_CALL_TRACE 0
 #endif
 
+#ifdef DEBUG
+#undef DEBUG
+#endif
 #if MIR_NO_GEN_DEBUG
 #define DEBUG(level, code)
 #else

--- a/hi_snex/snex_parser/snex_jit_TokenIterator.h
+++ b/hi_snex/snex_parser/snex_jit_TokenIterator.h
@@ -67,7 +67,7 @@ struct ParserHelpers
 
 		CodeLocation(const CodeLocation& other) noexcept : program(other.program), location(other.location) {}
 
-		void throwError(const juce::String& message) const
+		[[noreturn]] void throwError(const juce::String& message) const
 		{
 			Error e(*this);
 
@@ -452,7 +452,7 @@ struct ParserHelpers
 			return s;
 		}
 
-		void throwTokenMismatch(const char* expected)
+		[[noreturn]] void throwTokenMismatch(const char* expected)
 		{
 			String s;
 


### PR DESCRIPTION
Add required 'template' keyword before dependent template name when calling p.connect<P>(dst) where p is a dependent expression.

https://claude.ai/code/session_011oaJHUxVahg6svtz22UgD2

Fix Linux build warnings in RestHelpers.cpp and mir-gen.c

- Remove apostrophe from comment in #if 0 block in RestHelpers.cpp to fix "missing terminating ' character" tokenizer warning
- Add #undef DEBUG before redefining it in mir-gen.c to fix "DEBUG redefined" warning caused by command-line -DDEBUG definition

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8

Fix Linux -Wreturn-type warnings in snex by marking throw functions [[noreturn]]

Mark CodeLocation::throwError, TokenIterator::throwTokenMismatch, and Operations::Statement::throwError as [[noreturn]] since they always throw. This fixes four GCC -Wreturn-type warnings caused by RETURN_DEBUG_ONLY expanding to nothing in release builds, leaving no return statement after the always-throwing calls.

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8

Fix GCC -Wstringop-overflow warning in stb_image.h

Change tc[3] to tc[4] in stbi__parse_png_file. GCC warns because the loop iterates up to s->img_n times, and img_n can be 4. The guard (s->img_n & 1) means only odd values (1 or 3) reach this code path, so tc[3] is safe in practice, but enlarging to tc[4] silences the false-positive warning.

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8

Fix out-of-bounds write to currentNotes[] in ModulatorSampler

getNoteNumber() + getTransposeAmount() can exceed [0,127] when a transpose is applied, writing beyond the end of the 128-element currentNotes array (UB flagged by -Waggressive-loop-optimizations, iteration 127). Apply jlimit(0, 127, ...) consistent with the existing bounds check in resetNoteDisplay().

The repeated -Wfree-nonheap-object 'emptyString' warnings are a GCC false positive in JUCE's StringHolder::release(): the check against the static emptyString pointer is logically correct but not visible to the optimiser after inlining. The fix is to restructure that function to use an early return when b == &emptyString so the delete[] path is in a clearly separate branch. This requires modifying juce_String.cpp in the JUCE submodule (christophhart/JUCE_customized, juce6 branch).

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8

Fix off-by-one in noteColours array causing -Waggressive-loop-optimizations

Array was declared as [127] but accessed with indices 0-127 (128 elements). Iteration 127 was UB; correct size is [128].

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8

Fix -Wstringop-overflow in memcpy call in getBitReductionForDifferential

Cast b.size to size_t before multiplying to prevent GCC from inferring a potentially-negative signed int being passed as memcpy's size argument.

https://claude.ai/code/session_01QKATiMNcmsfMd3cEn4Z4S8