### PR TITLE
Fix MPE plotter LAF and expose corner text in drawAnalyserBackground

### DIFF
--- a/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
@@ -328,6 +328,37 @@ void MPEPanel::updateTableColours()
 	listbox.getViewport()->getVerticalScrollBar().setColour(ScrollBar::ColourIds::thumbColourId, laf.fillColour);
 }
 
+Identifier MPEPanel::getDefaultablePropertyId(int id) const
+{
+	if (id < (int)FloatingTileContent::PanelPropertyId::numPropertyIds)
+		return FloatingTileContent::getDefaultablePropertyId(id);
+
+	RETURN_DEFAULT_PROPERTY_ID(id, Properties::ShowTable, "ShowTable");
+	RETURN_DEFAULT_PROPERTY_ID(id, Properties::ShowPlotter, "ShowPlotter");
+	RETURN_DEFAULT_PROPERTY_ID(id, Properties::ShowPlotterPopup, "ShowPlotterPopup");
+
+	jassertfalse;
+	return {};
+}
+
+var MPEPanel::getDefaultProperty(int id) const
+{
+	switch (id)
+	{
+	case Properties::ShowTable:       return true;
+	case Properties::ShowPlotter:     return true;
+	case Properties::ShowPlotterPopup: return true;
+	default: return FloatingTileContent::getDefaultProperty(id);
+	}
+}
+
+var MPEPanel::toDynamicObject() const
+{
+	var obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, Properties::ShowPlotterPopup, showPlotterPopup, true);
+	return obj;
+}
+
 void MPEPanel::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
@@ -338,6 +369,11 @@ void MPEPanel::fromDynamicObject(const var& object)
 	laf.fillColour = findPanelColour(FloatingTileContent::PanelColourId::itemColour2);
 
 	laf.font = getFont();
+
+	showPlotterPopup = getPropertyWithDefault(object, Properties::ShowPlotterPopup);
+
+	if (currentPlotter != nullptr)
+		currentPlotter->setPopupEnabled(showPlotterPopup);
 
 	listbox.setRowHeight(roundToInt(getFont().getHeight() * 2.2f));
 
@@ -514,6 +550,7 @@ void MPEPanel::setCurrentMod(MPEModulator* newMod)
 			currentPlotter->setColour(Plotter::ColourIds::pathColour, laf.fillColour.withMultipliedAlpha(1.05f));
 			currentPlotter->setColour(Plotter::ColourIds::pathColour2, laf.fillColour);
 			currentPlotter->setColour(Plotter::ColourIds::backgroundColour, laf.fillColour.withAlpha(0.05f));
+			currentPlotter->setPopupEnabled(showPlotterPopup);
 			currentTable.setColour(TableEditor::ColourIds::bgColour, laf.fillColour.withAlpha(0.05f));
 		}
 

--- a/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
@@ -355,6 +355,8 @@ var MPEPanel::getDefaultProperty(int id) const
 var MPEPanel::toDynamicObject() const
 {
 	var obj = FloatingTileContent::toDynamicObject();
+	storePropertyInObject(obj, Properties::ShowTable,        showTable,        true);
+	storePropertyInObject(obj, Properties::ShowPlotter,      showPlotter,      true);
 	storePropertyInObject(obj, Properties::ShowPlotterPopup, showPlotterPopup, true);
 	return obj;
 }
@@ -370,6 +372,8 @@ void MPEPanel::fromDynamicObject(const var& object)
 
 	laf.font = getFont();
 
+	showTable       = getPropertyWithDefault(object, Properties::ShowTable);
+	showPlotter     = getPropertyWithDefault(object, Properties::ShowPlotter);
 	showPlotterPopup = getPropertyWithDefault(object, Properties::ShowPlotterPopup);
 
 	if (currentPlotter != nullptr)
@@ -417,11 +421,19 @@ void MPEPanel::resized()
 		{
 			auto r = bottomArea;
 
-			currentTable.setVisible(true);
+			const bool showBoth = showTable && showPlotter;
 
-			currentTable.setBounds(r.removeFromLeft(r.getWidth() / 2).reduced(margin));
+			currentTable.setVisible(showTable);
+
+			if (showTable)
+				currentTable.setBounds((showBoth ? r.removeFromLeft(r.getWidth() / 2) : r).reduced(margin));
+
 			if (currentPlotter)
-				currentPlotter->setBounds(r.reduced(margin));
+			{
+				currentPlotter->setVisible(showPlotter && enabled);
+				if (showPlotter)
+					currentPlotter->setBounds(r.reduced(margin));
+			}
 		}
 		else
 		{
@@ -429,7 +441,12 @@ void MPEPanel::resized()
 		}
 
 
