### PR TITLE
Preset Browser: adapt column behaviour to folder depth

### DIFF
--- a/hi_backend/backend/ai_tools/RestServer.cpp
+++ b/hi_backend/backend/ai_tools/RestServer.cpp
@@ -41,6 +41,13 @@
 #undef Rectangle
 #endif
 
+// On Linux, resolv.h (included transitively by httplib.h) defines DELETE as
+// ns_uop_delete (= 0), which collides with the RestServer::Method::DELETE enum
+// value in switch statements. Undefine it here after all system headers are done.
+#ifdef DELETE
+#undef DELETE
+#endif
+
 namespace hise { using namespace juce;
 
 //==============================================================================

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1008,6 +1008,7 @@ var PresetBrowserPanel::toDynamicObject() const
 	storePropertyInObject(obj, SpecialPanelIds::FavoriteIconOffset, options.favoriteIconOffset);
 	storePropertyInObject(obj, SpecialPanelIds::ShowFavoriteIcon, options.showFavoriteIcons);
 	storePropertyInObject(obj, SpecialPanelIds::FullPathFavorites, options.fullPathFavorites);
+	storePropertyInObject(obj, SpecialPanelIds::FullPathSearch, options.fullPathSearch);
 	storePropertyInObject(obj, SpecialPanelIds::ButtonsInsideBorder, options.buttonsInsideBorder);
 	storePropertyInObject(obj, SpecialPanelIds::NumColumns, options.numColumns);
 	storePropertyInObject(obj, SpecialPanelIds::ColumnWidthRatio, var(options.columnWidthRatios));
@@ -1035,6 +1036,7 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.showSearchBar = getPropertyWithDefault(object, SpecialPanelIds::ShowSearchBar);
 	options.favoriteIconOffset = getPropertyWithDefault(object, SpecialPanelIds::FavoriteIconOffset);
 	options.fullPathFavorites = getPropertyWithDefault(object, SpecialPanelIds::FullPathFavorites);
+	options.fullPathSearch = getPropertyWithDefault(object, SpecialPanelIds::FullPathSearch);
 	options.buttonsInsideBorder = getPropertyWithDefault(object, SpecialPanelIds::ButtonsInsideBorder);
 	options.editButtonOffset = getPropertyWithDefault(object, SpecialPanelIds::EditButtonOffset);
 	options.showExpansions = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionsAsColumn);
@@ -1130,6 +1132,7 @@ juce::Identifier PresetBrowserPanel::getDefaultablePropertyId(int index) const
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnRowPadding, "ColumnRowPadding");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::SearchBarBounds, "SearchBarBounds");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FullPathFavorites, "FullPathFavorites");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FullPathSearch, "FullPathSearch");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FavoriteButtonBounds, "FavoriteButtonBounds");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::SaveButtonBounds, "SaveButtonBounds");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::MoreButtonBounds, "MoreButtonBounds");
@@ -1160,6 +1163,7 @@ var PresetBrowserPanel::getDefaultProperty(int index) const
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowAddButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowRenameButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::FullPathFavorites, false);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::FullPathSearch, false);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::FavoriteIconOffset, 0);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowDeleteButton, true);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowSearchBar, true);

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -996,6 +996,7 @@ var PresetBrowserPanel::toDynamicObject() const
 
 	storePropertyInObject(obj, SpecialPanelIds::ShowSaveButton, options.showSaveButtons);
 	storePropertyInObject(obj, SpecialPanelIds::ShowExpansionsAsColumn, options.showExpansions);
+	storePropertyInObject(obj, SpecialPanelIds::ShowExpansionEditButtons, options.showExpansionEditButtons);
 	storePropertyInObject(obj, SpecialPanelIds::ShowFolderButton, options.showFolderButton);
 	storePropertyInObject(obj, SpecialPanelIds::ShowNotes, options.showNotesLabel);
 	storePropertyInObject(obj, SpecialPanelIds::ShowEditButtons, options.showEditButtons);
@@ -1037,6 +1038,7 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.buttonsInsideBorder = getPropertyWithDefault(object, SpecialPanelIds::ButtonsInsideBorder);
 	options.editButtonOffset = getPropertyWithDefault(object, SpecialPanelIds::EditButtonOffset);
 	options.showExpansions = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionsAsColumn);
+	options.showExpansionEditButtons = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionEditButtons);
 	options.numColumns = getPropertyWithDefault(object, SpecialPanelIds::NumColumns);
 
 	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
@@ -1136,6 +1138,7 @@ juce::Identifier PresetBrowserPanel::getDefaultablePropertyId(int index) const
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionsAsColumn, "ShowExpansionsAsColumn");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowFavoriteIcon, "ShowFavoriteIcon");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FavoriteIconOffset, "FavoriteIconOffset");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionEditButtons, "ShowExpansionEditButtons");
 
 	return Identifier();
 }
@@ -1169,6 +1172,7 @@ var PresetBrowserPanel::getDefaultProperty(int index) const
 
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ColumnWidthRatio, var(defaultRatios));
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowExpansionsAsColumn, false);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowExpansionEditButtons, false);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowFavoriteIcon, true);
 	
 	Array<var> defaultListAreaOffset = {0, 0, 0, 0};

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1041,6 +1041,7 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.editButtonOffset = getPropertyWithDefault(object, SpecialPanelIds::EditButtonOffset);
 	options.showExpansions = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionsAsColumn);
 	options.showExpansionEditButtons = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionEditButtons);
+	options.showExpansionContentOnly = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionContentOnly);
 	options.numColumns = getPropertyWithDefault(object, SpecialPanelIds::NumColumns);
 
 	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
@@ -1142,6 +1143,7 @@ juce::Identifier PresetBrowserPanel::getDefaultablePropertyId(int index) const
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowFavoriteIcon, "ShowFavoriteIcon");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::FavoriteIconOffset, "FavoriteIconOffset");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionEditButtons, "ShowExpansionEditButtons");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionContentOnly, "ShowExpansionContentOnly");
 
 	return Identifier();
 }
@@ -1177,6 +1179,7 @@ var PresetBrowserPanel::getDefaultProperty(int index) const
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ColumnWidthRatio, var(defaultRatios));
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowExpansionsAsColumn, false);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowExpansionEditButtons, false);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowExpansionContentOnly, false);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowFavoriteIcon, true);
 	
 	Array<var> defaultListAreaOffset = {0, 0, 0, 0};

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -504,10 +504,11 @@ public:
 		SaveButtonBounds,
 		MoreButtonBounds,
 		FavoriteButtonBounds,
-    FullPathFavorites,
+		FullPathFavorites,
     FullPathSearch,
-    FavoriteIconOffset,
+		FavoriteIconOffset,
 		ShowExpansionEditButtons,
+		ShowExpansionContentOnly,
 		numSpecialProperties
 	};
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -506,6 +506,7 @@ public:
 		FavoriteButtonBounds,
     FullPathFavorites,
     FavoriteIconOffset,
+		ShowExpansionEditButtons,
 		numSpecialProperties
 	};
 

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -505,6 +505,7 @@ public:
 		MoreButtonBounds,
 		FavoriteButtonBounds,
     FullPathFavorites,
+    FullPathSearch,
     FavoriteIconOffset,
 		ShowExpansionEditButtons,
 		numSpecialProperties

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1994,7 +1994,38 @@ void PresetBrowser::buttonClicked(Button* b)
 
 void PresetBrowser::addEntry(int columnIndex, const String& name)
 {
-	if (columnIndex == 0)	bankColumn->addEntry(name);
+	if (columnIndex == 0)
+	{
+		if (bankColumn->isFlatteningOneLevel())
+		{
+			// In flatten mode the bank column shows categories (2nd-level dirs), so new
+			// entries must be created inside a bank folder, not at the root level.
+			File parentBank;
+
+			if (currentBankFile.isDirectory())
+			{
+				parentBank = currentBankFile.getParentDirectory();
+			}
+			else
+			{
+				Array<File> banks;
+				rootFile.findChildFiles(banks, File::findDirectories, false);
+				DataBaseHelpers::cleanFileList(getMainController(), banks);
+				banks.sort();
+				if (!banks.isEmpty())
+					parentBank = banks.getFirst();
+			}
+
+			if (parentBank.isDirectory())
+			{
+				parentBank.getChildFile(name).createDirectory();
+				configureBankColumnForDepth();
+				return;
+			}
+		}
+
+		bankColumn->addEntry(name);
+	}
 	if (columnIndex == 1)	categoryColumn->addEntry(name);
 	if (columnIndex == 2)	presetColumn->addEntry(name);
 }

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1313,6 +1313,17 @@ void PresetBrowser::setOptions(const Options& newOptions)
 	setShowEditButtons(1, newOptions.showAddButton);
 	setShowEditButtons(2, newOptions.showRenameButton);
 	setShowEditButtons(3, newOptions.showDeleteButton);
