### PR TITLE
Fix popup menu width changing when getIdealPopupMenuItemSize returns …

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4207,6 +4207,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::getIdealPopupMenuItemSize(const
         }
         if(nObj.isInt() || nObj.isInt64() || nObj.isDouble())
         {
+            GlobalHiseLookAndFeel::getIdealPopupMenuItemSize(text, isSeparator, standardMenuItemHeight, idealWidth, idealHeight);
             idealHeight = (int)nObj;
             return;
         }


### PR DESCRIPTION
…height only

When the scripted LookAndFeel callback returns a single integer (height only), the idealWidth reference was left at its uninitialised value (0) because the fallback to GlobalHiseLookAndFeel was never reached. Now we call the fallback first to populate the default width, then override just the height with the script's return value.

https://claude.ai/code/session_01D4BkLLEzEgrYWac68fT8UE