### PR TITLE
Fix macro panel only showing first 8 macros when HISE_NUM_MACROS > 8

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1427,7 +1427,9 @@ int FrontendMacroPanel::getNumRows()
 
 	Array<WeakReference<MacroControlBroadcaster::MacroControlledParameterData>> newList;
 
-	for (int i = 0; i < 8; i++)
+	auto numMacros = HISE_GET_PREPROCESSOR(getMainController(), HISE_NUM_MACROS);
+
+	for (int i = 0; i < numMacros; i++)
 	{
 		auto d = macroChain->getMacroControlData(i);
 

--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -520,7 +520,8 @@ StringArray ScriptingApi::Content::ScriptComponent::getOptionsFor(const Identifi
 		StringArray sa;
 
 		sa.add("No MacroControl");
-		for (int i = 0; i < 8; i++)
+		auto numMacros = HISE_GET_PREPROCESSOR(getScriptProcessor()->getMainController_(), HISE_NUM_MACROS);
+		for (int i = 0; i < numMacros; i++)
 		{
 			sa.add("Macro " + String(i + 1));
 		}


### PR DESCRIPTION
Two locations had hardcoded 8 instead of using HISE_GET_PREPROCESSOR:
- FrontendMacroPanel::getNumRows() in FrontendPanelTypes.cpp
- ScriptComponent::getOptionsFor() macro dropdown in ScriptingApiContent.cpp

https://claude.ai/code/session_01DN5Ho6ZXXdXUoR3JSFwUzd