+
+	// Override expansion column buttons independently of the other columns.
+	// We hide individual buttons rather than disabling showButtonsAtBottom so that
+	// the 28px button area is still reserved, keeping the column height consistent
+	// with the bank/category/preset columns.
+	if (expansionColumn != nullptr && !newOptions.showExpansionEditButtons)
+	{
+		expansionColumn->setShowButtons(PresetBrowserColumn::AddButton, false);
+		expansionColumn->setShowButtons(PresetBrowserColumn::RenameButton, false);
+		expansionColumn->setShowButtons(PresetBrowserColumn::DeleteButton, false);
+	}
 	setShowSearchBar(newOptions.showSearchBar);
 	setButtonsInsideBorder(newOptions.buttonsInsideBorder);
 	setEditButtonOffset(newOptions.editButtonOffset);
@@ -1370,18 +1381,23 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		}
 
 		if(expansionColumn != nullptr)
+		{
+			if (file == File())
+				expansionColumn->setSelectedFile(File());
 			expansionColumn->repaint();
+			expansionColumn->updateButtonVisibility(false);
+		}
 
 		bankColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 0, this), rootFile);
 		bankColumn->setNewRootDirectory(rootFile);
 		categoryColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 1, this), rootFile);
 		categoryColumn->setNewRootDirectory(currentCategoryFile);
 		presetColumn->setNewRootDirectory(File());
-		
+
 		auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
 		pc->setDisplayDirectories(false);
 		presetColumn->setModel(pc, rootFile);
-		
+
 		loadPresetDatabase(rootFile);
 		presetColumn->setDatabase(getDataBase());
 		rebuildAllPresets();

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -389,6 +389,9 @@ void PresetBrowser::ModalWindow::buttonClicked(Button* b)
 			auto note = DataBaseHelpers::getNoteFromXml(le.newFile);
 			auto tags = DataBaseHelpers::getTagsFromXml(le.newFile);
 
+			if (le.oldFile.getFileName() != "tempFileBeforeMove.preset")
+				p->updateDatabaseKeyForFileRename(le.oldFile, le.newFile);
+
 			le.oldFile.moveFileTo(le.newFile);
 
 			if (note.isNotEmpty())
@@ -729,6 +732,158 @@ Array<File> PresetBrowser::getAllSearchRoots() const
 	return roots;
 }
 
