### PR TITLE
Expose readOnly flag in macro scripting API round-trip

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.cpp
@@ -10014,6 +10014,7 @@ namespace MacroIds
 	DECLARE_ID(Processor);
 	DECLARE_ID(Attribute);
 	DECLARE_ID(CustomAutomation);
+	DECLARE_ID(ReadOnly);
 #undef DECLARE_ID
 }
 
@@ -10111,8 +10112,9 @@ void ScriptingObjects::ScriptedMacroHandler::setFromCallbackArg(const var& obj)
 				fr = nr;
 
 			auto converterString = obj["converter"].toString();
+			auto readOnly = obj.hasProperty(MacroIds::ReadOnly) ? (bool)obj[MacroIds::ReadOnly] : true;
 
-			mm.getMacroChain()->getMacroControlData(mIndex)->addParameter(p, parameterIndex, pString, ValueToTextConverter::fromString(converterString), fr.rng, true, isCustomId, dontSendNotification);
+			mm.getMacroChain()->getMacroControlData(mIndex)->addParameter(p, parameterIndex, pString, ValueToTextConverter::fromString(converterString), fr.rng, readOnly, isCustomId, dontSendNotification);
 
 			auto pd = mm.getMacroChain()->getMacroControlData(mIndex)->getParameterWithProcessorAndIndex(p, parameterIndex);
 
@@ -10179,6 +10181,8 @@ var ScriptingObjects::ScriptedMacroHandler::getCallbackArg(int macroIndex, Proce
 			
 			RangeHelpers::storeDoubleRange(v, fr, RangeHelpers::IdSet::MidiAutomationFull);
 			RangeHelpers::storeDoubleRange(v, nr, RangeHelpers::IdSet::MidiAutomation);
+
+			obj->setProperty(MacroIds::ReadOnly, md->getParameter(i)->isReadOnly());
 		}
 	}
 	


### PR DESCRIPTION
I noticed when using `setMacroDataFromObject` all my knobs with macro assignments would be disabled. This commit fixes that problem by storing the ReadOnly flag when using getMacroDataObject.

getMacroDataObject now includes a ReadOnly property per connection. setMacroDataFromObject reads that property and passes it through to addParameter, defaulting to true when absent to preserve existing behaviour.