### PR TITLE
fix onControl not firing for child panels after changed() call

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -1172,7 +1172,12 @@ void ScriptingApi::Content::ScriptComponent::AsyncControlCallbackSender::handleA
 			if(cachedParameterIndex == -1)
 				cachedParameterIndex = p->getScriptingContent()->getComponentIndex(parent);
 
-			dynamic_cast<Processor*>(p)->setAttribute(cachedParameterIndex, value, dispatch::sendNotificationSync);
+			// Child panels (addChildPanel) are not in the content component list so the index
+			// will be -1. Fall back to a direct controlCallback call for those.
+			if(cachedParameterIndex != -1)
+				dynamic_cast<Processor*>(p)->setAttribute(cachedParameterIndex, value, dispatch::sendNotificationSync);
+			else
+				p->controlCallback(parent, v);
 		}
 		else
 		{


### PR DESCRIPTION
AsyncControlCallbackSender::handleAsyncUpdate routes numeric values through setAttribute -> setControlValue -> controlCallback. Child panels created with addChildPanel() are not registered in the scripting content component list, so getComponentIndex returns -1 and setAttribute(-1, ...) silently does nothing. Fall back to a direct controlCallback call when the component index is -1, restoring the pre-a21e2d5b behavior for child panels.

https://claude.ai/code/session_01MXsskeq5RcSHC9mHEv3L6m