+var PresetBrowser::loadDatabaseForRoot(const File& rootDir) const
+{
+	if (rootDir == rootFile)
+		return presetDatabase;
+
+	var db = JSON::parse(rootDir.getChildFile("db.json").loadFileAsString());
+	return db.isObject() ? db : var(new DynamicObject());
+}
+
+void PresetBrowser::saveDatabaseForRoot(const var& db, const File& rootDir)
+{
+	if (rootDir == rootFile)
+	{
+		presetDatabase = db;
+		savePresetDatabase(rootFile);
+	}
+	else
+	{
+		rootDir.getChildFile("db.json").replaceWithText(JSON::toString(db));
+	}
+}
+
+File PresetBrowser::findRootForFile(const File& f) const
+{
+	if (f.isAChildOf(rootFile))
+		return rootFile;
+
+	auto& handler = getMainController()->getExpansionHandler();
+
+	for (int i = 0; i < handler.getNumExpansions(); ++i)
+	{
+		if (auto e = handler.getExpansion(i))
+		{
+			auto userPresetsDir = e->getSubDirectory(FileHandlerBase::UserPresets);
+
+			if (f.isAChildOf(userPresetsDir))
+				return userPresetsDir;
+		}
+	}
+
+	if (f.isAChildOf(defaultRoot))
+		return defaultRoot;
+
+	return {};
+}
+
+void PresetBrowser::updateDatabaseKeysForRename(const File& oldDirectory, const File& newDirectory)
+{
+	auto root = findRootForFile(oldDirectory);
+
+	if (!root.isDirectory())
+		return;
+
+	var db = loadDatabaseForRoot(root);
+	DataBaseHelpers::renameEntriesInDatabase(db, root, oldDirectory, newDirectory);
+	saveDatabaseForRoot(db, root);
+	invalidateFavoritesCache();
+}
+
+void PresetBrowser::updateDatabaseKeyForFileRename(const File& oldFile, const File& newFile)
+{
+	auto root = findRootForFile(oldFile);
+
+	if (!root.isDirectory())
+		return;
+
+	var db = loadDatabaseForRoot(root);
+	DataBaseHelpers::renameFileEntryInDatabase(db, oldFile, newFile);
+	saveDatabaseForRoot(db, root);
+	invalidateFavoritesCache();
+}
+
+void PresetBrowser::rebuildFavoritesCache() const
+{
+	cachedFavorites.clear();
+
+	// Build the full cache across ALL roots regardless of which expansion is
+	// currently selected.  getAllFavoritePresets() filters by expansion later.
+	Array<File> allRoots;
+
+	if (defaultRoot.isDirectory())
+		allRoots.add(defaultRoot);
+
+	auto& handler = getMainController()->getExpansionHandler();
+
+	for (int i = 0; i < handler.getNumExpansions(); ++i)
+	{
+		if (auto e = handler.getExpansion(i))
+		{
+			auto userPresetsDir = e->getSubDirectory(FileHandlerBase::UserPresets);
+			if (userPresetsDir.isDirectory() && !allRoots.contains(userPresetsDir))
+				allRoots.add(userPresetsDir);
+		}
+	}
+
+	for (auto& rootDir : allRoots)
+	{
+		auto db = loadDatabaseForRoot(rootDir);
+
+		Array<File> presets;
+		rootDir.findChildFiles(presets, File::findFiles, true);
+		DataBaseHelpers::cleanFileList(const_cast<MainController*>(getMainController()), presets);
+
+		for (auto& preset : presets)
+		{
+			if (DataBaseHelpers::isFavorite(db, preset))
+				cachedFavorites.add(preset);
+		}
+	}
+
+	favoritesCacheDirty = false;
+}
+
+bool PresetBrowser::isFavoriteInAnyDatabase(const File& presetFile) const
+{
+	if (favoritesCacheDirty)
+		rebuildFavoritesCache();
+
+	return cachedFavorites.contains(presetFile);
+}
+
+void PresetBrowser::setFavoriteForFile(const File& presetFile, bool isFavorite)
+{
+	auto root = findRootForFile(presetFile);
+
+	if (!root.isDirectory())
+		return;
+
+	var db = loadDatabaseForRoot(root);
+	DataBaseHelpers::setFavorite(db, presetFile, isFavorite);
+	saveDatabaseForRoot(db, root);
+	invalidateFavoritesCache();
+}
+
+Array<File> PresetBrowser::getAllFavoritePresets()
+{
+	if (favoritesCacheDirty)
+		rebuildFavoritesCache();
+
+	if (currentlySelectedExpansion == nullptr)
+		return cachedFavorites;
+
+	auto expansionRoot = currentlySelectedExpansion->getSubDirectory(FileHandlerBase::UserPresets);
+	Array<File> filtered;
+
+	for (auto& f : cachedFavorites)
+		if (f.isAChildOf(expansionRoot))
+			filtered.add(f);
+
+	return filtered;
+}
+
 void PresetBrowser::presetChanged(const File& newPreset)
 {
 	// After we switched the expansions we need to make sure to run this logic so that it ca
@@ -939,6 +1094,28 @@ void PresetBrowser::resized()
 	if (tagList->isActive())
 		tagList->setBounds(listArea.removeFromTop(30));
 
+	const int folderOffset = expansionColumn != nullptr ? 1 : 0;
+	const int numColumnsToShow = jlimit(1, 4, numColumns + folderOffset);
+	int columnWidths[4] = { 0, 0, 0, 0 };
+	auto w = (double)getWidth();
+
+	if (columnWidthRatios.size() == numColumnsToShow)
+	{
+		for (int i = 0; i < numColumnsToShow; i++)
+		{
+			auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
+			columnWidths[i] = roundToInt(w * r);
+		}
+	}
+	else
+	{
+		// column amount mismatch, use equal spacing...
+		const int columnWidth = roundToInt(w / (double)numColumnsToShow);
+
+		for (int i = 0; i < numColumnsToShow; i++)
+			columnWidths[i] = columnWidth;
+	}
+
 	if (showOnlyPresets)
 	{
 		if (expansionColumn != nullptr)
@@ -948,28 +1125,6 @@ void PresetBrowser::resized()
 	}
 	else
 	{
-		const int folderOffset = expansionColumn != nullptr ? 1 : 0;
-		const int numColumnsToShow = jlimit(1, 4, numColumns + folderOffset);
-		int columnWidths[4] = { 0, 0, 0, 0 };
-		auto w = (double)getWidth();
-
-		if (columnWidthRatios.size() == numColumnsToShow)
-		{
-			for (int i = 0; i < numColumnsToShow; i++)
-			{
-				auto r = jlimit(0.0, 1.0, (double)columnWidthRatios[i]);
-				columnWidths[i] = roundToInt(w * r);
-			}
-		}
-		else
-		{
-			// column amount mismatch, use equal spacing...
-			const int columnWidth = roundToInt(w / (double)numColumnsToShow);
-
-			for (int i = 0; i < numColumnsToShow; i++)
-				columnWidths[i] = columnWidth;
-		}
-
 		if(expansionColumn != nullptr)
 			expansionColumn->setBounds(listArea.removeFromLeft(columnWidths[0]).reduced(2, 2));
 
@@ -1045,7 +1200,7 @@ void PresetBrowser::labelTextChanged(Label* l)
 	{
 		showOnlyPresets = !currentTagSelection.isEmpty() || l->getText().isNotEmpty() || favoriteButton->getToggleState();
 
-		if (showOnlyPresets)
+		if (l->getText().isNotEmpty())
 			currentWildcard = "*" + l->getText() + "*";
 		else
 			currentWildcard = "*";
@@ -1067,6 +1222,9 @@ void PresetBrowser::updateFavoriteButton()
 
 	if (presetColumn == nullptr)
 		return;
+
+	if (on)
+		invalidateFavoritesCache();
 
 	presetColumn->setShowFavoritesOnly(on);
 
@@ -1396,14 +1554,18 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		currentBankFile = File();
 		currentCategoryFile = File();
 		currentlyLoadedPreset = 0;
-		
+
+		// Flush before loadPresetDatabase overwrites the in-memory state.
+		if (rootFile.isDirectory())
+			savePresetDatabase(rootFile);
+
 		if (file == File())
 		{
 			if (FullInstrumentExpansion::isEnabled(getMainController()))
 				rootFile = File();
 			else
 				rootFile = defaultRoot;
-				
+
 			currentlySelectedExpansion = nullptr;
 		}
 		else
@@ -1430,7 +1592,6 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		categoryColumn->setNewRootDirectory(currentCategoryFile);
 
 		loadPresetDatabase(rootFile);
-		presetColumn->setDatabase(getDataBase());
 		rebuildAllPresets();
 
 		if (showOnlyPresets)
@@ -1447,6 +1608,8 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 			pc->setDisplayDirectories(false);
 			presetColumn->setModel(pc, rootFile);
 		}
+
+		presetColumn->setDatabase(getDataBase());
 	}
 
 	if (columnIndex == 0)
@@ -1524,6 +1687,7 @@ void PresetBrowser::renameEntry(int columnIndex, int rowIndex, const String& new
 			if (newBank.isDirectory())
 				return;
 
+            updateDatabaseKeysForRename(currentBankFile, newBank);
             currentBankFile.moveFileTo(newBank);
 
             categoryColumn->setNewRootDirectory(File());
@@ -1543,6 +1707,7 @@ void PresetBrowser::renameEntry(int columnIndex, int rowIndex, const String& new
             if(newCategory.isDirectory())
 				return;
 
+            updateDatabaseKeysForRename(currentCategoryFile, newCategory);
             currentCategoryFile.moveFileTo(newCategory);
 
             categoryColumn->setNewRootDirectory(currentBankFile);
@@ -1575,6 +1740,7 @@ void PresetBrowser::renameEntry(int columnIndex, int rowIndex, const String& new
 				modalInputWindow->confirmReplacement(presetFile, newFile);
 			else
 			{
+				updateDatabaseKeyForFileRename(presetFile, newFile);
 				presetFile.moveFileTo(newFile);
 				presetColumn->setNewRootDirectory(current);
 				rebuildAllPresets();
@@ -1964,6 +2130,80 @@ juce::Identifier PresetBrowser::DataBaseHelpers::getIdForFile(const File& preset
 	}
 
 	return Identifier();
+}
+
+void PresetBrowser::DataBaseHelpers::renameEntriesInDatabase(const var& database,
+                                                             const File& rootDir,
+                                                             const File& oldDirectory,
+                                                             const File& newDirectory)
+{
+	auto data = database.getDynamicObject();
+
+	if (data == nullptr)
+		return;
+
+	auto makePrefix = [&](const File& dir)
+	{
+		auto s = dir.getRelativePathFrom(rootDir);
+		s = s.replaceCharacter('/', '_');
+		s = s.replaceCharacter('\\', '_');
+		s = s.replaceCharacter('\'', '_');
+		s = s.removeCharacters(" \t!+&");
+		return s;
+	};
+
+	auto oldPrefix = makePrefix(oldDirectory);
+	auto newPrefix = makePrefix(newDirectory);
+
+	if (oldPrefix == newPrefix)
+		return;
+
+	Array<Identifier> keysToRename;
+	Array<var> valuesToMove;
+
+	for (auto& prop : data->getProperties())
+	{
+		if (prop.name.toString().startsWith(oldPrefix))
+		{
+			keysToRename.add(prop.name);
+			valuesToMove.add(prop.value);
+		}
+	}
+
+	for (int i = 0; i < keysToRename.size(); ++i)
+	{
+		auto oldKey = keysToRename[i].toString();
+		auto newKey = newPrefix + oldKey.substring(oldPrefix.length());
+
+		data->removeProperty(keysToRename[i]);
+
+		if (Identifier::isValidIdentifier(newKey))
+			data->setProperty(Identifier(newKey), valuesToMove[i]);
+	}
+}
+
+void PresetBrowser::DataBaseHelpers::renameFileEntryInDatabase(const var& database,
+                                                               const File& oldFile,
+                                                               const File& newFile)
+{
+	auto data = database.getDynamicObject();
+
+	if (data == nullptr)
+		return;
+
+	auto oldId = getIdForFile(oldFile);
+	auto newId = getIdForFile(newFile);
+
+	if (oldId.isNull() || newId.isNull() || oldId == newId)
+		return;
+
+	auto value = data->getProperty(oldId);
+
+	if (!value.isVoid())
+	{
+		data->removeProperty(oldId);
+		data->setProperty(newId, value);
+	}
 }
 
 } // namespace hise

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -699,6 +699,36 @@ Point<int> PresetBrowser::getMouseHoverInformation() const
 	return p;
 }
 
+Array<File> PresetBrowser::getAllSearchRoots() const
+{
+	Array<File> roots;
+
+	if (currentlySelectedExpansion != nullptr)
+	{
+		auto userPresetsDir = currentlySelectedExpansion->getSubDirectory(FileHandlerBase::UserPresets);
+		if (userPresetsDir.isDirectory())
+			roots.add(userPresetsDir);
+		return roots;
+	}
+
+	if (defaultRoot.isDirectory())
+		roots.add(defaultRoot);
+
+	auto& handler = getMainController()->getExpansionHandler();
+
+	for (int i = 0; i < handler.getNumExpansions(); ++i)
+	{
+		if (auto e = handler.getExpansion(i))
+		{
+			auto userPresetsDir = e->getSubDirectory(FileHandlerBase::UserPresets);
+			if (userPresetsDir.isDirectory() && !roots.contains(userPresetsDir))
+				roots.add(userPresetsDir);
+		}
+	}
+
+	return roots;
+}
+
 void PresetBrowser::presetChanged(const File& newPreset)
 {
 	// After we switched the expansions we need to make sure to run this logic so that it ca
@@ -1093,6 +1123,11 @@ void PresetBrowser::setShowFullPathFavorites(bool shouldShowFullPathFavorites)
 	fullPathFavorites = shouldShowFullPathFavorites;
 }
 
+void PresetBrowser::setShowFullPathSearch(bool shouldShowFullPathSearch)
+{
+	fullPathSearch = shouldShowFullPathSearch;
+}
+
 void PresetBrowser::setHighlightColourAndFont(Colour c, Colour bgColour, Font f)
 {
 	auto& lf = getPresetBrowserLookAndFeel();
@@ -1333,7 +1368,8 @@ void PresetBrowser::setOptions(const Options& newOptions)
 	setShowFavorites(newOptions.showFavoriteIcons);
 	setFavoriteIconOffset(newOptions.favoriteIconOffset);
 	setShowFullPathFavorites(newOptions.fullPathFavorites);
-	
+	setShowFullPathSearch(newOptions.fullPathSearch);
+
 	if (expansionColumn != nullptr)
 		expansionColumn->update();
 
@@ -1392,15 +1428,25 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		bankColumn->setNewRootDirectory(rootFile);
 		categoryColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 1, this), rootFile);
 		categoryColumn->setNewRootDirectory(currentCategoryFile);
-		presetColumn->setNewRootDirectory(File());
-
-		auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
-		pc->setDisplayDirectories(false);
-		presetColumn->setModel(pc, rootFile);
 
 		loadPresetDatabase(rootFile);
 		presetColumn->setDatabase(getDataBase());
 		rebuildAllPresets();
+
+		if (showOnlyPresets)
+		{
+			// Keep the existing model so the search wildcard is preserved; just
+			// refresh the list — getAllSearchRoots() now returns the new expansion.
+			presetColumn->setNewRootDirectory(rootFile);
+		}
+		else
+		{
+			presetColumn->setNewRootDirectory(File());
+
+			auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
+			pc->setDisplayDirectories(false);
+			presetColumn->setModel(pc, rootFile);
+		}
 	}
 
 	if (columnIndex == 0)

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -582,7 +582,7 @@ expHandler(mc->getExpansionHandler())
 		currentlySelectedExpansion = e;
 	}
 	
