### PR TITLE
PolyShape FX: add Mix parameter for parity with Shape FX

### DIFF
--- a/hi_core/hi_modules/effects/editors/PolyShapeFXEditor.cpp
+++ b/hi_core/hi_modules/effects/editors/PolyShapeFXEditor.cpp
@@ -75,6 +75,14 @@ PolyShapeFXEditor::PolyShapeFXEditor (ProcessorEditor* p)
     bias->addListener (this);
     bias->setSkewFactor (0.3);
 
+    addAndMakeVisible (mixSlider = new HiSlider ("Mix"));
+    mixSlider->setSliderStyle (Slider::RotaryHorizontalVerticalDrag);
+    mixSlider->setTextBoxStyle (Slider::TextBoxRight, true, 80, 20);
+    mixSlider->setColour (Slider::backgroundColourId, Colour (0x00000000));
+    mixSlider->setColour (Slider::thumbColourId, Colour (0x80666666));
+    mixSlider->setColour (Slider::textBoxTextColourId, Colours::white);
+    mixSlider->addListener (this);
+
     addAndMakeVisible (table2 = new TableEditor (getProcessor()->getMainController()->getControlUndoManager(), static_cast<PolyshapeFX*>(getProcessor())->getTable(1)));
     table2->setName ("new component");
 
@@ -104,6 +112,8 @@ PolyShapeFXEditor::PolyShapeFXEditor (ProcessorEditor* p)
 
 	md.setup(*bias, getProcessor(), PolyshapeFX::SpecialParameters::Bias);
 
+	md.setup(*mixSlider, getProcessor(), PolyshapeFX::SpecialParameters::Mix);
+
     //[/UserPreSize]
 
     setSize (800, 200);
@@ -126,6 +136,7 @@ PolyShapeFXEditor::~PolyShapeFXEditor()
     overSampling = nullptr;
     table = nullptr;
     bias = nullptr;
+    mixSlider = nullptr;
     table2 = nullptr;
 
 
@@ -174,7 +185,8 @@ void PolyShapeFXEditor::resized()
     driveSlider->setBounds ((getWidth() / 2) + -280 - (128 / 2), 24, 128, 48);
     overSampling->setBounds (((getWidth() / 2) + -280 - (128 / 2)) + 128 / 2 + 288 - (128 / 2), 8, 128, 32);
     table->setBounds ((getWidth() / 2) + 140 - ((getWidth() - 408) / 2), 48, getWidth() - 408, 128);
-    bias->setBounds ((getWidth() / 2) + -280 - (128 / 2), 88, 128, 48);
+    bias->setBounds ((getWidth() / 2) + -280 - (128 / 2), 76, 128, 48);
+    mixSlider->setBounds ((getWidth() / 2) + -280 - (128 / 2), 128, 128, 48);
     table2->setBounds ((getWidth() / 2) + 140 - ((getWidth() - 408) / 2), 48, getWidth() - 408, 128);
     //[UserResized] Add your own custom resize handling here..
     //[/UserResized]
@@ -209,6 +221,11 @@ void PolyShapeFXEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     {
         //[UserSliderCode_bias] -- add your slider handling code here..
         //[/UserSliderCode_bias]
+    }
+    else if (sliderThatWasMoved == mixSlider)
+    {
+        //[UserSliderCode_mixSlider] -- add your slider handling code here..
+        //[/UserSliderCode_mixSlider]
     }
 
     //[UsersliderValueChanged_Post]

--- a/hi_core/hi_modules/effects/editors/PolyShapeFXEditor.h
+++ b/hi_core/hi_modules/effects/editors/PolyShapeFXEditor.h
@@ -87,6 +87,7 @@ private:
     ScopedPointer<HiToggleButton> overSampling;
     ScopedPointer<TableEditor> table;
     ScopedPointer<HiSlider> bias;
+    ScopedPointer<HiSlider> mixSlider;
     ScopedPointer<TableEditor> table2;
 
 

--- a/hi_core/hi_modules/effects/fx/ShapeFX.cpp
+++ b/hi_core/hi_modules/effects/fx/ShapeFX.cpp
@@ -705,6 +705,11 @@ hise::ProcessorMetadata PolyshapeFX::createMetadata()
 			.withDescription("Adds a DC offset before the shaping function for asymmetric distortion")
 			.withSliderMode(HiSlider::NormalizedPercentage, {})
 			.withDefault(0.0f))
+		.withParameter(Par(Mix)
+			.withId("Mix")
+			.withDescription("Dry and wet balance where 0.0 is fully dry and 1.0 is fully wet")
+			.withSliderMode(HiSlider::NormalizedPercentage, Range(0.0, 1.0, 0.0))
+			.withDefault(1.0f))
 		.withModulation(Mod(DriveModulation)
 			.withId("Drive Modulation")
 			.withDescription("Audio-rate modulation of the drive amount")
@@ -765,6 +770,7 @@ float PolyshapeFX::getAttribute(int parameterIndex) const
 	case Mode: return (float)mode;
 	case Oversampling: return oversampling ? 1.0f : 0.0f;
 	case Bias: return bias;
+	case Mix: return mix;
 	default: break;
 	}
 
@@ -779,6 +785,7 @@ void PolyshapeFX::setInternalAttribute(int parameterIndex, float newValue)
 	case Mode: mode = (int)newValue; recalculateDisplayTable(); break;
 	case Oversampling: oversampling = newValue > 0.5f; break;
 	case Bias: bias = newValue; break;
+	case Mix: mix = newValue; break;
 	}
 }
 
@@ -793,6 +800,7 @@ void PolyshapeFX::restoreFromValueTree(const ValueTree &v)
 	loadAttribute(Mode, "Mode");
 	loadAttribute(Oversampling, "Oversampling");
 	loadAttribute(Bias, "Bias");
