### PR TITLE
Set AlertWindow components to non-opaque

### DIFF
--- a/hi_backend/backend/ai_tools/RestServer.cpp
+++ b/hi_backend/backend/ai_tools/RestServer.cpp
@@ -41,6 +41,13 @@
 #undef Rectangle
 #endif
 
+// On Linux, resolv.h (included transitively by httplib.h) defines DELETE as
+// ns_uop_delete (= 0), which collides with the RestServer::Method::DELETE enum
+// value in switch statements. Undefine it here after all system headers are done.
+#ifdef DELETE
+#undef DELETE
+#endif
+
 namespace hise { using namespace juce;
 
 //==============================================================================

--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -544,6 +544,34 @@ void PresetHandler::copyProcessorToClipboard(Processor *p)
 
 void* PresetHandler::currentController = nullptr;
 
+static void applyAlertWindowMargin(AlertWindow* window, LookAndFeel* laf)
+{
+	if (auto alertLaf = dynamic_cast<AlertWindowLookAndFeel*>(laf))
+	{
+		int margin = alertLaf->getAlertWindowMargin();
+
+		if (margin > 0)
+		{
+			// Save current child positions before resize triggers updateLayout
+			struct ChildPos { Component* comp; int x, y; };
+			Array<ChildPos> positions;
+
+			for (int i = 0; i < window->getNumChildComponents(); i++)
+			{
+				auto* child = window->getChildComponent(i);
+				positions.add({ child, child->getX(), child->getY() });
+			}
+
+			window->setSize(window->getWidth() + margin * 2,
+			                window->getHeight() + margin * 2);
+
+			// Restore original positions offset by the margin
+			for (auto& p : positions)
+				p.comp->setTopLeftPosition(p.x + margin, p.y + margin);
+		}
+	}
+}
+
 String PresetHandler::getCustomName(const String &typeName, const String& thisMessage/*=String()*/)
 {
 	String message;
@@ -568,7 +596,7 @@ String PresetHandler::getCustomName(const String &typeName, const String& thisMe
 
     ScopedPointer<AlertWindow> nameWindow = new AlertWindow(useCustomMessage ? ("Enter " + typeName) : ("Enter name for " + typeName), "", AlertWindow::AlertIconType::NoIcon);
 
-
+	nameWindow->setOpaque(false);
 	nameWindow->setLookAndFeel(laf);
 
 	nameWindow->addCustomComponent(comp);
@@ -589,9 +617,11 @@ String PresetHandler::getCustomName(const String &typeName, const String& thisMe
 	nameWindow->getTextEditor("Name")->setSelectAllWhenFocused(true);
 	nameWindow->getTextEditor("Name")->grabKeyboardFocusAsync();
 
+	applyAlertWindowMargin(nameWindow, laf);
+
 	if(nameWindow->runModalLoop()) return nameWindow->getTextEditorContents("Name");
 	else return String();
-    
+
 };
 
 bool PresetHandler::showYesNoWindow(const String &title, const String &message, PresetHandler::IconType type)
@@ -620,14 +650,17 @@ bool PresetHandler::showYesNoWindow(const String &title, const String &message, 
 	
 	ScopedPointer<AlertWindow> nameWindow = new AlertWindow(title, "", AlertWindow::AlertIconType::NoIcon);
 
+	nameWindow->setOpaque(false);
 	nameWindow->setLookAndFeel(laf);
 	nameWindow->addCustomComponent(comp);
-	
+
 	nameWindow->addButton("OK", 1, KeyPress(KeyPress::returnKey));
 	nameWindow->addButton("Cancel", 0, KeyPress(KeyPress::escapeKey));
 
+	applyAlertWindowMargin(nameWindow, laf);
+
 	return (nameWindow->runModalLoop() == 1);
-    
+
 #endif
 };
 
@@ -667,9 +700,12 @@ void PresetHandler::showMessageWindow(const String &title, const String &message
 		ScopedPointer<MessageWithIcon> comp = new MessageWithIcon(type, laf, message);
 		ScopedPointer<AlertWindow> nameWindow = new AlertWindow(title, "", AlertWindow::AlertIconType::NoIcon);
 
+		nameWindow->setOpaque(false);
 		nameWindow->setLookAndFeel(laf);
 		nameWindow->addCustomComponent(comp);
 		nameWindow->addButton("OK", 1, KeyPress(KeyPress::returnKey));
+
+		applyAlertWindowMargin(nameWindow, laf);
 
 		nameWindow->runModalLoop();
 #endif

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4173,7 +4173,12 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawAlertBox(Graphics& g_, Aler
 	{
 		auto obj = new DynamicObject();
 
-		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, w.getLocalBounds().toFloat()));
+		auto fullArea = w.getLocalBounds().toFloat();
+		auto margin = (float)getAlertWindowMargin();
+		auto contentArea = fullArea.reduced(margin);
+
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, contentArea));
+		obj->setProperty("bounds", ApiHelpers::getVarRectangle(useRectangleClass, fullArea));
 		obj->setProperty("title", w.getName());
 
 		addParentFloatingTile(w, obj);
@@ -4183,6 +4188,14 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawAlertBox(Graphics& g_, Aler
 	}
 
 	GlobalHiseLookAndFeel::drawAlertBox(g_, w, ta, tl);
+}
+
+int ScriptingObjects::ScriptedLookAndFeel::Laf::getAlertWindowMargin()
+{
+	if (functionDefined("drawAlertWindow"))
+		return 50;
+
+	return 0;
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::getIdealPopupMenuItemSize(const String &text, bool isSeparator, int standardMenuItemHeight, int &idealWidth, int &idealHeight)

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -847,6 +847,8 @@ namespace ScriptingObjects
 
 			void drawAlertBox(Graphics&, AlertWindow&, const Rectangle<int>& textArea, TextLayout&) override;
 
+			int getAlertWindowMargin() override;
+
 			Font getAlertWindowMessageFont() override;
 			Font getAlertWindowTitleFont() override;
 			Font getTextButtonFont(TextButton &, int) override;

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -513,6 +513,9 @@ public:
 
 	void drawAlertBox (Graphics &g, AlertWindow &alert, const Rectangle< int > &textArea, juce::TextLayout &textLayout) override;;
 
+	/** Override this to add extra margin around the alert window for custom drop shadows. */
+	virtual int getAlertWindowMargin() { return 0; }
+
 	Colour dark, bright, special;
 };
 


### PR DESCRIPTION
Depends on #902 

Set AlertWindow components to non-opaque so that scripted look and feel
overrides of drawAlertWindow can draw rounded windows with transparent
corners. The default drawAlertBox still fills the entire area, so
non-customized alert windows are visually unchanged.

When drawAlertWindow is defined, the alert window is automatically
expanded by 50px for drawing custom drop shadows. Child components
remain at their original positions, offset inward by the margin.

obj.area is the content area (backwards compatible with existing
scripts),
obj.bounds is the full window bounds including margin for shadow
drawing.