### PR TITLE
Add addNoiseFromPath look and feel function

### DIFF
--- a/hi_scripting/scripting/api/ScriptDrawActions.cpp
+++ b/hi_scripting/scripting/api/ScriptDrawActions.cpp
@@ -103,6 +103,46 @@ struct ScriptedPostDrawActions
 		const bool monochrom;
 	};
 
+	struct addNoiseFromPath : public DrawActions::ActionBase
+	{
+		addNoiseFromPath(DrawActions::NoiseMapManager* manager, const Path& p_, Rectangle<float> a,
+		                 float v, bool monochrom_=false, float scale_=1.0f) :
+			m(manager),
+			noise(v),
+			scale(scale_),
+			monochrom(monochrom_),
+			p(p_)
+		{
+			if (!p.getBounds().isEmpty())
+			{
+				p.scaleToFit(a.getX(), a.getY(), a.getWidth(), a.getHeight(), false);
+				area = p.getBounds().toNearestIntEdges();
+			}
+		}
+
+		SET_ACTION_ID(addNoiseFromPath);
+
+		void perform(Graphics& g) override
+		{
+			if (area.isEmpty())
+				return;
+
+			Graphics::ScopedSaveState state(g);
+			g.reduceClipRegion(p);
+			m->drawNoiseMap(g, area, noise, monochrom, scale);
+		}
+
+		bool wantsCachedImage() const override { return false; }
+		bool wantsToDrawOnParent() const override { return false; }
+
+		DrawActions::NoiseMapManager* m;
+		Path p;
+		Rectangle<int> area;
+		const float noise;
+		const float scale;
+		const bool monochrom;
+	};
+
 	struct applyHSL : public DrawActions::PostActionBase
 	{
 		applyHSL(float hue, float sat, float light) :

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -1642,6 +1642,7 @@ struct ScriptingObjects::GraphicsObject::Wrapper
 	API_VOID_METHOD_WRAPPER_1(GraphicsObject, boxBlur);
 	API_VOID_METHOD_WRAPPER_0(GraphicsObject, desaturate);
 	API_VOID_METHOD_WRAPPER_1(GraphicsObject, addNoise);
+	API_VOID_METHOD_WRAPPER_3(GraphicsObject, addNoiseFromPath);
 	API_VOID_METHOD_WRAPPER_3(GraphicsObject, applyMask);
 	API_VOID_METHOD_WRAPPER_1(GraphicsObject, beginLayer);
 	API_VOID_METHOD_WRAPPER_0(GraphicsObject, endLayer);
@@ -1772,6 +1773,7 @@ ScriptingObjects::GraphicsObject::GraphicsObject(ProcessorWithScriptingContent *
 	ADD_API_METHOD_1(boxBlur);
 	ADD_API_METHOD_0(desaturate);
 	ADD_API_METHOD_1(addNoise);
+	ADD_API_METHOD_3(addNoiseFromPath);
 	ADD_API_METHOD_3(applyMask);
     ADD_API_METHOD_2(flip);
 
@@ -1933,6 +1935,37 @@ void ScriptingObjects::GraphicsObject::addNoise(var noiseAmount)
 			auto scale = jlimit(0.125, 2.0, (double)sf);
 
 			drawActionHandler.addDrawAction(new ScriptedPostDrawActions::addNoise(m, jlimit(0.0f, 1.0f, (float)alpha), ar, monochrom, scale));
+		}
+	}
+}
+
+void ScriptingObjects::GraphicsObject::addNoiseFromPath(var path, var area, var noiseAmount)
+{
+	auto m = drawActionHandler.getNoiseMapManager();
+	auto r = getRectangleFromVar(area);
+
+	if (auto p = dynamic_cast<ScriptingObjects::PathObject*>(path.getObject()))
+	{
+		Path sp = p->getPath();
+
+		if (noiseAmount.isDouble())
+		{
+			drawActionHandler.addDrawAction(new ScriptedPostDrawActions::addNoiseFromPath(
+				m, sp, r, jlimit(0.0f, 1.0f, (float)noiseAmount)));
+		}
+		else if (auto obj = noiseAmount.getDynamicObject())
+		{
+			auto alpha = jlimit(0.0f, 1.0f, (float)noiseAmount["alpha"]);
+			auto monochrom = (bool)noiseAmount["monochromatic"];
+			auto sf = (float)noiseAmount.getProperty("scaleFactor", 1.0);
+
+			if (sf == -1.0f)
+				sf = drawActionHandler.getScaleFactor();
+
+			auto scale = jlimit(0.125, 2.0, (double)sf);
+
+			drawActionHandler.addDrawAction(new ScriptedPostDrawActions::addNoiseFromPath(
+				m, sp, r, alpha, monochrom, (float)scale));
 		}
 	}
 }

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -626,6 +626,9 @@ namespace ScriptingObjects
 		/** Adds noise to the current layer. */
 		void addNoise(var noiseAmount);
 
+		/** Adds noise clipped to the given path. noiseAmount can be a float (0..1) or an object with alpha, monochromatic and scaleFactor properties. */
+		void addNoiseFromPath(var path, var area, var noiseAmount);
+
 		/** Removes all colour from the current layer. */
 		void desaturate();
 


### PR DESCRIPTION
Adds a new graphics API method g.addNoiseFromPath(path, area, noiseAmount) that draws noise clipped to a path shape, analogous to how drawDropShadowFromPath extends drawDropShadow to path-shaped regions.

noiseAmount accepts the same float or object form as addNoise (alpha, monochromatic, scaleFactor properties).

https://claude.ai/code/session_01V9Fo6L1Mj1Xpvunr4V4uwW