### PR TITLE
Fix macro panel showing component ID instead of pluginParameterName

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1534,7 +1534,10 @@ juce::String FrontendMacroPanel::getCellText(int rowNumber, int columnId) const
 	if (auto data = connectionList[rowNumber].get())
 	{
 		if (columnId == ColumnId::ParameterName)
-			return data->getParameterName();
+		{
+			auto prettyName = ProcessorHelpers::getPrettyNameForAutomatedParameter(data->getProcessor(), data->getParameter());
+			return prettyName.isNotEmpty() ? prettyName : data->getParameterName();
+		}
 		else if (columnId == ColumnId::CCNumber)
 			return getData(data)->getMacroName();
 	}


### PR DESCRIPTION
getCellText() now calls ProcessorHelpers::getPrettyNameForAutomatedParameter() at render time, which resolves the pluginParameterName property first and falls back to the stored name if none is set.

https://claude.ai/code/session_01VoLGLEjHK8ZAUHvP5LLTfX