### PR TITLE
Add CompanyURL and UUID to archive metadata for getMetaDataFromPackage()

### DIFF
--- a/hi_core/hi_core/BackgroundThreads.cpp
+++ b/hi_core/hi_core/BackgroundThreads.cpp
@@ -966,6 +966,8 @@ String SampleDataExporter::getMetadataJSON() const
 	d->setProperty("Name", getProjectName());
 	d->setProperty("Version", getProjectVersion());
 	d->setProperty("Company", getCompanyName());
+	d->setProperty("CompanyURL", getCompanyURL());
+	d->setProperty("UUID", getExpansionUUID());
 
 	auto expName = getExpansionName();
 
@@ -1026,6 +1028,16 @@ String SampleDataExporter::getCompanyName() const
 #else
 	return FrontendHandler::getCompanyName();
 #endif
+}
+
+String SampleDataExporter::getCompanyURL() const
+{
+	return dynamic_cast<GlobalSettingManager*>(synthChain->getMainController())->getSettingsObject().getSetting(HiseSettings::User::CompanyURL);
+}
+
+String SampleDataExporter::getExpansionUUID() const
+{
+	return dynamic_cast<GlobalSettingManager*>(synthChain->getMainController())->getSettingsObject().getSetting(HiseSettings::ExpansionSettings::UUID);
 }
 
 String SampleDataExporter::getProjectVersion() const

--- a/hi_core/hi_core/BackgroundThreads.h
+++ b/hi_core/hi_core/BackgroundThreads.h
@@ -522,6 +522,10 @@ private:
 
 	String getCompanyName() const;
 
+	String getCompanyURL() const;
+
+	String getExpansionUUID() const;
+
 	String getProjectVersion() const;
 
 	File getTargetFile() const;


### PR DESCRIPTION
SampleDataExporter::getMetadataJSON() now writes CompanyURL (from HiseSettings::User::CompanyURL) and UUID (from HiseSettings::ExpansionSettings::UUID) into the archive metadata JSON. These fields are then available via expansionHandler.getMetaDataFromPackage() which reads them back unchanged.

https://claude.ai/code/session_01A8gXWuzzqRjPPQ7TRZytwU