### PR TITLE
Fix crash when release trigger fires on purged sampler mic position

### DIFF
--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
@@ -364,7 +364,13 @@ bool SampleLoader::advanceReadIndex(double uptime)
 		}
 		else
 		{
-			readBuffer = sound.get()->getReleaseStartBuffer();
+			auto rsb = sound.get()->getReleaseStartBuffer();
+
+			// Sound may have been purged while release start was pending
+			if(rsb == nullptr)
+				return false;
+
+			readBuffer = rsb;
 			writeBuffer = &b1;
 
 			lastSwapPosition = sound.get()->getReleaseStart() - sound.get()->getSampleStart();
@@ -1072,33 +1078,35 @@ void StreamingSamplerVoice::renderNextBlock(AudioSampleBuffer &outputBuffer, int
 
 			auto rb = sound->getReleaseStartBuffer();
 
-			auto offsetInBuffer = releaseFadeDuration - releaseFadeCounter;
-
-
-			auto numToCopy = jmin(rb->getNumSamples() - offsetInBuffer - numToFadeIn, numToFadeIn);
-
-			if(releaseGain != 1.0f)
+			if(rb != nullptr)
 			{
-				hlac::HiseSampleBuffer::addWithGain(*tempVoiceBuffer, *rb, 0, offsetInBuffer, numToCopy, releaseGain);
-				applyReleaseGainToFullBuffer = false;
-			}
-			else
-			{
-				hlac::HiseSampleBuffer::add(*tempVoiceBuffer, *rb, 0, offsetInBuffer, numToCopy);
-			}
+				auto offsetInBuffer = releaseFadeDuration - releaseFadeCounter;
 
-			releaseFadeCounter -= (pitchCounter + startAlpha);
+				auto numToCopy = jmin(rb->getNumSamples() - offsetInBuffer - numToFadeIn, numToFadeIn);
 
-			if(releaseFadeCounter <= 0.0)
-			{
-				voiceUptime = (double)(sound->getReleaseStart() - sound->getSampleStart());
+				if(releaseGain != 1.0f)
+				{
+					hlac::HiseSampleBuffer::addWithGain(*tempVoiceBuffer, *rb, 0, offsetInBuffer, numToCopy, releaseGain);
+					applyReleaseGainToFullBuffer = false;
+				}
+				else
+				{
+					hlac::HiseSampleBuffer::add(*tempVoiceBuffer, *rb, 0, offsetInBuffer, numToCopy);
+				}
 
-				voiceUptime += releaseFadeDuration;
-				voiceUptime += (-1) * releaseFadeCounter;
-				voiceUptime -= pitchCounter;
-				
-				releaseFadeCounter = 0.0;
-				loader.setSeekToReleaseStart();
+				releaseFadeCounter -= (pitchCounter + startAlpha);
+
+				if(releaseFadeCounter <= 0.0)
+				{
+					voiceUptime = (double)(sound->getReleaseStart() - sound->getSampleStart());
+
+					voiceUptime += releaseFadeDuration;
+					voiceUptime += (-1) * releaseFadeCounter;
+					voiceUptime -= pitchCounter;
+
+					releaseFadeCounter = 0.0;
+					loader.setSeekToReleaseStart();
+				}
 			}
 		}
 #endif

--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.h
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.h
@@ -366,6 +366,15 @@ public:
 	bool jumpToRelease()
 	{
 		auto s = getLoadedSound();
+
+		// Voice was never started for this mic position (e.g. channel is purged)
+		if(s == nullptr)
+			return false;
+
+		// Release start buffer is absent (sound purged after start, or not configured)
+		if(s->getReleaseStartBuffer() == nullptr)
+			return false;
+
 		auto startOffset = s->getReleaseStart() - s->getSampleStart();
 		auto loopStart = s->getLoopStart() - s->getSampleStart();
 
@@ -375,7 +384,7 @@ public:
 		// if the loop is enabled, always seek to the end
 		if(s->isLoopEnabled())
 			shouldSkip |= roundToInt(voiceUptime) > loopStart;
-		
+
 		if(shouldSkip)
 		{
 			jumpToReleaseOnNextRender = true;


### PR DESCRIPTION
In a multi-mic sampler, when a channel is purged, startVoiceInternal skips startNote() for that channel's StreamingSamplerVoice, leaving its loaded sound as nullptr. On note-off, jumpToRelease() was called on all wrapped voices including the unstarted purged one, immediately dereferencing the null sound pointer.

Three fixes in StreamingSamplerVoice:
- jumpToRelease(): bail out early if the loaded sound is null (unstarted purged channel) or has no release start buffer
- calculateBlock(): guard the release buffer dereference behind a null check as a safety net
- SampleLoader::advanceReadIndex(): guard the release start buffer assignment when streaming a non-fully-loaded sound

https://claude.ai/code/session_01RWnFyULaxrjBkmB7wDVUcb

Forum thread: https://forum.hise.audio/topic/14721/crash-when-using-release-start-purged-multi-mic