### PR TITLE
Fix Shape FX mode dropdown not populating curve functions

### DIFF
--- a/hi_core/hi_modules/effects/editors/ShapeFXEditor.cpp
+++ b/hi_core/hi_modules/effects/editors/ShapeFXEditor.cpp
@@ -188,7 +188,7 @@ ShapeFXEditor::ShapeFXEditor (ProcessorEditor* p)
 		}
 	}
 
-	md.setup(*modeSelector, getProcessor(), ShapeFX::SpecialParameters::Mode);
+	modeSelector->setup(getProcessor(), ShapeFX::SpecialParameters::Mode, "Mode");
 	md.setup(*biasLeft, getProcessor(), ShapeFX::SpecialParameters::BiasLeft);
 	md.setup(*biasRight, getProcessor(), ShapeFX::SpecialParameters::BiasRight);
 	md.setup(*limitButton, getProcessor(), ShapeFX::SpecialParameters::LimitInput);


### PR DESCRIPTION
## Problem

The mode/function selector in the Shape FX editor renders empty - none of the
waveshaping curve functions appear in the dropdown.

## Cause

`ShapeFXEditor` populates the mode selector dynamically: it clears the combo
box and adds the available shaper functions in a loop
(`ShapeFXEditor.cpp`, the `modeSelector->addItem(...)` block).

The metadata migration in 1b11c788a then changed the setup call from
`modeSelector->setup(...)` to the generic `md.setup(*modeSelector, ...)`.
That generic helper (`ProcessorMetadata::setup(HiComboBox&, ...)`) calls
`comboBox.clear()` and repopulates from the parameter's *static* metadata
item list - which is empty for this parameter, since its items are added
dynamically by the editor. The result is that the curve items added just
above are discarded, leaving the dropdown empty.

## Fix

Use `HiComboBox::setup()` directly for the mode selector, preserving the
dynamically-added items. This matches the working pattern already used in
`PolyShapeFXEditor`.

## Alternative considered

This could instead be fixed inside `ProcessorMetadata::setup(HiComboBox&)`
by skipping the clear/repopulate when the parameter has no static item list
(or when the combo box already holds dynamically-added items). I went with
the minimal, localized revert to match the existing PolyShapeFX editor
pattern, but happy to take the metadata-level approach if you'd prefer that
direction for the metadata architecture.

## Note

The `HiComboBox::setup` form does not carry over the metadata-driven tooltip
that `md.setup` would set. The selector keeps its existing
`setTooltip("Choose the waveshape function.")` from the constructor, so there
is no visible tooltip regression.