+	loadAttribute(Mix, "Mix");
 }
 
 juce::ValueTree PolyshapeFX::exportAsValueTree() const
@@ -806,6 +814,7 @@ juce::ValueTree PolyshapeFX::exportAsValueTree() const
 	saveAttribute(Mode, "Mode");
 	saveAttribute(Oversampling, "Oversampling");
 	saveAttribute(Bias, "Bias");
+	saveAttribute(Mix, "Mix");
 
 	return v;
 }
@@ -836,6 +845,8 @@ void PolyshapeFX::prepareToPlay(double sampleRate, int samplesPerBlock)
 	for (int i = 0; i < NUM_POLYPHONIC_VOICES; i++)
 	{
 		driveSmoothers[i].reset(sampleRate, 0.05);
+		mixSmoothers[i].reset(sampleRate, 0.04);
+		mixSmoothers[i].setValueWithoutSmoothing(mix);
 	}
 
 	for (auto os : oversamplers)
@@ -884,6 +895,25 @@ void PolyshapeFX::applyEffect(int voiceIndex, AudioSampleBuffer &b, int startSam
 
 	float* l = b.getWritePointer(0, startSample);
 	float* r = b.getWritePointer(1, startSample);
+
+	auto& mixSmoother = mixSmoothers[voiceIndex];
+	mixSmoother.setTargetValue(mix);
+
+	// Process the dry/wet blend whenever we are not fully wet, or while the
+	// smoother is still ramping toward a fully wet target (so the ramp completes).
+	const bool applyMix = mix < 1.0f || mixSmoother.isSmoothing();
+
+	float* dryL = nullptr;
+	float* dryR = nullptr;
+
+	if (applyMix)
+	{
+		dryL = (float*)alloca(sizeof(float) * numSamples);
+		dryR = (float*)alloca(sizeof(float) * numSamples);
+
+		FloatVectorOperations::copy(dryL, l, numSamples);
+		FloatVectorOperations::copy(dryR, r, numSamples);
+	}
 
 	if (mode == ShapeFX::ShapeMode::Sin || mode == ShapeFX::ShapeMode::TanCos)
 	{
@@ -943,7 +973,18 @@ void PolyshapeFX::applyEffect(int voiceIndex, AudioSampleBuffer &b, int startSam
 		FilterHelpers::RenderData renderData(b, startSample, numSamples);
 		dcRemovers[voiceIndex].render(renderData);
 	}
-		
+
+	if (applyMix)
+	{
+		for (int i = 0; i < numSamples; i++)
+		{
+			const float m = mixSmoother.getNextValue();
+			const float dryGain = 1.0f - m;
+
+			l[i] = l[i] * m + dryL[i] * dryGain;
+			r[i] = r[i] * m + dryR[i] * dryGain;
+		}
+	}
 
 }
 
@@ -984,6 +1025,7 @@ void PolyshapeFX::startVoice(int voiceIndex, const HiseEvent& e)
 	VoiceEffectProcessor::startVoice(voiceIndex, e);
 
 	driveSmoothers[voiceIndex].setValueWithoutSmoothing(drive-1.0f);
+	mixSmoothers[voiceIndex].setValueWithoutSmoothing(mix);
 
 }
 

--- a/hi_core/hi_modules/effects/fx/ShapeFX.h
+++ b/hi_core/hi_modules/effects/fx/ShapeFX.h
@@ -374,6 +374,7 @@ public:
 		Mode,
 		Oversampling,
 		Bias,
+		Mix,
 		numParameters
 	};
 
@@ -486,6 +487,7 @@ private:
 	float drive = 1.0f;
 
 	LinearSmoothedValue<float> driveSmoothers[NUM_POLYPHONIC_VOICES];
+	LinearSmoothedValue<float> mixSmoothers[NUM_POLYPHONIC_VOICES];
 
 	int mode = ShapeFX::ShapeMode::Linear;
 	bool oversampling = false;
@@ -499,6 +501,7 @@ private:
 	
 
 	float bias = 0.0f;
+	float mix = 1.0f;
 
 	float displayTable[SAMPLE_LOOKUP_TABLE_SIZE];
 	float unusedTable[SAMPLE_LOOKUP_TABLE_SIZE];


### PR DESCRIPTION
## Summary

Small parity fix: adds a wet/dry **Mix** control to PolyShapeFX. ShapeFX
already has a Mix parameter; PolyShapeFX didn't, so this just brings the
polyphonic variant in line with its sibling. No new concepts - same
parameter, same NormalizedPercentage range, default 1.0 (fully wet).

I'm aware the waveshaper modules are considered somewhat legacy and that
this is all doable in Scriptnode - so no worries at all if you'd rather
not carry it. Putting it up in case the parity is useful for existing
projects that use the module directly.

## Details

- New `Mix` parameter (NormalizedPercentage, default 1.0), appended to the
  `SpecialParameters` enum so existing parameter indices are unchanged.
- Saved/restored by name (`loadAttribute(Mix, "Mix")`), so older presets
  load fine and fall back to the fully-wet default.
- The blend uses per-voice `LinearSmoothedValue` smoothers (mirroring the
  existing `driveSmoothers`) so automation ramps without zipper noise.
- The dry capture and blend are skipped entirely while fully wet and
  settled, so the default case costs nothing.
- Editor exposes the knob in the left column (Drive / Bias / Mix).

## Note on implementation

The dry-signal capture uses `alloca` per block, matching the existing
`scratch` buffer already used in the same `applyEffect` function. I
considered a preallocated member buffer (as mono ShapeFX does for its Mix)
but kept it consistent with PolyShapeFX's own local idiom and minimal in
footprint. Happy to switch to a member buffer if you'd prefer.