### PR TITLE
Fix saved MIDI inputs not re-applied on standalone launch

### DIFF
--- a/hi_core/hi_core/StandaloneProcessor.cpp
+++ b/hi_core/hi_core/StandaloneProcessor.cpp
@@ -343,27 +343,23 @@ void AudioProcessorDriver::initialiseAudioDriver(XmlElement *deviceData)
 
 	getSettingsObject().initialiseAudioDriverData();
 
-	// Apply saved MIDI input settings to ensure MIDI inputs are properly connected
-	// This fixes the issue where MIDI keyboards appear selected but don't work until manually toggled
+	// Apply the saved MIDI input enabled-state on launch. getSetting(Midi::MidiInput) runs the
+	// value through a generic Yes/No coercion (HiseSettings.cpp getSetting), so the bitmask comes
+	// back as a bool ("1"->true, "0"->false) or a string ("3") - never an int64. The old
+	// isInt64() guard therefore always failed and the restore never ran, leaving the device
+	// disabled even though its settings checkbox read as ticked. Coerce with (int64) the same way
+	// settingWasChanged does (HiseSettings.cpp:1605): (int64)var(true)=1, (int64)var("3")=3 etc.
+	// At this point the port reads as disabled, so applying the saved state is a genuine enable.
 	auto midiInputSetting = getSettingsObject().getSetting(HiseSettings::Midi::MidiInput);
-	if (midiInputSetting.isInt64())
+	auto mc = dynamic_cast<MainController*>(this);
+
+	if (mc != nullptr && !mc->isFlakyThreadingAllowed())
 	{
 		auto state = BigInteger((int64)midiInputSetting);
-		auto mc = dynamic_cast<MainController*>(this);
+		auto midiNames = MidiInput::getDevices();
 
-		StringArray midiNames;
-		if (mc != nullptr && !mc->isFlakyThreadingAllowed())
-		{
-			midiNames = MidiInput::getDevices();
-		}
-
-		if (midiNames.size() > 0)
-		{
-			for (int i = 0; i < midiNames.size(); i++)
-			{
-				toggleMidiInput(midiNames[i], state[i]);
-			}
-		}
+		for (int i = 0; i < midiNames.size(); i++)
+			toggleMidiInput(midiNames[i], state[i]);
 	}
 }
 


### PR DESCRIPTION
## Problem

A MIDI input that is enabled in the standalone audio settings shows as ticked after a relaunch, but does not actually stream events until it is manually unticked and re-ticked. This matches the reports in #691 and #716.

## Cause

`AudioProcessorDriver::initialiseAudioDriver()` already tries to re-apply the saved `HiseSettings::Midi::MidiInput` bitmask on launch, but it guards the work on `var::isInt64()`:

```cpp
auto midiInputSetting = getSettingsObject().getSetting(HiseSettings::Midi::MidiInput);
if (midiInputSetting.isInt64())   // never true for this setting
{
    ...
}
```

`getSetting(Midi::MidiInput)` runs the stored value through a generic Yes/No coercion (`HiseSettings::Data::getSetting`), so it comes back as a `bool` (`"1"` -> true, `"0"` -> false) or a `String` (`"3"`), never an `int64`. The guard is therefore always false and the re-apply never runs. On launch the checkbox reflects the saved value, but the underlying port is never enabled, so it stays silent until a manual untick/re-tick triggers `settingWasChanged()`.

## Fix

Drop the `isInt64()` guard and coerce with `(int64)` the same way `settingWasChanged()` already does. That recovers the correct bitmask in every case (`(int64)var(true) == 1`, `(int64)var("3") == 3`, etc.). At that point the port reads as disabled, so applying the saved state is a genuine enable that opens it.

## Scope / testing

- Standalone / IDE path only (`AudioProcessorDriver`); exported plugins are not covered by this change.
- Tested manually: with a hardware controller enabled in settings, the input now streams immediately on launch without the manual untick/re-tick workaround.

Addresses #691 and #716.

Generated with Claude Code (https://claude.com/claude-code)
