### PR TITLE
Add removeExpansion to ExpansionHandler and scripting API

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -406,6 +406,91 @@ void ExpansionHandler::unloadExpansion(Expansion* e)
 	}
 }
 
+void ExpansionHandler::removeExpansion(Expansion* e, bool removeUserPresets)
+{
+	if (e == nullptr)
+		return;
+
+	auto expansionRoot = e->getRootFolder();
+
+	// FullInstrumentExpansion lazy-loads its pool; ensure it is populated before
+	// we read sample map data. This is a no-op for other expansion types.
+	e->populateSampleMapPool();
+
+	// getSubDirectory follows any link file and returns the true samples path.
+	auto actualSamplesDir = e->getSubDirectory(FileHandlerBase::Samples);
+
+	// Monolith files are named "{ID.replace('/','_')}.chN" (flat, no subdirectories).
+	// Channel count is the number of ';' characters in the MicPositions property.
+	struct MonolithInfo { String flatId; int numChannels; };
+	Array<MonolithInfo> monolithFiles;
+
+	for (const auto& ref : e->pool->getSampleMapPool().getListOfAllReferences(true))
+	{
+		if (auto loaded = e->pool->getSampleMapPool().loadFromReference(ref, PoolHelpers::LoadAndCacheWeak))
+		{
+			const auto& vt = loaded->data;
+
+			if ((int)vt.getProperty("SaveMode") != (int)SampleMap::SaveMode::Monolith)
+				continue;
+
+			String flatId = vt.getProperty("ID").toString().replace("/", "_");
+			auto micStr = vt.getProperty("MicPositions").toString().toStdString();
+			int numCh = (int)std::count(micStr.begin(), micStr.end(), ';');
+
+			if (numCh > 0)
+				monolithFiles.add({ flatId, numCh });
+		}
+	}
+
+	// unloadExpansion removes from expansionList and clears currentExpansion
+	unloadExpansion(e);
+
+	// unloadExpansion only checks expansionList; handle other lists here
+	uninitialisedExpansions.removeObject(e, false);
+
+	// Take ownership so the Expansion object is deleted on function exit.
+	// After unloadExpansion, e is in unloadedExpansions if it was active.
+	ScopedPointer<Expansion> owned;
+	auto idx = unloadedExpansions.indexOf(e);
+	if (idx != -1)
+		owned = unloadedExpansions.removeAndReturn(idx);
+	else
+		owned = e;
+
+	if (actualSamplesDir.isDirectory() && !monolithFiles.isEmpty())
+	{
+		for (const auto& info : monolithFiles)
+		{
+			for (int i = 0; i < info.numChannels; i++)
+				actualSamplesDir.getChildFile(info.flatId + ".ch" + String(i + 1)).deleteFile();
+		}
+
+		if (actualSamplesDir.getNumberOfChildFiles(File::findFilesAndDirectories) == 0)
+			actualSamplesDir.deleteFile();
+	}
+
+	Array<File> subDirs;
+	expansionRoot.findChildFiles(subDirs, File::findDirectories, false);
+
+	for (const auto& dir : subDirs)
+	{
+		if (!removeUserPresets && dir.getFileName() == "UserPresets")
+			continue;
+
+		dir.deleteRecursively();
+	}
+
+	Array<File> rootFiles;
+	expansionRoot.findChildFiles(rootFiles, File::findFiles, false);
+
+	for (const auto& f : rootFiles)
+		f.deleteFile();
+
+	if (expansionRoot.getNumberOfChildFiles(File::findFilesAndDirectories) == 0)
+		expansionRoot.deleteFile();
+}
+
 bool ExpansionHandler::installFromResourceFile(const File& resourceFile, const File& sampleDirectoryToUse)
 {
 	auto expRoot = getExpansionTargetFolder(resourceFile);

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -93,11 +93,16 @@ public:
 	~Expansion();
 
 	/** Override this method and initialise the expansion. You need to do at least those things:
-	
+
 		- create a Data object
 	    - setup the pools
 	*/
 	virtual Result initialise();;
+
+	/** Override to ensure the sample map pool is populated before removal.
+	    The default no-op is sufficient for expansion types that populate
+	    the pool eagerly during initialise(). */
+	virtual void populateSampleMapPool() {}
 
 	struct Helpers
 	{
@@ -299,6 +304,12 @@ public:
 	};
 
 	void unloadExpansion(Expansion* e);
+
+	/** Removes an expansion and its associated files from disk.
+	    Monolith sample files are identified via the sample map pool and deleted
+	    from the true samples directory. Pass true for removeUserPresets to also
+	    delete the expansion's UserPresets subfolder. */
+	void removeExpansion(Expansion* e, bool removeUserPresets);
 
 	void createNewExpansion(const File& expansionFolder);
 	File getExpansionFolder() const;

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -1137,6 +1137,7 @@ struct ScriptExpansionHandler::Wrapper
 	API_METHOD_WRAPPER_2(ScriptExpansionHandler, installExpansionFromPackage);
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getExpansionForInstallPackage);
 	API_METHOD_WRAPPER_1(ScriptExpansionHandler, getMetaDataFromPackage);
