### PR TITLE
Fix combo box submenu parent shown as selected after value cleared

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -2418,6 +2418,7 @@ void HiComboBox::updateValue(NotificationType /*sendAttributeChange*/)
 	setEnabled(enabled);
 
 	setSelectedId(roundToInt(getProcessor()->getAttribute(parameter)), dontSendNotification);
+	refreshTickState();
 
 	//addItemsToMenu(*getRootMenu());
 }

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1222,10 +1222,10 @@ void ScriptCreatedComponentWrappers::ComboBoxWrapper::updateItems(HiComboBox * c
 {
 	cb->clear(dontSendNotification);
 	cb->addItemList(dynamic_cast<ScriptingApi::Content::ScriptComboBox*>(getScriptComponent())->getItemList(), 1);
-    cb->rebuildPopupMenu();
-    
+
     auto currentValue = (int)getScriptComponent()->getValue();
     cb->setSelectedId(currentValue, dontSendNotification);
+    cb->rebuildPopupMenu();
 }
 
 void ScriptCreatedComponentWrappers::ComboBoxWrapper::updateColours(HiComboBox * cb)

--- a/hi_tools/hi_dev/ZoomableViewport.cpp
+++ b/hi_tools/hi_dev/ZoomableViewport.cpp
@@ -666,7 +666,7 @@ void SubmenuComboBox::rebuildPopupMenu()
 			continue;
 
 		if(item.itemID == getSelectedId())
-			activeIndexes.add(item.itemID);
+			activeIndexes.add(item.itemID - 1);
             
 		sa.add(item.text);
 	}


### PR DESCRIPTION
Two bugs caused the submenu parent item to persist as ticked:

1. Off-by-one in SubmenuComboBox::rebuildPopupMenu(): activeIndexes was populated with 1-based JUCE item IDs but addToPopupMenu() compares against menuIndex-1 (0-based), so the item after the selected one was ticked instead, making the wrong parent submenu appear selected. Fixed by storing item.itemID - 1 in activeIndexes.

2. HiComboBox::updateValue() calls setSelectedId(..., dontSendNotification), bypassing the ComboBox listener that triggers refreshTickState(). Added a refreshTickState() call after setSelectedId so programmatic value changes sync the menu tick state without rebuilding the submenu structure.

Also fixed updateItems() to call setSelectedId() before rebuildPopupMenu() so tick state is computed from the correct current value.

https://claude.ai/code/session_01P8qE7tQnA8MbgdQ9Jiwb7b