### PR TITLE
Remove stale expansions in createAvailableExpansions

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -212,6 +212,15 @@ bool ExpansionHandler::createAvailableExpansions()
     OwnedArray<Expansion> newList;
 	bool didSomething = false;
 
+	for (int i = expansionList.size() - 1; i >= 0; i--)
+	{
+		if (!expansionList[i]->getRootFolder().isDirectory())
+		{
+			expansionList.remove(i);
+			didSomething = true;
+		}
+	}
+
 	for (auto f : folders)
 	{
 		bool exists = false;
@@ -240,7 +249,7 @@ bool ExpansionHandler::createAvailableExpansions()
 			}
 		}
 	}
-    
+
 	if (didSomething)
 	{
 		Expansion::Sorter s;


### PR DESCRIPTION
refreshExpansions now removes entries from the expansion list whose root folder no longer exists on disk, so the list stays in sync when expansions are deleted from the system.

https://claude.ai/code/session_01F5HwNVikUSU3BGQ5nQVyvV