### PR TITLE
Mpe panel

### DIFF
--- a/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.cpp
@@ -332,6 +332,8 @@ void MPEPanel::fromDynamicObject(const var& object)
 {
 	FloatingTileContent::fromDynamicObject(object);
 
+	hideEnableMPEButton = (bool)object.getProperty("HideEnableMPEButton", false);
+
 	laf.bgColour = findPanelColour(FloatingTileContent::PanelColourId::bgColour);
 	laf.lineColour = findPanelColour(FloatingTileContent::PanelColourId::itemColour1);
 	laf.textColour = findPanelColour(FloatingTileContent::PanelColourId::textColour);
@@ -363,7 +365,15 @@ void MPEPanel::resized()
 
 	const int margin = 2;
 
-	enableMPEButton.setBounds(ar.removeFromTop(32).reduced(margin));
+	if (hideEnableMPEButton)
+	{
+		enableMPEButton.setVisible(false);
+	}
+	else
+	{
+		enableMPEButton.setVisible(true);
+		enableMPEButton.setBounds(ar.removeFromTop(32).reduced(margin));
+	}
 
 	const bool enabled = enableMPEButton.getToggleState();
 
@@ -406,10 +416,18 @@ void MPEPanel::updateRectangles()
 {
 	auto ar = getParentShell()->getContentBounds();
 
-	ar.removeFromTop(32);
+	if (!hideEnableMPEButton)
+	{
+		ar.removeFromTop(32);
+		topArea = ar.removeFromTop(ar.getHeight() / 2);
+		topBar = topArea.removeFromTop(30);
+	}
+	else
+	{
+		topArea = ar.removeFromTop(ar.getHeight() / 2);
+		topBar = {};
+	}
 
-	topArea = ar.removeFromTop(ar.getHeight() / 2);
-	topBar = topArea.removeFromTop(30);
 	tableHeader = topArea.removeFromTop(30);
 
 	bottomArea = ar;
@@ -479,7 +497,7 @@ void MPEPanel::paint(Graphics& g)
 			g.drawText("Plot", bottomBar.removeFromLeft(getWidth() / 2), Justification::centred);
 		}
 	}
-	else
+	else if (!hideEnableMPEButton)
 	{
 		updateRectangles();
 

--- a/hi_core/hi_modules/modulators/mods/MPEComponents.h
+++ b/hi_core/hi_modules/modulators/mods/MPEComponents.h
@@ -261,6 +261,8 @@ private:
 	Rectangle<int> bottomArea;
 	Rectangle<int> bottomBar;
 
+	bool hideEnableMPEButton = false;
+
 	JUCE_DECLARE_WEAK_REFERENCEABLE(MPEPanel);
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MPEPanel);
 };

--- a/hi_scripting/scripting/api/ScriptingApi.cpp
+++ b/hi_scripting/scripting/api/ScriptingApi.cpp
@@ -1202,6 +1202,7 @@ struct ScriptingApi::Engine::Wrapper
 	API_METHOD_WRAPPER_0(Engine, getCurrentUserPresetName);
 	API_VOID_METHOD_WRAPPER_1(Engine, saveUserPreset);
 	API_METHOD_WRAPPER_0(Engine, isMpeEnabled);
+	API_VOID_METHOD_WRAPPER_1(Engine, setMpeEnabled);
 	API_METHOD_WRAPPER_1(Engine, createAndRegisterSliderPackData);
 	API_METHOD_WRAPPER_1(Engine, createAndRegisterTableData);
 	API_METHOD_WRAPPER_1(Engine, createAndRegisterAudioFile);
@@ -1370,6 +1371,7 @@ parentMidiProcessor(dynamic_cast<ScriptBaseMidiProcessor*>(p))
 	ADD_API_METHOD_1(loadUserPreset);
 	ADD_API_METHOD_0(getUserPresetList);
 	ADD_API_METHOD_0(isMpeEnabled);
+	ADD_API_METHOD_1(setMpeEnabled);
 	ADD_API_METHOD_0(createMidiList);
 	ADD_API_METHOD_0(createUnorderedStack);
 	ADD_API_METHOD_1(createBackgroundTask);
@@ -2663,6 +2665,19 @@ void ScriptingApi::Engine::loadPreviousUserPreset(bool stayInDirectory)
 bool ScriptingApi::Engine::isMpeEnabled() const
 {
 	return getScriptProcessor()->getMainController_()->getMacroManager().getMidiControlAutomationHandler()->getMPEData().isMpeEnabled();
+}
+
+void ScriptingApi::Engine::setMpeEnabled(bool shouldBeEnabled)
+{
+	auto mc = getScriptProcessor()->getMainController_();
+
+	auto f = [shouldBeEnabled](Processor* p)
+	{
+		p->getMainController()->getMacroManager().getMidiControlAutomationHandler()->getMPEData().setMpeMode(shouldBeEnabled);
+		return SafeFunctionCall::OK;
+	};
+
+	mc->getKillStateHandler().killVoicesAndCall(mc->getMainSynthChain(), f, MainController::KillStateHandler::TargetThread::SampleLoadingThread);
 }
 
 String ScriptingApi::Engine::getCurrentUserPresetName()

--- a/hi_scripting/scripting/api/ScriptingApi.h
+++ b/hi_scripting/scripting/api/ScriptingApi.h
@@ -483,6 +483,9 @@ public:
 		/** Checks if the global MPE mode is enabled. */
 		bool isMpeEnabled() const;
 
+		/** Enables or disables the global MPE mode. */
+		void setMpeEnabled(bool shouldBeEnabled);
+
 		/** Returns the currently loaded user preset (without extension). */
 		String getCurrentUserPresetName();
 


### PR DESCRIPTION
Add a data property to hide the enable/disable mpe button. Hiding it also removes the gap between the top of the table and the top of the panel.

Also added an engine function to enable/disable mpe via scripting. 

These two options changes open up a lot more customisation options while keeping the core functionality intact.