### PR TITLE
Add cancelInstallation to expansion handler

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -412,15 +412,19 @@ bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const F
 
 	if (expRoot != File())
 	{
+		installationCancelled = false;
+
 		auto f = [this, expRoot, resourceFile, sampleDirectoryToUse](Processor* p)
 		{
 			jassert(LockHelpers::freeToGo(getMainController()));
+
+			bool expRootExistedBefore = expRoot.isDirectory();
 
 			expRoot.createDirectory();
 			auto samplesDir = expRoot.getChildFile("Samples");
 			samplesDir.createDirectory();
 
-			if (sampleDirectoryToUse != getExpansionFolder() && 
+			if (sampleDirectoryToUse != getExpansionFolder() &&
 				sampleDirectoryToUse != getMainController()->getCurrentFileHandler().getSubDirectory(FileHandlerBase::Samples))
 				FileHandlerBase::createLinkFileInFolder(samplesDir, sampleDirectoryToUse);
 			else
@@ -455,9 +459,38 @@ bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const F
 
 			hlac::HlacArchiver a(currentThread);
 			a.setListener(this);
-			auto ok = a.extractSampleData(data);
+			a.setCancelCheck([this]() { return installationCancelled.load(); });
+			a.extractSampleData(data);
 
-			ignoreUnused(ok);
+			if (installationCancelled.load())
+			{
+				// Only remove the expansion root if this installation created it.
+				// If it already existed the user may have custom presets or other
+				// files there that must be preserved across update installs.
+				if (!expRootExistedBefore)
+					expRoot.deleteRecursively();
+
+				// header.dat is always written by the archiver to the samples
+				// directory first. On a cancelled update it may be partially
+				// overwritten and is no longer valid, so remove it.
+				sampleDirectoryToUse.getChildFile("header.dat").deleteFile();
+
+				// TmpFlac files are intermediate files the archiver normally
+				// cleans up itself; one may be left behind on cancellation.
+				Array<File> tmpFlacFiles;
+				sampleDirectoryToUse.findChildFiles(tmpFlacFiles, File::findFiles, false, "TmpFlac*.flac");
+
+				for (auto& tf : tmpFlacFiles)
+					tf.deleteFile();
+
+				for (auto l : listeners)
+				{
+					if (l.get() != nullptr)
+						l->expansionInstalled(nullptr);
+				}
+
+				return SafeFunctionCall::OK;
+			}
 
 			auto headerFile = samplesDir.getChildFile("header.dat");
 			jassert(headerFile.existsAsFile());
@@ -480,7 +513,7 @@ bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const F
 			forceReinitialisation();
 
 			auto expToSend = getExpansionFromRootFile(expRoot);
-			
+
 			if(expToSend != nullptr)
 				expToSend->initialise();
 
@@ -499,6 +532,16 @@ bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const F
 	}
 
 	return false;
+}
+
+void ExpansionHandler::cancelInstallation()
+{
+	installationCancelled = true;
+}
+
+bool ExpansionHandler::isInstallationCancelled() const noexcept
+{
+	return installationCancelled.load();
 }
 
 juce::File ExpansionHandler::getExpansionTargetFolder(const File& resourceFile)

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -322,6 +322,10 @@ public:
 
 	bool installFromResourceFile(const File& f, const File& sampleDirectoryToUse);
 
+	void cancelInstallation();
+
+	bool isInstallationCancelled() const noexcept;
+
 	File getExpansionTargetFolder(const File& resourceFile);
 
 	PooledAudioFile loadAudioFileReference(const PoolReference& sampleId);
@@ -440,6 +444,7 @@ private:
 	var credentials;
 	bool installFullDynamics = false;
 	double totalProgress = 0.0;
+	std::atomic<bool> installationCancelled { false };
 
 	void checkAllowedExpansions(Result& r, Expansion* e);
 

--- a/hi_lac/hlac/CompressionHelpers.cpp
+++ b/hi_lac/hlac/CompressionHelpers.cpp
@@ -1276,7 +1276,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 		auto archiveTime = Time::fromISO8601(fis->readString());
 		CHECK_FLAG(Flag::EndTime);
 
-		if (thread->threadShouldExit())
+		if (shouldAbort())
 			return false;
 
 		
@@ -1305,7 +1305,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 				
 		}
 
-		if (thread->threadShouldExit())
+		if (shouldAbort())
 			return false;
 		
 		if (overwriteThisFile || data.debugLogMode)
@@ -1358,7 +1358,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 				currentFlag = readFlag(fis);
 			}
 
-			if (thread->threadShouldExit())
+			if (shouldAbort())
 				return false;
 
 			jassert(currentFlag == Flag::EndMonolith);
@@ -1397,7 +1397,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			hlac::HlacEncoder::CompressorOptions options = hlac::HlacEncoder::CompressorOptions::getPreset(hlac::HlacEncoder::CompressorOptions::Presets::Diff);
 
-			if (thread->threadShouldExit())
+			if (shouldAbort())
 				return false;
 
 			options.applyDithering = false;
@@ -1416,7 +1416,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 
 			for (int64 readerOffset = 0; readerOffset < flacReader->lengthInSamples; readerOffset += bufferSize)
 			{
-				if (thread->threadShouldExit())
+				if (shouldAbort())
 					return false;
 
 				const int numToRead = jmin<int>(bufferSize, (int)(flacReader->lengthInSamples - readerOffset));
@@ -1447,7 +1447,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 					return false;
 				}
 
-				if (thread->threadShouldExit())
+				if (shouldAbort())
 					return false;
 
 				writer = nullptr;
@@ -1480,7 +1480,7 @@ bool HlacArchiver::extractSampleData(const DecompressData& data)
 				bytesToSkip = fis->readInt64();
 				CHECK_FLAG(Flag::EndMonolithLength);
 
