### PR TITLE
Mpe connection api

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.cpp
@@ -10196,6 +10196,7 @@ struct ScriptingObjects::ScriptedMidiAutomationHandler::Wrapper
 	API_VOID_METHOD_WRAPPER_2(ScriptedMidiAutomationHandler, setControllerNumberNames);
 	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, addMPEConnection);
 	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, removeMPEConnection);
+	API_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, isMPEConnected);
 };
 
 
@@ -10216,6 +10217,7 @@ ScriptingObjects::ScriptedMidiAutomationHandler::ScriptedMidiAutomationHandler(P
 	ADD_API_METHOD_2(setControllerNumberNames);
 	ADD_API_METHOD_1(addMPEConnection);
 	ADD_API_METHOD_1(removeMPEConnection);
+	ADD_API_METHOD_1(isMPEConnected);
 }
 
 ScriptingObjects::ScriptedMidiAutomationHandler::~ScriptedMidiAutomationHandler()
@@ -10319,6 +10321,17 @@ void ScriptingObjects::ScriptedMidiAutomationHandler::removeMPEConnection(String
 		reportScriptError("Could not find MPE modulator: " + modulatorId);
 	else
 		mpeData.removeConnection(mod);
+}
+
+bool ScriptingObjects::ScriptedMidiAutomationHandler::isMPEConnected(String modulatorId)
+{
+	auto& mpeData = handler->getMPEData();
+	auto* mod = mpeData.findMPEModulator(modulatorId);
+
+	if (mod == nullptr)
+		reportScriptError("Could not find MPE modulator: " + modulatorId);
+
+	return mod != nullptr && mpeData.contains(mod);
 }
 
 struct ScriptingObjects::ScriptBuilder::Wrapper

--- a/hi_scripting/scripting/api/ScriptingApiObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.cpp
@@ -10194,6 +10194,8 @@ struct ScriptingObjects::ScriptedMidiAutomationHandler::Wrapper
 	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, setUpdateCallback);
 	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, setConsumeAutomatedControllers);
 	API_VOID_METHOD_WRAPPER_2(ScriptedMidiAutomationHandler, setControllerNumberNames);
+	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, addMPEConnection);
+	API_VOID_METHOD_WRAPPER_1(ScriptedMidiAutomationHandler, removeMPEConnection);
 };
 
 
@@ -10212,6 +10214,8 @@ ScriptingObjects::ScriptedMidiAutomationHandler::ScriptedMidiAutomationHandler(P
 	ADD_API_METHOD_1(setUpdateCallback);
 	ADD_API_METHOD_1(setConsumeAutomatedControllers);
 	ADD_API_METHOD_2(setControllerNumberNames);
+	ADD_API_METHOD_1(addMPEConnection);
+	ADD_API_METHOD_1(removeMPEConnection);
 }
 
 ScriptingObjects::ScriptedMidiAutomationHandler::~ScriptedMidiAutomationHandler()
@@ -10293,6 +10297,28 @@ void ScriptingObjects::ScriptedMidiAutomationHandler::setUpdateCallback(var call
 void ScriptingObjects::ScriptedMidiAutomationHandler::setConsumeAutomatedControllers(bool shouldBeConsumed)
 {
 	handler->setConsumeAutomatedControllers(shouldBeConsumed);
+}
+
+void ScriptingObjects::ScriptedMidiAutomationHandler::addMPEConnection(String modulatorId)
+{
+	auto& mpeData = handler->getMPEData();
+	auto* mod = mpeData.findMPEModulator(modulatorId);
+
+	if (mod == nullptr)
+		reportScriptError("Could not find MPE modulator: " + modulatorId);
+	else
+		mpeData.addConnection(mod);
+}
+
+void ScriptingObjects::ScriptedMidiAutomationHandler::removeMPEConnection(String modulatorId)
+{
+	auto& mpeData = handler->getMPEData();
+	auto* mod = mpeData.findMPEModulator(modulatorId);
+
+	if (mod == nullptr)
+		reportScriptError("Could not find MPE modulator: " + modulatorId);
+	else
+		mpeData.removeConnection(mod);
 }
 
 struct ScriptingObjects::ScriptBuilder::Wrapper

--- a/hi_scripting/scripting/api/ScriptingApiObjects.h
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.h
@@ -3029,6 +3029,9 @@ namespace ScriptingObjects
 		/** Removes the MPE modulator with the given ID from the active MPE connections (equivalent to "Remove MPE Gesture" in the context menu). */
 		void removeMPEConnection(String modulatorId);
 
+		/** Returns true if the MPE modulator with the given ID is actively connected. */
+		bool isMPEConnected(String modulatorId);
+
 		// ============================================================================================================ End of API Methods
 
 	private:

--- a/hi_scripting/scripting/api/ScriptingApiObjects.h
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.h
@@ -3023,6 +3023,12 @@ namespace ScriptingObjects
 		/** Sets whether a automated MIDI CC message should be consumed by the automation handler (default is enabled). */
 		void setConsumeAutomatedControllers(bool shouldBeConsumed);
 
+		/** Adds the MPE modulator with the given ID to the active MPE connections (equivalent to "Add MPE Gesture" in the context menu). */
+		void addMPEConnection(String modulatorId);
+
+		/** Removes the MPE modulator with the given ID from the active MPE connections (equivalent to "Remove MPE Gesture" in the context menu). */
+		void removeMPEConnection(String modulatorId);
+
 		// ============================================================================================================ End of API Methods
 
 	private:


### PR DESCRIPTION
Added a few API calls to the MIDI automation handler to check the status of MPE mod connections, and add/remove connections programatically. This is for the use case where the mods are setup with MPE at the end of the name for connection through the component context menu.