-	bankColumn->setNewRootDirectory(rootFile);
+	configureBankColumnForDepth();
 
 	rebuildAllPresets();
 
@@ -1349,6 +1349,38 @@ void PresetBrowser::setHighlightColourAndFont(Colour c, Colour bgColour, Font f)
 	setOpaque(bgColour.isOpaque());
 }
 
+int PresetBrowser::getActualFolderDepth() const
+{
+	if (!rootFile.isDirectory()) return 1;
+
+	auto mc = const_cast<MainController*>(getMainController());
+
+	Array<File> level1;
+	rootFile.findChildFiles(level1, File::findDirectories, false);
+	DataBaseHelpers::cleanFileList(mc, level1);
+
+	if (level1.isEmpty()) return 1;
+
+	// If any first-level directory contains preset files directly, depth is 2
+	for (auto& bankDir : level1)
+	{
+		Array<File> presets;
+		bankDir.findChildFiles(presets, File::findFiles, false, "*.preset");
+		DataBaseHelpers::cleanFileList(mc, presets);
+		if (!presets.isEmpty()) return 2;
+	}
+
+	// No presets found at level 2, assume a 3-level structure (bank/category/preset)
+	return 3;
+}
+
+void PresetBrowser::configureBankColumnForDepth()
+{
+	const bool flattenBank = (numColumns == 2 && getActualFolderDepth() > 2);
+	bankColumn->setFlattenOneLevel(flattenBank);
+	bankColumn->setNewRootDirectory(rootFile);
+}
+
 void PresetBrowser::setNumColumns(int newNumColumns)
 {
 	newNumColumns = jlimit<int>(1, 3, newNumColumns);
@@ -1360,6 +1392,8 @@ void PresetBrowser::setNumColumns(int newNumColumns)
 
 		if (numColumns == 1)
 			rebuildAllPresets();
+		else
+			configureBankColumnForDepth();
 	}
 }
 
@@ -1636,7 +1670,7 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		}
 
 		bankColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 0, this), rootFile);
-		bankColumn->setNewRootDirectory(rootFile);
+		configureBankColumnForDepth();
 		categoryColumn->setModel(new PresetBrowserColumn::ColumnListModel(this, 1, this), rootFile);
 		categoryColumn->setNewRootDirectory(currentCategoryFile);
 
@@ -1656,8 +1690,16 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 			auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
 			pc->setDisplayDirectories(false);
 			presetColumn->setModel(pc, rootFile);
+			presetColumn->setAllowRecursiveFileSearch(true);
 		}
 
+		// In single-column mode the preset column must be pointed at the new
+		// expansion root directly — no bank selection will do it later.
+		if (numColumns == 1)
+			presetColumn->setNewRootDirectory(rootFile);
+
+		// Set the database after the model may have been replaced above so the
+		// active model always has a valid database reference.
 		presetColumn->setDatabase(getDataBase());
 
 		// Update the add button and column visibility for showExpansionContentOnly mode.
@@ -1743,6 +1785,7 @@ void PresetBrowser::renameEntry(int columnIndex, int rowIndex, const String& new
             updateDatabaseKeysForRename(currentBankFile, newBank);
             currentBankFile.moveFileTo(newBank);
 
+            configureBankColumnForDepth();
             categoryColumn->setNewRootDirectory(File());
             presetColumn->setNewRootDirectory(File());
         }
@@ -1811,7 +1854,7 @@ void PresetBrowser::deleteEntry(int columnIndex, const File& f)
 
 		bankToDelete.deleteRecursively();
 
-		bankColumn->setNewRootDirectory(rootFile);
+		configureBankColumnForDepth();
 		categoryColumn->setNewRootDirectory(File());
 		presetColumn->setNewRootDirectory(File());
 	}

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -643,6 +643,10 @@ void PresetBrowser::expansionPackLoaded(Expansion* currentExpansion)
 		selectionChanged(-1, -1, currentExpansion->getRootFolder(), false);
 	else
 		selectionChanged(-1, -1, File(), false);
+
+	// selectionChanged may have returned early (expansion already selected), so
+	// explicitly refresh the add button state in case only the loaded expansion changed.
+	updateExpansionContentOnlyState();
 }
 
 void PresetBrowser::expansionPackCreated(Expansion* newExpansion)
@@ -1286,6 +1290,52 @@ void PresetBrowser::setShowFullPathSearch(bool shouldShowFullPathSearch)
 	fullPathSearch = shouldShowFullPathSearch;
 }
 
+void PresetBrowser::updateExpansionContentOnlyState()
+{
+	if (!expansionContentOnly)
+	{
+		presetColumn->setExpansionAddButtonHidden(false);
+		return;
+	}
+
+	// When no expansions exist (e.g. expansion type is Disabled), the whole
+	// expansionContentOnly restriction is a no-op: keep the preset browser fully
+	// accessible and make sure the search root points at project presets.
+	if (expHandler.getNumExpansions() == 0)
+	{
+		presetColumn->setTotalRoot(rootFile);
+		return;
+	}
+
+	const auto* loadedExpansion = expHandler.getCurrentExpansion();
+	Expansion* selectedExpansion = currentlySelectedExpansion;
+	const bool isLoadedExpansion = (selectedExpansion != nullptr) && (selectedExpansion == loadedExpansion);
+
+	// Only show the add button in the preset column when the selected expansion
+	// is also the currently loaded (active) expansion.
+	presetColumn->setExpansionAddButtonHidden(!isLoadedExpansion);
+
+	// When no expansion is selected, clear the bank/category/preset column contents
+	// so the columns appear empty. Leave the preset column content alone when in
+	// search/favourites mode (showOnlyPresets) so those results are still displayed.
+	if (selectedExpansion == nullptr)
+	{
+		bankColumn->setNewRootDirectory(File());
+		categoryColumn->setNewRootDirectory(File());
+
+		if (!showOnlyPresets)
+			presetColumn->setNewRootDirectory(File());
+
+		presetColumn->setTotalRoot(File());
+	}
+	else
+	{
+		// Sync the search root to the selected expansion so that the search
+		// filter only shows presets from that expansion and not project presets.
+		presetColumn->setTotalRoot(selectedExpansion->getSubDirectory(FileHandlerBase::UserPresets));
+	}
+}
+
 void PresetBrowser::setHighlightColourAndFont(Colour c, Colour bgColour, Font f)
 {
 	auto& lf = getPresetBrowserLookAndFeel();
@@ -1507,6 +1557,9 @@ void PresetBrowser::setOptions(const Options& newOptions)
 	setShowEditButtons(2, newOptions.showRenameButton);
 	setShowEditButtons(3, newOptions.showDeleteButton);
 
+	expansionContentOnly = newOptions.showExpansionContentOnly;
+	updateExpansionContentOnlyState();
+
 	// Override expansion column buttons independently of the other columns.
 	// We hide individual buttons rather than disabling showButtonsAtBottom so that
 	// the 28px button area is still reserved, keeping the column height consistent
@@ -1561,11 +1614,7 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 
 		if (file == File())
 		{
-			if (FullInstrumentExpansion::isEnabled(getMainController()))
-				rootFile = File();
-			else
-				rootFile = defaultRoot;
-
+			rootFile = defaultRoot;
 			currentlySelectedExpansion = nullptr;
 		}
 		else
@@ -1610,6 +1659,10 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		}
 
 		presetColumn->setDatabase(getDataBase());
+
+		// Update the add button and column visibility for showExpansionContentOnly mode.
+		updateExpansionContentOnlyState();
+		resized();
 	}
 
 	if (columnIndex == 0)

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -98,6 +98,7 @@ public:
 		bool fullPathSearch = false;
 		bool showExpansions = false;
 		bool showExpansionEditButtons = false;
+		bool showExpansionContentOnly = false;
 	};
 
 	// ============================================================================================
@@ -189,6 +190,7 @@ public:
 	bool shouldShowFavoritesButton() { return showFavoritesButton; }
 	bool shouldShowFullPathFavorites() { return fullPathFavorites; }
 	bool shouldShowFullPathSearch() { return fullPathSearch; }