-		listbox.setBounds(topArea.reduced(margin));
+		auto listboxBounds = topArea;
+
+		if (!showTable && !showPlotter)
+			listboxBounds = listboxBounds.withBottom(bottomArea.getBottom());
+
+		listbox.setBounds(listboxBounds.reduced(margin));
 	}
 
 
@@ -506,13 +523,18 @@ void MPEPanel::paint(Graphics& g)
 			g.drawText("No Active Modulations", tableHeader, Justification::centred);
 		}
 
-		if (currentlyEditedMod != nullptr)
+		if (currentlyEditedMod != nullptr && (showTable || showPlotter))
 		{
 			g.setColour(laf.textColour);
 			g.setFont(laf.font);
 
-			g.drawText("Curve", bottomBar.removeFromLeft(getWidth() / 2), Justification::centred);
-			g.drawText("Plot", bottomBar.removeFromLeft(getWidth() / 2), Justification::centred);
+			const bool showBoth = showTable && showPlotter;
+
+			if (showTable)
+				g.drawText("Curve", showBoth ? bottomBar.removeFromLeft(getWidth() / 2) : bottomBar, Justification::centred);
+
+			if (showPlotter)
+				g.drawText("Plot", bottomBar, Justification::centred);
 		}
 	}
 	else

--- a/hi_core/hi_modules/modulators/mods/MPEComponents.h
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.h
@@ -47,7 +47,9 @@ public:
 	enum Properties
 	{
 		ShowTable = (int)FloatingTileContent::PanelPropertyId::numPropertyIds,
-		ShowPlotte
+		ShowPlotter,
+		ShowPlotterPopup,
+		numPropertyIds
 	};
 
 	struct LookAndFeel : public PopupLookAndFeel
@@ -99,6 +101,10 @@ public:
 
 	void updateTableColours();
 
+	int getNumDefaultableProperties() const override { return Properties::numPropertyIds; }
+	Identifier getDefaultablePropertyId(int id) const override;
+	var getDefaultProperty(int id) const override;
+	var toDynamicObject() const override;
 	void fromDynamicObject(const var& object) override;
 
 	bool keyPressed(const KeyPress& key) override;
@@ -251,6 +257,8 @@ private:
 	TextButton enableMPEButton;
 
 	ScopedPointer<MarkdownHelpButton> helpButton;
+
+	bool showPlotterPopup = true;
 
 	TableEditor currentTable;
 	ScopedPointer<Plotter> currentPlotter;

--- a/hi_core/hi_modules/modulators/mods/MPEComponents.h
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.h
@@ -258,6 +258,8 @@ private:
 
 	ScopedPointer<MarkdownHelpButton> helpButton;
 
+	bool showTable = true;
+	bool showPlotter = true;
 	bool showPlotterPopup = true;
 
 	TableEditor currentTable;

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -4341,10 +4341,15 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawOscilloscopeBackground(Grap
 		writeId(obj, c);
 		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, areaToFill));
 
-		
 		setColourOrBlack(obj, "bgColour", *c, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour1", *c, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", *c, RingBufferComponentBase::ColourId::lineColour);
+
+		if (auto plotter = dynamic_cast<Plotter*>(c))
+		{
+			obj->setProperty("topText", plotter->getCornerText(true));
+			obj->setProperty("bottomText", plotter->getCornerText(false));
+		}
 
 		if (get()->callWithGraphics(g_, "drawAnalyserBackground", var(obj), c))
 			return;

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -949,6 +949,7 @@ namespace ScriptingObjects
 			void drawOscilloscopePath(Graphics& g, RingBufferComponentBase& ac, const Path& p) override;
 			void drawGonioMeterDots(Graphics& g, RingBufferComponentBase& ac, const RectangleList<float>& dots, int index) override;
 			void drawAnalyserGrid(Graphics& g, RingBufferComponentBase& ac, const Path& p) override;
+			bool providesCustomAnalyserBackground() override { return functionDefined("drawAnalyserBackground"); }
 
             void drawMatrixPeakMeter(Graphics& g, float* peakValues, float* maxPeaks, int numChannels, bool isVertical, float segmentSize, float paddingSize, Component* c) override;
             

--- a/hi_scripting/scripting/api/laf_style_guide.json
+++ b/hi_scripting/scripting/api/laf_style_guide.json
@@ -1861,6 +1861,14 @@
                 "itemColour2": {
                   "type": "int (ARGB)",
                   "description": "Line colour"
+                },
+                "topText": {
+                  "type": "String",
+                  "description": "The label text for the top corner (only present for Plotter components)"
+                },
+                "bottomText": {
+                  "type": "String",
+                  "description": "The label text for the bottom corner (only present for Plotter components)"
                 }
               }
             },

