### PR TITLE
Fix addNoise to accept rectangle objects as area parameter

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -1918,7 +1918,7 @@ void ScriptingObjects::GraphicsObject::addNoise(var noiseAmount)
 
 		auto customArea = noiseAmount.getProperty("area", var());
 
-		if (customArea.isArray())
+		if (customArea.isArray() || dynamic_cast<RectangleDynamicObject*>(customArea.getDynamicObject()) != nullptr)
 		{
 			ar = ApiHelpers::getIntRectangleFromVar(customArea);
 		}


### PR DESCRIPTION
The area check in addNoise only handled plain JS arrays, so passing a ScriptRectangle/RectangleDynamicObject directly (with HISE_USE_SCRIPT_RECTANGLE_OBJECT=1) produced "Invalid area for noise map" in compiled plugins. ApiHelpers::getIntRectangleFromVar already handles both arrays and RectangleDynamicObjects, so widening the condition is sufficient.

Users can now write area: a instead of area: a.toArray() and it works in both the HISE IDE and compiled plugins.

https://claude.ai/code/session_01QJgvLAT4VH3oTQsQpTLgNj