+	bool isExpansionContentOnly() const { return expansionContentOnly && expHandler.getNumExpansions() > 0; }
 
 	void lookAndFeelChanged() override;
 
@@ -320,6 +322,7 @@ private:
 	bool fullPathFavorites = false;
 	bool fullPathSearch = false;
 	bool showOnlyPresets = false;
+	bool expansionContentOnly = false;
 	String currentWildcard = "*";
 	StringArray currentTagSelection;
 
@@ -337,6 +340,7 @@ private:
 	File findRootForFile(const File& f) const;
 	void updateDatabaseKeysForRename(const File& oldDirectory, const File& newDirectory);
 	void updateDatabaseKeyForFileRename(const File& oldFile, const File& newFile);
+	void updateExpansionContentOnlyState();
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PresetBrowser);
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -217,6 +217,9 @@ public:
 		static bool matchesAvailableExpansions(MainController* mc, const File& currentPreset);
 		static bool isFavorite(const var& database, const File& presetFile);
 		static Identifier getIdForFile(const File& presetFile);
+		static void renameEntriesInDatabase(const var& database, const File& rootDir,
+		                                    const File& oldDirectory, const File& newDirectory);
+		static void renameFileEntryInDatabase(const var& database, const File& oldFile, const File& newFile);
 	};
 
 	void setOptions(const Options& newOptions);
@@ -237,6 +240,10 @@ public:
 	Point<int> getMouseHoverInformation() const;
 
 	Array<File> getAllSearchRoots() const;
+	Array<File> getAllFavoritePresets();
+	bool isFavoriteInAnyDatabase(const File& presetFile) const;
+	void setFavoriteForFile(const File& presetFile, bool isFavorite);
+	void invalidateFavoritesCache() { favoritesCacheDirty = true; }
 
 	Component* getColumn(int columnIndex)
 	{
@@ -319,6 +326,17 @@ private:
 	WeakReference<Expansion> currentlySelectedExpansion;
 
 	var presetDatabase;
+
+	// Lazily rebuilt cache of favourite files across all roots.
+	mutable Array<File> cachedFavorites;
+	mutable bool favoritesCacheDirty = true;
+
+	void rebuildFavoritesCache() const;
+	var loadDatabaseForRoot(const File& rootDir) const;
+	void saveDatabaseForRoot(const var& db, const File& rootDir);
+	File findRootForFile(const File& f) const;
+	void updateDatabaseKeysForRename(const File& oldDirectory, const File& newDirectory);
+	void updateDatabaseKeyForFileRename(const File& oldFile, const File& newFile);
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PresetBrowser);
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -96,6 +96,7 @@ public:
 		bool showFavoriteIcons = true;
 		bool fullPathFavorites = false;
 		bool showExpansions = false;
+		bool showExpansionEditButtons = false;
 	};
 
 	// ============================================================================================

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -95,6 +95,7 @@ public:
 		bool showFolderButton = true;
 		bool showFavoriteIcons = true;
 		bool fullPathFavorites = false;
+		bool fullPathSearch = false;
 		bool showExpansions = false;
 		bool showExpansionEditButtons = false;
 	};
@@ -187,6 +188,7 @@ public:
 	void updateFavoriteButton();
 	bool shouldShowFavoritesButton() { return showFavoritesButton; }
 	bool shouldShowFullPathFavorites() { return fullPathFavorites; }
+	bool shouldShowFullPathSearch() { return fullPathSearch; }
 
 	void lookAndFeelChanged() override;
 
@@ -234,6 +236,8 @@ public:
 
 	Point<int> getMouseHoverInformation() const;
 
