### PR TITLE
Fix ScriptLabel text vertical alignment during editing

### DIFF
--- a/hi_core/hi_core/MiscComponents.cpp
+++ b/hi_core/hi_core/MiscComponents.cpp
@@ -1273,6 +1273,20 @@ TextEditor * MultilineLabel::createEditorComponent()
 
 	textEditor->setJustification(alignmentForLabelAndEditor);
 
+	if (!multiline)
+	{
+		auto fontHeight = (int)getFont().getHeight();
+		auto slack = jmax(0, getHeight() - fontHeight);
+		int topIndent = 0;
+
+		if (alignmentForLabelAndEditor.testFlags(Justification::verticallyCentred))
+			topIndent = slack / 2;
+		else if (alignmentForLabelAndEditor.testFlags(Justification::bottom))
+			topIndent = slack;
+
+		textEditor->setIndents(0, topIndent);
+	}
+
 	if(auto root = simple_css::CSSRootComponent::find(*this))
 		root->stateWatcher.registerComponentToUpdate(textEditor);
 


### PR DESCRIPTION
MultilineLabel::createEditorComponent was not setting the TextEditor's topIndent, causing text to appear misaligned in single-line mode. topIndent is now derived from the vertical component of the label's alignment property: 0 for top, (height - fontHeight) / 2 for centred, and (height - fontHeight) for bottom. Horizontal alignment continues to be handled by setJustification.

https://claude.ai/code/session_01Ya2gpX3FGJtVRbiF4P3GzS

