### PR TITLE
Fix tempo sync time stretch

### DIFF
--- a/hi_core/hi_sampler/sampler/ModulatorSampler.cpp
+++ b/hi_core/hi_sampler/sampler/ModulatorSampler.cpp
@@ -1381,8 +1381,8 @@ void ModulatorSampler::preStartVoice(int voiceIndex, const HiseEvent& e)
 			if(auto nextSound = dynamic_cast<ModulatorSamplerSound*>(soundsToBeStarted[0]))
 			{
                 auto nq = nextSound->getNumQuartersForTimestretch(currentTimestretchOptions.numQuarters);
-                
-				syncer.setSource(nextSound->getSampleRate(), nextSound->getReferenceToSound(0)->getSampleLength(), nq);
+
+				syncer.setSource(nextSound->getSampleRate(), nextSound->getReferenceToSound(0)->getSampleLength(), nq, currentTimestretchOptions.sourceBpm);
 			}
 				
 			v->setTimestretchRatio(getCurrentTimestretchRatio());

--- a/hi_core/hi_sampler/sampler/ModulatorSampler.h
+++ b/hi_core/hi_sampler/sampler/ModulatorSampler.h
@@ -276,6 +276,7 @@ public:
 		double tonality = 0.0;
 		bool synchronousSkip = false;
 		double numQuarters = 0.0;
+		double sourceBpm = 0.0;
 		Identifier engineId;
 
 		void reset()
@@ -284,6 +285,7 @@ public:
 			tonality = 0.0;
 			synchronousSkip = false;
 			numQuarters = 0.0;
+			sourceBpm = 0.0;
 			engineId = {};
 		}
 
@@ -296,6 +298,7 @@ public:
 			obj->setProperty("SkipLatency", synchronousSkip);
 			obj->setProperty("Mode", modes[static_cast<int>(mode)]);
 			obj->setProperty("NumQuarters", numQuarters);
+			obj->setProperty("SourceBPM", sourceBpm);
 			obj->setProperty("PreferredEngine", engineId.toString());
 
 			return {obj.get()};
@@ -309,6 +312,7 @@ public:
 			synchronousSkip = json.getProperty("SkipLatency", false);
 			mode = static_cast<TimestretchMode>(modes.indexOf(json.getProperty("Mode", "Disabled").toString()));
 			numQuarters = json.getProperty("NumQuarters", 0.0);
+			sourceBpm = jmax(0.0, static_cast<double>(json.getProperty("SourceBPM", 0.0)));
 
 			auto id = json.getProperty("PreferredEngine", "").toString();
 

--- a/hi_dsp_library/dsp_nodes/StretchNode.h
+++ b/hi_dsp_library/dsp_nodes/StretchNode.h
@@ -89,11 +89,15 @@ template <int NV> struct stretch_player: public data::base,
             return false;
         }
 
-        void setSource(double sourceSamplerate, int numSourceSamples, double numQuarters = 0.0)
+        void setSource(double sourceSamplerate, int numSourceSamples, double numQuarters = 0.0, double sourceBpm = 0.0)
         {
             const auto numSeconds = static_cast<double>(numSourceSamples) / sourceSamplerate;
 
-            if (numQuarters == 0.0)
+            if (sourceBpm != 0.0)
+            {
+                numQuarters = numSeconds * (sourceBpm / 60.0);
+            }
+            else if (numQuarters == 0.0)
             {
                 // Try to guess the duration by picking the nearest numQuarters that matches a bar
                 const auto durationPerQuarterForCurrentBpm = 60.0 / bpm;

--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
@@ -674,12 +674,14 @@ void StreamingSamplerVoice::startNote(int /*midiNoteNumber*/,
 
 void StreamingSamplerVoice::skipTimestretchSilenceAtStart()
 {
-	auto numBeforeOutput = stretcher.getLatency(stretchRatio);
+	// Use roundToInt to match skipLatency's rounding — mismatched rounding causes a
+	// one-sample buffer overread into uninitialised memory at certain stretch ratios.
+	auto numBeforeOutput = roundToInt(stretcher.getLatency(stretchRatio));
 
 	StereoChannelData data = loader.fillVoiceBuffer(*getTemporaryVoiceBuffer(), numBeforeOutput);
 
-	auto outL = (float*)alloca(sizeof(float*) * numBeforeOutput);
-	auto outR = (float*)alloca(sizeof(float*) * numBeforeOutput);
+	auto outL = (float*)alloca(sizeof(float) * numBeforeOutput);
+	auto outR = (float*)alloca(sizeof(float) * numBeforeOutput);
 
 	interpolateFromStereoData(0, outL, outR, numBeforeOutput, nullptr, 1.0, 0.0, data, numBeforeOutput);
 


### PR DESCRIPTION
Add SourceBPM to timestretch options and fix skipLatency click

SourceBPM parameter (ModulatorSampler.h, ModulatorSampler.cpp, StretchNode.h)

Adds a SourceBPM field to TimestretchOptions as a more intuitive alternative to NumQuarters when using timestretching. Previously, users had to calculate NumQuarters manually (e.g. a 4-bar loop at 140 BPM = 16 quarters). With SourceBPM, you simply supply the BPM the sample was recorded at and HISE derives the correct stretch ratio automatically.

NumQuarters and the auto-guess fallback continue to work unchanged. SourceBPM takes precedence when non-zero.

Serialised as "SourceBPM" in the timestretch options JSON.

Fix pop/click at certain BPM values when SkipLatency is true (StreamingSamplerVoice.cpp)

skipTimestretchSilenceAtStart was computing the input buffer size using the raw double returned by getLatency(), while skipLatency internally uses roundToInt() on the same value. At BPM ratios where the latency has a fractional part greater than 0.5 (e.g. 60 or 71 BPM against a 140 BPM source), skipLatency would read one sample beyond the end of the prepared buffer into uninitialised stack memory. That value was fed through the timestretcher engine and produced as an audible click at the start of playback.

Fixed by using roundToInt consistently in skipTimestretchSilenceAtStart to match skipLatency. Also corrects sizeof(float*) → sizeof(float) in the alloca calls; the pointer-sized over-allocation on 64-bit systems was coincidentally preventing a crash by giving the overread somewhere to land, but the uninitialised content was exactly what caused the click.