--- a/hi_tools/hi_standalone_components/Plotter.cpp
+++ b/hi_tools/hi_standalone_components/Plotter.cpp
@@ -185,7 +185,7 @@ void Plotter::paint (Graphics& g)
 		g.fillPath(drawPath);
 	}
 
-	if (!popupPosition.isOrigin() && !tc.isTransparent())
+	if (popupEnabled && !popupPosition.isOrigin() && !tc.isTransparent())
 	{
 		Font f = font;
 

--- a/hi_tools/hi_standalone_components/Plotter.cpp
+++ b/hi_tools/hi_standalone_components/Plotter.cpp
@@ -121,6 +121,17 @@ void Plotter::paint (Graphics& g)
 {
 	auto slaf = dynamic_cast<RingBufferComponentBase::LookAndFeelMethods*>(&getLookAndFeel());
 
+	if (slaf == nullptr)
+	{
+		auto* parent = getParentComponent();
+
+		while (parent != nullptr && slaf == nullptr)
+		{
+			slaf = dynamic_cast<RingBufferComponentBase::LookAndFeelMethods*>(&parent->getLookAndFeel());
+			parent = parent->getParentComponent();
+		}
+	}
+
 	if(slaf != nullptr)
 	{
 		slaf->drawOscilloscopeBackground(g, *this, getLocalBounds().toFloat());
@@ -135,7 +146,7 @@ void Plotter::paint (Graphics& g)
 
 	auto tc = findColour(textColour);
 
-	if(!tc.isTransparent())
+	if((slaf == nullptr || !slaf->providesCustomAnalyserBackground()) && !tc.isTransparent())
 	{
 		g.setColour(tc);
 

--- a/hi_tools/hi_standalone_components/Plotter.h
+++ b/hi_tools/hi_standalone_components/Plotter.h
@@ -96,6 +96,14 @@ public:
 
 	void setYConverter(const Table::ValueTextConverter& newYConverter);
 
+	String getCornerText(bool top) const
+	{
+		if (top)
+			return yConverter(1.0f);
+
+		return yConverter(currentMode == PanMode ? -1.0f : 0.0f);
+	}
+
 	void setCleanupFunction(const CleanupFunction& cf)
 	{
 		cleanupFunction = cf;

--- a/hi_tools/hi_standalone_components/Plotter.h
+++ b/hi_tools/hi_standalone_components/Plotter.h
@@ -96,6 +96,8 @@ public:
 
 	void setYConverter(const Table::ValueTextConverter& newYConverter);
 
+	void setPopupEnabled(bool shouldBeEnabled) { popupEnabled = shouldBeEnabled; }
+
 	String getCornerText(bool top) const
 	{
 		if (top)
@@ -133,6 +135,7 @@ private:
 
 	Point<int> popupPosition;
 	bool stickPopup = false;
+	bool popupEnabled = true;
 
 	Table::ValueTextConverter yConverter;
 

--- a/hi_tools/hi_standalone_components/RingBuffer.h
+++ b/hi_tools/hi_standalone_components/RingBuffer.h
@@ -307,6 +307,7 @@ struct RingBufferComponentBase : public ComplexDataUIBase::EditorBase,
 		virtual void drawOscilloscopePath(Graphics& g, RingBufferComponentBase& ac, const Path& p);
 		virtual void drawGonioMeterDots(Graphics& g, RingBufferComponentBase& ac, const RectangleList<float>& dots, int index);
 		virtual void drawAnalyserGrid(Graphics& g, RingBufferComponentBase& ac, const Path& p);
+		virtual bool providesCustomAnalyserBackground() { return false; }
 	};
 
 	struct DefaultLookAndFeel : public GlobalHiseLookAndFeel,


### PR DESCRIPTION
The Plotter component installed its own GlobalHiseLookAndFeel via setSpecialLookAndFeel, which does not implement
RingBufferComponentBase::LookAndFeelMethods. This meant the scripted drawAnalyserBackground / drawAnalyserPath callbacks had no effect on the MPE plotter regardless of what LAF was assigned to a parent component.

Plotter::paint() now walks up the parent component chain when its own LAF does not implement LookAndFeelMethods, so a local ScriptedLookAndFeel on any ancestor (e.g. the MPE FloatingTile) is found and used. When a custom LAF is active the native corner text drawing is also suppressed, giving drawAnalyserBackground full control over all decoration.

The drawAnalyserBackground obj now includes topText and bottomText when the component is a Plotter. Both values come from the Plotter's yConverter and reflect whatever the parent modulator chain is configured to display ("Not assigned", "100%", semitone values, etc.).

The show plotter and show table IDs were already present but not implemented. This commits implements them - and fixes a typo.

https://claude.ai/code/session_01RBk8AaWjdCnzDuBU1UZZMb