### PR TITLE
fixed script FX/modulator getMetadata() not falling back to script pa…

### DIFF
--- a/hi_scripting/scripting/ScriptProcessorModules.h
+++ b/hi_scripting/scripting/ScriptProcessorModules.h
@@ -297,7 +297,9 @@ public:
 
 	ProcessorMetadata getMetadata() const override
 	{
-		return withDynamicParametersFromNetwork(createMetadata(), -1, 0);
+		if (getActiveNetwork() != nullptr)
+			return withDynamicParametersFromNetwork(createMetadata(), -1, 0);
+		return withDynamicScriptParameters(createMetadata());
 	}
 
 	enum Callback
@@ -470,7 +472,9 @@ public:
 
 	ProcessorMetadata getMetadata() const override
 	{
-		return withDynamicParametersFromNetwork(createMetadata(), -1, 0);
+		if (getActiveNetwork() != nullptr)
+			return withDynamicParametersFromNetwork(createMetadata(), -1, 0);
+		return withDynamicScriptParameters(createMetadata());
 	}
 
 	JavascriptEnvelopeModulator(MainController *mc, const String &id, int numVoices, Modulation::Mode m);
@@ -571,7 +575,9 @@ public:
 	ProcessorMetadata getMetadata() const override
 	{
 		auto numMods = HISE_GET_PREPROCESSOR(getMainController(), HISE_NUM_SCRIPTNODE_FX_MODS);
-		return withDynamicParametersFromNetwork(createMetadata(), numMods, 0);
+		if (getActiveNetwork() != nullptr)
+			return withDynamicParametersFromNetwork(createMetadata(), numMods, 0);
+		return withDynamicScriptParameters(createMetadata());
 	}
 
 	enum class Callback
@@ -685,7 +691,9 @@ public:
 	ProcessorMetadata getMetadata() const override
 	{
 		auto numMods = HISE_GET_PREPROCESSOR(getMainController(), HISE_NUM_POLYPHONIC_SCRIPTNODE_FX_MODS);
-		return withDynamicParametersFromNetwork(createMetadata(), numMods, 0);
+		if (getActiveNetwork() != nullptr)
+			return withDynamicParametersFromNetwork(createMetadata(), numMods, 0);
+		return withDynamicScriptParameters(createMetadata());
 	}
 
 	enum class Callback


### PR DESCRIPTION
…rameters

When JavascriptMasterEffect, JavascriptPolyphonicEffect, JavascriptTimeVariantModulator, or JavascriptEnvelopeModulator have no active DSP network (eg. using Libraries.load() with Content.addKnob()), getMetadata() returned empty parameters because withDynamicParametersFromNetwork only reads from the scriptnode network.

This broke parameter lookup via getParameterIndexForIdentifier() after commit 716d713 changed getParameterIndexFromProcessor() to use the cached metadata. UI component processor/parameter ID connections to script FX would resolve to -1 and stop working.

Fix: mirror the JavascriptMidiProcessor pattern - call withDynamicScriptParameters() when there is no active network, which reads parameters from the scripted content components instead.

https://claude.ai/code/session_018zS9gZLYMyacXyv6LBqM4F