+	API_METHOD_WRAPPER_2(ScriptExpansionHandler, removeExpansion);
 };
 
 ScriptExpansionHandler::ScriptExpansionHandler(JavascriptProcessor* jp_) :
@@ -1169,6 +1170,7 @@ ScriptExpansionHandler::ScriptExpansionHandler(JavascriptProcessor* jp_) :
 	ADD_CALLBACK_DIAGNOSTIC(installCallback, setInstallCallback, 0);
 	ADD_API_METHOD_1(getMetaDataFromPackage);
 	ADD_API_METHOD_1(getExpansionForInstallPackage);
+	ADD_API_METHOD_2(removeExpansion);
 
 	
 
@@ -1393,6 +1395,23 @@ var ScriptExpansionHandler::getExpansionForInstallPackage(var packageFile)
 
 	reportScriptError("getExpansionForInstallPackage requires a file as parameter");
 	RETURN_IF_NO_THROW(var());
+}
+
+bool ScriptExpansionHandler::removeExpansion(var expansion, bool removeUserPresets)
+{
+	Expansion* e = nullptr;
+
+	if (auto se = dynamic_cast<ScriptExpansionReference*>(expansion.getObject()))
+		e = se->exp;
+
+	if (e == nullptr)
+	{
+		reportScriptError("removeExpansion requires a valid expansion object");
+		RETURN_IF_NO_THROW(false);
+	}
+
+	getMainController()->getExpansionHandler().removeExpansion(e, removeUserPresets);
+	return true;
 }
 
 void ScriptExpansionHandler::setAllowedExpansionTypes(var typeList)
@@ -2498,6 +2517,17 @@ struct PublicIconProvider : public PoolBase::DataProvider
 
 	MemoryBlock mb;
 };
+
+void FullInstrumentExpansion::populateSampleMapPool()
+{
+	if (!pool->getSampleMapPool().getListOfAllReferences(true).isEmpty())
+		return;
+
+	auto allData = getValueTreeFromFile(getExpansionType());
+
+	if (allData.isValid())
+		initialiseFromValueTree(allData);
+}
 
 juce::Result FullInstrumentExpansion::initialise()
 {

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -261,6 +261,9 @@ public:
 	/** Returns a meta data object from the .hr file */
 	var getMetaDataFromPackage(var packageFile);
 
+	/** Removes an expansion and its files from disk. Pass true to also delete the UserPresets folder. */
+	bool removeExpansion(var expansion, bool removeUserPresets);
+
 	/** Checks if the expansion is already installed and returns a reference to the expansion if it exists. */
 	var getExpansionForInstallPackage(var packageFile);
 
@@ -423,6 +426,8 @@ public:
 	void expansionPackLoaded(Expansion* e);
 
 	Result initialise() override;
+
+	void populateSampleMapPool() override;
 
 	Result encodeExpansion() override;
 


### PR DESCRIPTION
Function to uninstall expansions. Previously I was handling this via scripting but it seems since we have an installFromPackage function we should also have a built in way to remove an expansion.

Also I wanted to be able to make sure I was only removing monoliths that belong to the expansion - you never know what a user might add to the folder. For that I followed the method you used in [this commit](https://github.com/davidhealey/HISE/commit/8ab7569bd8142a2dbf08ab4f67cd1ff3d93aa2a9) for loading the expansion's value tree. Since it's only going to be one expansion at a time I don't think there is a performance hit to worry about.

- ExpansionHandler::removeExpansion(Expansion* e, bool removeUserPresets) identifies monolith sample files via the sample map pool (channel count from MicPositions ';' count, flat filename from ID with '/' replaced by '_'), deletes them from the true samples directory, removes the expansion root folder contents, and optionally removes the UserPresets subfolder.
- Adds Expansion::populateSampleMapPool() virtual hook so that FullInstrumentExpansion (which lazy-loads its pool) can populate it before removal without triggering a full lazyLoad().
- Exposes the function as ScriptExpansionHandler.removeExpansion(expansion, bool) in HISEScript.

https://claude.ai/code/session_01DvEhKLoRpGJ2aoDrx4v64c