+	Array<File> getAllSearchRoots() const;
+
 	Component* getColumn(int columnIndex)
 	{
 		switch(columnIndex)
@@ -255,6 +259,7 @@ private:
 	void setShowFavorites(bool shouldShowFavorites);
 	void setFavoriteIconOffset(int xOffset);
 	void setShowFullPathFavorites(bool shouldShowFullPathFavorites);
+	void setShowFullPathSearch(bool shouldShowFullPathSearch);
 	void setHighlightColourAndFont(Colour c, Colour bgColour, Font f);
 	void setNumColumns(int numColumns);
 
@@ -306,6 +311,7 @@ private:
 
 	bool showFavoritesButton = true;
 	bool fullPathFavorites = false;
+	bool fullPathSearch = false;
 	bool showOnlyPresets = false;
 	String currentWildcard = "*";
 	StringArray currentTagSelection;

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -272,6 +272,14 @@ private:
 	void setHighlightColourAndFont(Colour c, Colour bgColour, Font f);
 	void setNumColumns(int numColumns);
 
+	/** Returns the actual depth of the folder structure under rootFile.
+	    1 = presets directly in root, 2 = bank/preset, 3 = bank/category/preset. */
+	int getActualFolderDepth() const;
+
+	/** Configures the bank column's display mode based on the actual folder depth
+	    relative to numColumns, and refreshes it with the current rootFile. */
+	void configureBankColumnForDepth();
+
 	/** SaveButton = 1, ShowFolderButton = 0 */
 	void setShowButton(int buttonId, bool newValue);
 	void setShowNotesLabel(bool shouldBeShown);

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -227,30 +227,24 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 {
 	if (wildcard.isEmpty() && currentlyActiveTags.isEmpty())
 	{
-		const File& rootToUse = showFavoritesOnly ? totalRoot : root;
+		if (showFavoritesOnly && index == 2)
+		{
+			entries = parent->getAllFavoritePresets();
+			entries.sort();
+			empty = entries.isEmpty();
+			return entries.size();
+		}
 
-		if (!rootToUse.isDirectory())
+		if (!root.isDirectory())
 		{
 			entries.clear();
 			return 0;
 		}
 
 		entries.clear();
-		rootToUse.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch || showFavoritesOnly);
+		root.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch);
 
 		PresetBrowser::DataBaseHelpers::cleanFileList(parent->getMainController(), entries);
-
-		if (showFavoritesOnly && index == 2)
-		{
-			for (int i = 0; i < entries.size(); i++)
-			{
-				if (!PresetBrowser::DataBaseHelpers::isFavorite(database, entries[i]))
-				{
-					entries.remove(i--);
-					continue;
-				}
-			}
-		}
 
 		entries.sort();
 		empty = entries.isEmpty();
@@ -310,11 +304,8 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		{
 			for (int i = 0; i < entries.size(); i++)
 			{
-				if (!PresetBrowser::DataBaseHelpers::isFavorite(database, entries[i]))
-				{
+				if (!parent->isFavoriteInAnyDatabase(entries[i]))
 					entries.remove(i--);
-					continue;
-				}
 			}
 		}
 
@@ -401,16 +392,14 @@ void PresetBrowserColumn::ColumnListModel::paintListBoxItem(int rowNumber, Graph
 		auto column = parent->getColumn(index);
 		jassert(dynamic_cast<ListBox*>(column)->getModel() == this);
 		
-		if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
-			itemName = entries[rowNumber].getRelativePathFrom(totalRoot);
+		bool showFullPath = (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
+		                 || (!wildcard.isEmpty() && parent.getComponent()->shouldShowFullPathSearch());
 
-		if (!wildcard.isEmpty() && parent.getComponent()->shouldShowFullPathSearch())
+		if (showFullPath)
 		{
 			const auto& f = entries[rowNumber];
 			const auto searchRoots = parent->getAllSearchRoots();
 
-			// Index 0 is the project root; expansions start at index 1 and are
-			// prefixed with their folder name so the user can tell them apart.
 			itemName = f.getRelativePathFrom(totalRoot);
 
 			for (int i = 0; i < searchRoots.size(); ++i)
@@ -442,15 +431,34 @@ const juce::Array<PresetBrowserColumn::ColumnListModel::CachedTag>& PresetBrowse
 
 Component* PresetBrowserColumn::ColumnListModel::refreshComponentForRow(int rowNumber, bool /*isRowSelected*/, Component* existingComponentToUpdate)
 {
+	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton())
+	{
+		// Reuse existing overlays to avoid flicker, but only if the parent
+		// reference is still valid (setModel() may have replaced the model,
+		// leaving stale overlays in JUCE's spare-component cache).
+		if (auto* existing = dynamic_cast<FavoriteOverlay*>(existingComponentToUpdate))
+		{
+			if (&existing->parent == this)
+			{
+				existing->refreshIndex(rowNumber);
+				existing->refreshShape();
+				return existing;
+			}
+
+			delete existing;
+			existingComponentToUpdate = nullptr;
+		}
+
+		if (existingComponentToUpdate != nullptr)
+			delete existingComponentToUpdate;
+
+		return new FavoriteOverlay(*this, rowNumber);
+	}
+
 	if (existingComponentToUpdate != nullptr)
 		delete existingComponentToUpdate;
 
-	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton())
-	{
-		return new FavoriteOverlay(*this, rowNumber);
-	}
-	else
-		return nullptr;
+	return nullptr;
 }
 
 void PresetBrowserColumn::ColumnListModel::sendRowChangeMessage(int row)
@@ -488,7 +496,7 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::refreshShape()
 {
 	auto f = parent.getFileForIndex(index);
 
-	const bool on = PresetBrowser::DataBaseHelpers::isFavorite(parent.database, f);
+	const bool on = parent.isFavoriteInAnyDatabase(f);
 
 	auto path = parent.getPresetBrowserLookAndFeel().createPresetBrowserIcons(on ? "favorite_on" : "favorite_off");
 
@@ -509,14 +517,22 @@ void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::refreshShape()
 }
 
 
+bool PresetBrowserColumn::ColumnListModel::isFavoriteInAnyDatabase(const File& f) const
+{
+	if (auto* pb = parent.getComponent())
+		return pb->isFavoriteInAnyDatabase(f);
+	return false;
+}
+
+
 void PresetBrowserColumn::ColumnListModel::FavoriteOverlay::buttonClicked(Button*)
 {
 	const bool newValue = !b->getToggleState();
 
 	auto f = parent.getFileForIndex(index);
 
-	PresetBrowser::DataBaseHelpers::setFavorite(parent.database, f, newValue);
-
+	if (auto* pb = findParentComponentOfClass<PresetBrowser>())
+		pb->setFavoriteForFile(f, newValue);
 
 	refreshShape();
 
@@ -1005,7 +1021,7 @@ void PresetBrowserColumn::paint(Graphics& g)
 
 	StringArray columnNames = { "Expansion", "Nothing", "Bank", "Column" };
 
-	if (currentRoot == File() && listModel->wildcard.isEmpty() && listModel->currentlyActiveTags.isEmpty())
+	if (currentRoot == File() && listModel->wildcard.isEmpty() && listModel->currentlyActiveTags.isEmpty() && !listModel->getShowFavoritesOnly())
 		emptyText = "Select a " + columnNames[jlimit(0, 3, index+1)];
 	else if (listModel->isEmpty())
 		emptyText = isResultBar ? "No results" : "Add a " + name;

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -260,7 +260,14 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 	{
 		jassert(index == 2);
 		Array<File> allFiles;
-		totalRoot.findChildFiles(allFiles, File::findFiles, true);
+
+		auto searchRoots = parent->getAllSearchRoots();
+
+		if (searchRoots.isEmpty())
+			totalRoot.findChildFiles(allFiles, File::findFiles, true);
+		else
+			for (auto& r : searchRoots)
+				r.findChildFiles(allFiles, File::findFiles, true);
 		entries.clear();
 
 		for (int i = 0; i < allFiles.size(); i++)
@@ -394,9 +401,30 @@ void PresetBrowserColumn::ColumnListModel::paintListBoxItem(int rowNumber, Graph
 		auto column = parent->getColumn(index);
 		jassert(dynamic_cast<ListBox*>(column)->getModel() == this);
 		
-    if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
+		if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
 			itemName = entries[rowNumber].getRelativePathFrom(totalRoot);
-    
+
+		if (!wildcard.isEmpty() && parent.getComponent()->shouldShowFullPathSearch())
+		{
+			const auto& f = entries[rowNumber];
+			const auto searchRoots = parent->getAllSearchRoots();
+
+			// Index 0 is the project root; expansions start at index 1 and are
+			// prefixed with their folder name so the user can tell them apart.
+			itemName = f.getRelativePathFrom(totalRoot);
+
+			for (int i = 0; i < searchRoots.size(); ++i)
+			{
+				if (f.isAChildOf(searchRoots[i]))
+				{
+					auto rel = f.getRelativePathFrom(searchRoots[i]);
+					itemName = (i > 0) ? searchRoots[i].getParentDirectory().getFileName() + File::getSeparatorString() + rel
+					                   : rel;
+					break;
+				}
+			}
+		}
+
 		getPresetBrowserLookAndFeel().drawListItem(g, *column, index, rowNumber, itemName, position, rowIsSelected, deleteOnClick, isMouseHover(rowNumber));
 	}
 }

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -652,11 +652,161 @@ void PresetBrowserColumn::buttonClicked(Button* b)
 	}
 	else if (b == addButton)
 	{
+		if (index == -1)
+		{
+			// Expansion column: install expansion from .hr1 package file
+			FileChooser fc("Select Expansion Package", File(), "*.hr1", true);
+
+			if (fc.browseForFileToOpen())
+			{
+				auto hr1File = fc.getResult();
+				auto& expHandler = mc->getExpansionHandler();
+
+				auto targetFolder = expHandler.getExpansionTargetFolder(hr1File);
+
+				if (targetFolder == File())
+				{
+					PresetHandler::showMessageWindow("Invalid Package", "Could not read the expansion package metadata.", PresetHandler::IconType::Error);
+					return;
+				}
+
+				auto existingExpansion = expHandler.getExpansionFromRootFile(targetFolder);
+
+				File sampleDirectory;
+
+				if (existingExpansion != nullptr)
+				{
+					// Expansion already installed: reuse existing sample location
+					sampleDirectory = existingExpansion->getSubDirectory(FileHandlerBase::Samples);
+				}
+				else
+				{
+					// New expansion: prompt for sample install location
+					FileChooser sampleFc("Select Sample Install Location");
+
+					if (sampleFc.browseForDirectory())
+						sampleDirectory = sampleFc.getResult();
+					else
+						return;
+
+					// Put samples in a subfolder named after the expansion unless the
+					// chosen directory already matches the expansion name (case-insensitive,
+					// treating spaces, underscores, and dashes as equivalent).
+					auto normalize = [](String s) {
+						return s.toLowerCase().replaceCharacters("-_", "  ");
+					};
+
+					auto expansionName = targetFolder.getFileName();
+
+					if (normalize(sampleDirectory.getFileName()) != normalize(expansionName))
+						sampleDirectory = sampleDirectory.getChildFile(expansionName);
+
+					sampleDirectory.createDirectory();
+				}
+
+				expHandler.installFromResourceFile(hr1File, sampleDirectory);
+			}
+			return;
+		}
+
 		parent->openModalAction(PresetBrowser::ModalWindow::Action::Add, index == 2 ? "New Preset" : "New Directory", File(), index, -1);
 	}
 #if !OLD_PRESET_BROWSER
 	else if (b == renameButton)
 	{
+		if (index == -1)
+		{
+			// Expansion column: relocate samples for the selected expansion
+			if (auto ecm = dynamic_cast<ExpansionColumnModel*>(listModel.get()))
+			{
+				int selectedIdx = ecm->lastIndex;
+
+				if (selectedIdx >= 0)
+				{
+					auto rootFolder = ecm->getFileForIndex(selectedIdx);
+
+					if (auto expansion = mc->getExpansionHandler().getExpansionFromRootFile(rootFolder))
+					{
+						auto expName = expansion->getProperty(ExpansionIds::Name);
+						FileChooser fc("Select new sample location for '" + expName + "'");
+
+						if (fc.browseForDirectory())
+						{
+							auto selectedDir = fc.getResult();
+
+							// Validate that the selected folder contains the expected monolith
+							// files for all sample maps in this expansion.
+							//
+							// Ensure the pool is populated before checking.
+							// FullInstrumentExpansion uses lazy loading, so the pool may be
+							// empty if the expansion hasn't been activated yet.
+							expansion->loadSampleMapsIfEmpty();
+
+							StringArray missingSampleMaps;
+
+							auto checkMonolithRef = [&](const ValueTree& v)
+							{
+								MonolithFileReference mref(v);
+
+								if (!mref.isUsingMonolith())
+									return;
+
+								mref.setFileNotFoundBehaviour(MonolithFileReference::FileNotFoundBehaviour::DoNothing);
+								mref.addSampleDirectory(selectedDir);
+
+								if (!mref.getFile(false).existsAsFile())
+									missingSampleMaps.add(mref.referenceString);
+							};
+
+							auto& smPool = expansion->pool->getSampleMapPool();
+							auto sampleMapRefs = smPool.getListOfAllReferences(true);
+
+							if (sampleMapRefs.isEmpty())
+							{
+								// File-based expansion fallback: read XMLs directly from disk.
+								Array<File> sampleMapFiles;
+								expansion->getSubDirectory(FileHandlerBase::SampleMaps)
+								         .findChildFiles(sampleMapFiles, File::findFiles, true, "*.xml");
+
+								for (auto& smFile : sampleMapFiles)
+								{
+									if (auto xml = XmlDocument::parse(smFile))
+										checkMonolithRef(ValueTree::fromXml(*xml));
+								}
+							}
+							else
+							{
+								// Pool-based (HXI): all sample maps are already loaded.
+								for (auto& ref : sampleMapRefs)
+								{
+									auto entry = smPool.loadFromReference(ref, PoolHelpers::LoadingType::DontCreateNewEntry);
+
+									if (entry != nullptr)
+										checkMonolithRef(entry->data);
+								}
+							}
+
+							if (!missingSampleMaps.isEmpty())
+							{
+								PresetHandler::showMessageWindow("Missing Sample Files",
+									"The selected folder is missing sample files for:\n" + missingSampleMaps.joinIntoString("\n"),
+									PresetHandler::IconType::Warning);
+								return;
+							}
+
+							expansion->createLinkFile(FileHandlerBase::Samples, selectedDir);
+							expansion->checkSubDirectories();
+						
+							PresetHandler::showMessageWindow("Sample Folder Relocated",
+								"The sample folder for '" + expName + "' has been successfully relocated to:\n" + selectedDir.getFullPathName(),
+								PresetHandler::IconType::Info);
+						}
+					}
+				}
+			}
+			return;
+		}
+
 		int selectedIndex = listbox->getSelectedRow(0);
 
 		if (selectedIndex >= 0)
@@ -668,6 +818,102 @@ void PresetBrowserColumn::buttonClicked(Button* b)
 	}
 	else if (b == deleteButton)
 	{
+		if (index == -1)
+		{
+			// Expansion column: uninstall the selected expansion and its samples
+			if (auto ecm = dynamic_cast<ExpansionColumnModel*>(listModel.get()))
+			{
+				int selectedIdx = ecm->lastIndex;
+
+				if (selectedIdx >= 0)
+				{
+					auto rootFolder = ecm->getFileForIndex(selectedIdx);
+
+					if (auto expansion = mc->getExpansionHandler().getExpansionFromRootFile(rootFolder))
+					{
+						auto expName = expansion->getProperty(ExpansionIds::Name);
+
+						if (!PresetHandler::showYesNoWindow("Uninstall Expansion",
+							"Are you sure you want to uninstall '" + expName + "' and its samples?"))
+							return;
+
+						bool removePresets = PresetHandler::showYesNoWindow("Remove User Presets",
+							"Do you want to remove your custom presets for '" + expName + "'?\n\nSelect 'No' to keep your presets.");
+
+						// getSubDirectory() returns the already-resolved path (follows link files).
+						// The expansion is still loaded here because unloadExpansion() is called last.
+						auto samplesDir = expansion->getSubDirectory(FileHandlerBase::Samples);
+						bool samplesAreExternal = !samplesDir.isAChildOf(rootFolder);
+
+						// Don't touch the samples folder if it's shared (parent has project_info.xml).
+						bool safeToDeleteSamples = !samplesDir.getParentDirectory()
+						                                       .getChildFile("project_info.xml")
+						                                       .existsAsFile();
+
+						// Deletes all .ch* monolith files from a directory, then removes the
+						// directory itself if empty. Uses .ch* prefix (HISE's monolith format).
+						auto deleteMonolithFiles = [](const File& dir)
+						{
+							if (!dir.isDirectory())
+								return;
+
+							Array<File> files;
+							dir.findChildFiles(files, File::findFiles, false);
+
+							for (auto& f : files)
+								if (f.getFileExtension().startsWith(".ch"))
+									f.deleteFile();
+
+							if (dir.getNumberOfChildFiles(File::findFilesAndDirectories) == 0)
+								dir.deleteFile();
+						};
+
+						if (safeToDeleteSamples && samplesAreExternal)
+							deleteMonolithFiles(samplesDir);
+
+						if (removePresets)
+						{
+							rootFolder.deleteRecursively();
+						}
+						else
+						{
+							Array<File> children;
+							rootFolder.findChildFiles(children, File::findFilesAndDirectories, false);
+
+							for (auto& child : children)
+							{
+								if (child.getFileName() == "UserPresets")
+									continue;
+
+								if (!samplesAreExternal && child.getFileName() == "Samples" && child.isDirectory())
+								{
+									if (safeToDeleteSamples)
+										deleteMonolithFiles(child);
+									continue;
+								}
+
+								if (child.isDirectory())
+									child.deleteRecursively();
+								else
+									child.deleteFile();
+							}
+						}
+
+						mc->getExpansionHandler().unloadExpansion(expansion);
+
+						ecm->setLastIndex(-1);
+						listbox->deselectAllRows();
+						listbox->updateContent();
+						listbox->repaint();
+						updateButtonVisibility(false);
+
+						parent->selectionChanged(-1, -1, File(), false);
+					}
+				}
+			}
+			return;
+		}
+
 		int selectedIndex = listbox->getSelectedRow(0);
 
 		if (selectedIndex >= 0)
@@ -784,7 +1030,10 @@ void PresetBrowserColumn::updateButtonVisibility(bool isReadOnly)
 {
 	editButton->setVisible(false);
 
-	const bool buttonsVisible = showButtonsAtBottom && !isResultBar && currentRoot.isDirectory() && !isReadOnly;
+	// The expansion column (index == -1) doesn't use setNewRootDirectory so currentRoot
+	// is never set; bypass the directory check for it
+	const bool rootOk = (index == -1) || currentRoot.isDirectory();
+	const bool buttonsVisible = showButtonsAtBottom && !isResultBar && rootOk && !isReadOnly;
 	const bool fileIsSelected = listbox->getNumSelectedRows() > 0;
 
 	addButton->setVisible(buttonsVisible && shouldShowAddButton);

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -264,6 +264,19 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 				r.findChildFiles(allFiles, File::findFiles, true);
 		entries.clear();
 
+		// When showExpansionContentOnly is active, remove any files that don't
+		// live under the expansion folder so project-level presets never appear
+		// in search results.
+		if (parent && parent->isExpansionContentOnly())
+		{
+			const File expansionFolder = parent->expHandler.getExpansionFolder();
+			for (int i = allFiles.size() - 1; i >= 0; i--)
+			{
+				if (!allFiles[i].isAChildOf(expansionFolder))
+					allFiles.remove(i);
+			}
+		}
+
 		for (int i = 0; i < allFiles.size(); i++)
 		{
 			const bool matchesWildcard = wildcard.isEmpty() || allFiles[i].getFullPathName().containsIgnoreCase(wildcard);
@@ -1080,7 +1093,7 @@ void PresetBrowserColumn::updateButtonVisibility(bool isReadOnly)
 	const bool buttonsVisible = showButtonsAtBottom && !isResultBar && rootOk && !isReadOnly;
 	const bool fileIsSelected = listbox->getNumSelectedRows() > 0;
 
-	addButton->setVisible(buttonsVisible && shouldShowAddButton);
+	addButton->setVisible(buttonsVisible && shouldShowAddButton && !expansionAddButtonHidden);
 	deleteButton->setVisible(buttonsVisible && fileIsSelected && shouldShowDeleteButton);
 	renameButton->setVisible(buttonsVisible && fileIsSelected && shouldShowRenameButton);
 }

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -242,7 +242,22 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		}
 
 		entries.clear();
-		root.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch);
+
+		if (flattenOneLevel && displayDirectories)
+		{
+			// When the folder structure is deeper than the number of columns, skip
+			// the top level (bank) and collect all second-level directories instead,
+			// so categories are shown directly in the first visible column.
+			Array<File> level1;
+			root.findChildFiles(level1, File::findDirectories, false);
+			PresetBrowser::DataBaseHelpers::cleanFileList(parent->getMainController(), level1);
+			for (auto& l1 : level1)
+				l1.findChildFiles(entries, File::findDirectories, false);
+		}
+		else
+		{
+			root.findChildFiles(entries, displayDirectories ? File::findDirectories : File::findFiles, allowRecursiveSearch);
+		}
 
 		PresetBrowser::DataBaseHelpers::cleanFileList(parent->getMainController(), entries);
 

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -417,20 +417,20 @@ public:
 		return favoriteIconOffset;
 	}
 
+	enum ButtonIndexes
+	{
+		All = 0,
+		AddButton,
+		RenameButton,
+		DeleteButton
+	};
+
 	void setShowButtons(int buttonId, bool shouldBeShown)
 	{
-		enum ButtonIndexes
-		{
-			All = 0,
-			AddButton,
-			RenameButton,
-			DeleteButton
-		};
-		
 		switch (buttonId)
 		{
-			case All: showButtonsAtBottom = shouldBeShown; break;
-			case AddButton: shouldShowAddButton = shouldBeShown; break;
+			case All:         showButtonsAtBottom   = shouldBeShown; break;
+			case AddButton:   shouldShowAddButton   = shouldBeShown; break;
 			case RenameButton: shouldShowRenameButton = shouldBeShown; break;
 			case DeleteButton: shouldShowDeleteButton = shouldBeShown; break;
 		}

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -310,10 +310,14 @@ public:
 			showFavoritesOnly = shouldShowFavoritesOnly;
 		}
 
+		bool getShowFavoritesOnly() const { return showFavoritesOnly; }
+
 		File getFileForIndex(int fileIndex) const
 		{
 			return entries[fileIndex];
 		};
+
+		bool isFavoriteInAnyDatabase(const File& f) const;
 
 		int getIndexForFile(const File& f) const
 		{

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -520,6 +520,13 @@ public:
 		listModel = newModel;
 	}
 
+	void setTotalRoot(const File& newTotalRoot)
+	{
+		listModel->setTotalRoot(newTotalRoot);
+		listbox->updateContent();
+		listbox->repaint();
+	}
+
 	void setDatabase(var db)
 	{
 		listModel->database = db;
@@ -528,6 +535,14 @@ public:
 	void showAddButton()
 	{
 		addButton->setVisible(true && shouldShowAddButton);
+	}
+
+	/** When showExpansionContentOnly is active, hides the add button in the preset
+	    column unless the selected expansion is the currently loaded expansion. */
+	void setExpansionAddButtonHidden(bool hidden)
+	{
+		expansionAddButtonHidden = hidden;
+		updateButtonVisibility(false);
 	}
 
 	Component* getListbox() { return listbox.get(); }
@@ -543,6 +558,7 @@ private:
 	bool shouldShowRenameButton = true;
 	bool shouldShowDeleteButton = true;
 	bool buttonsInsideBorder = false;
+	bool expansionAddButtonHidden = false;
 	int editButtonOffset = 10;
 	int favoriteIconOffset = 0;
 	double rowPadding = 0;

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -256,6 +256,7 @@ public:
 		void setRootDirectory(const File& newRootDirectory) { root = newRootDirectory; }
 		void toggleEditMode() { editMode = !editMode; }
 		void setDisplayDirectories(bool shouldDisplayDirectories) { displayDirectories = shouldDisplayDirectories; }
+		void setFlattenOneLevel(bool shouldFlatten) { flattenOneLevel = shouldFlatten; }
 
 		int getNumRows() override;
 		void listBoxItemClicked(int row, const MouseEvent &) override;
@@ -335,6 +336,7 @@ public:
 		void updateTags(const StringArray& newSelection);
 
 		bool allowRecursiveSearch = false;
+		bool flattenOneLevel = false;
 		bool deleteOnClick = false;
 
 		int getColumnIndex() const { return index; }
@@ -408,6 +410,12 @@ public:
 	void setAllowRecursiveFileSearch(bool shouldAllow)
 	{
 		listModel->allowRecursiveSearch = shouldAllow;
+		listbox->updateContent();
+	}
+
+	void setFlattenOneLevel(bool shouldFlatten)
+	{
+		listModel->setFlattenOneLevel(shouldFlatten);
 		listbox->updateContent();
 	}
 

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -419,6 +419,8 @@ public:
 		listbox->updateContent();
 	}
 
+	bool isFlatteningOneLevel() const { return listModel->flattenOneLevel; }
+
 	void setFavoriteIconOffset(int xOffset)
 	{
 		favoriteIconOffset = xOffset;

--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -1122,6 +1122,7 @@ String ExpansionHandler::getEncryptionKey(const Identifier& expansionName) const
 bool ExpansionHandler::isEnabled() const noexcept
 { return enabled; }
 
+
 Array<Expansion::ExpansionType> ExpansionHandler::getAllowedExpansionTypes() const
 { 
 #if HISE_USE_UNLOCKER_FOR_EXPANSIONS && USE_FRONTEND

--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -482,7 +482,18 @@ bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const F
 			auto expToSend = getExpansionFromRootFile(expRoot);
 			
 			if(expToSend != nullptr)
+			{
 				expToSend->initialise();
+
+				// Force-extract user presets after a fresh install so the preset
+				// browser is populated immediately without requiring a manual rebuild.
+				if (auto se = dynamic_cast<ScriptEncryptedExpansion*>(expToSend))
+				{
+					ValueTree v;
+					if (se->loadValueTree(v).wasOk())
+						se->extractUserPresetsIfEmpty(v, true);
+				}
+			}
 
 			for (auto l : listeners)
 			{
@@ -848,6 +859,12 @@ Result Expansion::initialise()
 	pool->getMidiFilePool().loadAllFilesFromProjectFolder();
 
 	return Result::ok();
+}
+
+void Expansion::loadSampleMapsIfEmpty()
+{
+	if (pool->getSampleMapPool().getNumLoadedFiles() == 0)
+		pool->getSampleMapPool().loadAllFilesFromProjectFolder();
 }
 
 template <class T>

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -99,6 +99,10 @@ public:
 	*/
 	virtual Result initialise();;
 
+	/** Ensures the sample map pool is populated, loading from disk if needed.
+	 *  Call this before iterating the pool for validation purposes. */
+	virtual void loadSampleMapsIfEmpty();
+
 	struct Helpers
 	{
 		static ValueTree loadValueTreeForFileBasedExpansion(const File& root);;

--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -2738,15 +2738,10 @@ void FileHandlerBase::createLinkFileInFolder(const File& source, const File& tar
 	{
         if(linkFile.loadFileAsString() == target.getFullPathName())
             return;
-        
+
 		if (!target.isDirectory())
 		{
 			linkFile.deleteFile();
-			return;
-		}
-
-		if (!PresetHandler::showYesNoWindowIfMessageThread("Already there", "Link redirect file exists. Do you want to replace it?", true))
-		{
 			return;
 		}
 	}

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -2554,6 +2554,37 @@ juce::Result FullInstrumentExpansion::initialise()
 }
 
 
+void FullInstrumentExpansion::loadSampleMapsIfEmpty()
+{
+	// For non-lazy-loaded expansion types just use the base class (reads from disk).
+	if (getExpansionType() != Expansion::Intermediate)
+	{
+		Expansion::loadSampleMapsIfEmpty();
+		return;
+	}
+
+	// FullInstrumentExpansion uses lazy loading: the pool is empty until the
+	// expansion is actually activated.  Populate just the sample maps so that
+	// the redirect-sample validation in the preset browser can check them.
+	if (pool->getSampleMapPool().getNumLoadedFiles() > 0)
+		return;
+
+	// A valid Blowfish key is required to decrypt the embedded pool data.
+	ScopedPointer<BlowFish> bf = createBlowfish();
+
+	if (bf == nullptr)
+		return;
+
+	auto allData = getValueTreeFromFile(getExpansionType());
+
+	if (!allData.isValid())
+		return;
+
+	setCompressorForPool(FileHandlerBase::SampleMaps, true);
+	restorePool(allData, FileHandlerBase::SampleMaps);
+	pool->getSampleMapPool().loadAllFilesFromDataProvider();
+}
+
 juce::ValueTree FullInstrumentExpansion::getValueTreeFromFile(Expansion::ExpansionType type)
 {
 	auto hxiFile = Helpers::getExpansionInfoFile(getRootFolder(), type);

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -424,6 +424,8 @@ public:
 
 	Result initialise() override;
 
+	void loadSampleMapsIfEmpty() override;
+
 	Result encodeExpansion() override;
 
 	ValueTree getEmbeddedNetwork(const String& id) override;


### PR DESCRIPTION
Depends on #914 

When the preset browser is configured for fewer columns than the folder
structure has levels, the browser now adapts intelligently:

- numColumns=2, 3-level structure (bank/category/preset): the bank level
  is ignored and categories are shown in the first column instead, so
  users can browse categories and presets without a bank selection step.

- numColumns=1 with expansion column: selecting an expansion immediately
  populates the preset column with all presets for that expansion, without
  requiring any further column selection.

- Expansion switches restore allowRecursiveSearch on the new preset model
  so presets at any nesting depth remain visible after switching.

Implementation:
- Add `flattenOneLevel` flag to `ColumnListModel`. When set, `getNumRows()`
  collects second-level directories from all first-level subdirs of root
  instead of first-level directories, effectively skipping the bank level.
- Add `getActualFolderDepth()` to `PresetBrowser` to detect whether presets
  live directly under level-1 dirs (depth 2) or deeper (depth 3).
- Add `configureBankColumnForDepth()` which enables `flattenOneLevel` when
  numColumns==2 and the actual depth is 3, then refreshes the column.
- Call `configureBankColumnForDepth()` from the constructor, setNumColumns(),
  selectionChanged() (expansion switches), deleteEntry(), and renameEntry().
- After an expansion switch sets a new preset column model, set the column
  root to rootFile when numColumns==1 so presets appear immediately.

https://claude.ai/code/session_012m7zbrsb4iRaUbFhh3SaLw