### PR TITLE
Add getNumChannels() to DspNetwork scripting API

### DIFF
--- a/hi_scripting/scripting/scriptnode/api/DspNetwork.cpp
+++ b/hi_scripting/scripting/scriptnode/api/DspNetwork.cpp
@@ -50,6 +50,7 @@ struct DspNetwork::Wrapper
 	API_METHOD_WRAPPER_2(DspNetwork, createFromJSON);
 	API_METHOD_WRAPPER_0(DspNetwork, undo);
 	API_METHOD_WRAPPER_2(DspNetwork, injectAndProbe);
+	API_METHOD_WRAPPER_0(DspNetwork, getNumChannels);
 	//API_VOID_METHOD_WRAPPER_0(DspNetwork, disconnectAll);
 	//API_VOID_METHOD_WRAPPER_3(DspNetwork, injectAfter);
 };
@@ -173,6 +174,7 @@ DspNetwork::DspNetwork(hise::ProcessorWithScriptingContent* p, ValueTree data_, 
 	ADD_API_METHOD_2(createFromJSON);
 	ADD_API_METHOD_0(undo);
 	ADD_API_METHOD_2(injectAndProbe);
+	ADD_API_METHOD_0(getNumChannels);
 	//ADD_API_METHOD_0(disconnectAll);
 	
 	selectionUpdater = new SelectionUpdater(*this);
@@ -259,6 +261,17 @@ void DspNetwork::setNumChannels(int newNumChannels)
         currentSpecs.numChannels = newNumChannels;
         prepareToPlay(currentSpecs.sampleRate, currentSpecs.blockSize);
     }
+}
+
+int DspNetwork::getNumChannels() const
+{
+	if (currentSpecs.numChannels > 0)
+		return currentSpecs.numChannels;
+
+	if (auto rp = dynamic_cast<const RoutableProcessor*>(getScriptProcessor()))
+		return rp->getMatrix().getNumSourceChannels();
+
+	return 0;
 }
 
 void DspNetwork::createAllNodesOnce()

--- a/hi_scripting/scripting/scriptnode/api/DspNetwork.h
+++ b/hi_scripting/scripting/scriptnode/api/DspNetwork.h
@@ -454,6 +454,8 @@ public:
 
 	void setNumChannels(int newNumChannels);
 
+	int getNumChannels() const;
+
 	void createAllNodesOnce();
 
 	Identifier getObjectName() const override { return "DspNetwork"; };


### PR DESCRIPTION
Exposes channel count to HiseScript at onInit time by first checking currentSpecs (set after prepareToPlay) and falling back to the parent processor's routing matrix (available after restoreFromValueTree). https://claude.ai/code/session_017gbpPhbbMurwCirBLwZXqN