-				if (thread->threadShouldExit())
+				if (shouldAbort())
 					return false;
 
 				CHECK_FLAG(Flag::ResumeMonolith);
@@ -1527,7 +1527,7 @@ FileInputStream* HlacArchiver::writeTempFile(AudioFormatReader* reader, int bitD
 	for (int offsetInReader = 0; offsetInReader < reader->lengthInSamples; offsetInReader += bufferSize)
 	{
 
-		if (thread->threadShouldExit())
+		if (shouldAbort())
 		{
 			tempOutput->flush();
 			writer = nullptr;
@@ -1633,7 +1633,7 @@ void HlacArchiver::compressSampleData(const CompressData& data)
 		{
 			for (int i = 0; i < hlacFiles.size(); i++)
 			{
-				if (thread->threadShouldExit())
+				if (shouldAbort())
 					return;
 
 				*data.totalProgress = ((double)i / (double)hlacFiles.size());

--- a/hi_lac/hlac/CompressionHelpers.h
+++ b/hi_lac/hlac/CompressionHelpers.h
@@ -452,7 +452,21 @@ struct HlacArchiver
 		listener = l;
 	}
 
+	void setCancelCheck(std::function<bool()> f)
+	{
+		cancelCheck = std::move(f);
+	}
+
 private:
+
+	bool shouldAbort() const
+	{
+		if (thread != nullptr && thread->threadShouldExit())
+			return true;
+		if (cancelCheck && cancelCheck())
+			return true;
+		return false;
+	}
 
 	FileInputStream* writeTempFile(AudioFormatReader* reader, int bitDepth=16);
 
@@ -473,8 +487,9 @@ private:
 	bool decompressMode = false;
 
 	Thread* thread = nullptr;
-	
-	
+
+	mutable std::function<bool()> cancelCheck;
+
 	File tmpFile;
 
 	double deltaPerFile = 0.1;

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -1137,6 +1137,7 @@ struct ScriptExpansionHandler::Wrapper
 	API_METHOD_WRAPPER_2(ScriptExpansionHandler, installExpansionFromPackage);
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getExpansionForInstallPackage);
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getMetaDataFromPackage);
+	API_VOID_METHOD_WRAPPER_0(ScriptExpansionHandler, cancelInstallation);
 };
 
 ScriptExpansionHandler::ScriptExpansionHandler(JavascriptProcessor* jp_) :
@@ -1169,8 +1170,9 @@ ScriptExpansionHandler::ScriptExpansionHandler(JavascriptProcessor* jp_) :
 	ADD_CALLBACK_DIAGNOSTIC(installCallback, setInstallCallback, 0);
 	ADD_API_METHOD_1(getMetaDataFromPackage);
 	ADD_API_METHOD_1(getExpansionForInstallPackage);
+	ADD_API_METHOD_0(cancelInstallation);
 
-	
+
 
 	addConstant(Expansion::Helpers::getExpansionTypeName(Expansion::FileBased), Expansion::FileBased);
 	addConstant(Expansion::Helpers::getExpansionTypeName(Expansion::Intermediate), Expansion::Intermediate);
@@ -1395,6 +1397,11 @@ var ScriptExpansionHandler::getExpansionForInstallPackage(var packageFile)
 	RETURN_IF_NO_THROW(var());
 }
 
+void ScriptExpansionHandler::cancelInstallation()
+{
+	getMainController()->getExpansionHandler().cancelInstallation();
+}
+
 void ScriptExpansionHandler::setAllowedExpansionTypes(var typeList)
 {
 	Array<Expansion::ExpansionType> l;
@@ -1485,9 +1492,11 @@ void ScriptExpansionHandler::InstallState::expansionInstalled(Expansion* newExpa
 	SimpleReadWriteLock::ScopedWriteLock sl(timerLock);
 
 	stopTimer();
-	status = 2;
 
-	if (newExpansion != nullptr && newExpansion->getRootFolder() == targetFolder)
+	bool wasCancelled = parent.getMainController()->getExpansionHandler().isInstallationCancelled();
+	status = wasCancelled ? 3 : 2;
+
+	if (!wasCancelled && newExpansion != nullptr && newExpansion->getRootFolder() == targetFolder)
 		createdExpansion = newExpansion;
 
 	call();

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -267,6 +267,9 @@ public:
 	/** Sets a list of allowed expansion types that can be loaded. */
 	void setAllowedExpansionTypes(var typeList);
 
+	/** Cancels a running installExpansionFromPackage call. The install callback will fire with Status 3. */
+	void cancelInstallation();
+
 	// ============================================================== End of API calls
 
 	bool isUsingCredentials() const


### PR DESCRIPTION
Adds getExpansionHandler.cancelInstallation() to abort a running installExpansionFromPackage call. The install callback fires with Status 3 on cancellation.

On cancellation the following cleanup is performed:
- The expansion root directory is removed only if this installation created it. If it already existed (update scenario) it is left untouched to preserve any custom presets or data files.
- header.dat is deleted from the samples directory. On a cancelled update it will have been partially overwritten and is no longer valid.
- Any TmpFlac*.flac intermediates left behind by the archiver are removed.
- Partially extracted monolith files are left in place; the archiver uses ForceOverwrite so they will be replaced on a retry - not sure if there's a better way to handle this, maybe extract to a temp location first before overwriting existing files, then we could do a proper cleanup?

The cancellation flag is scoped to the install action: it is reset at the start of each install and checked inside HlacArchiver via a new setCancelCheck hook (shouldAbort()). Post-processing is skipped if the flag is set when extraction returns.

https://claude.ai/code/session_015n78EQy5QCx9KD4KZPXdeQ