### PR TITLE
Fix dead extra_mod modulation in exported hardcoded FX on cold load

### DIFF
--- a/hi_core/hi_modules/hardcoded/HardcodedModules.cpp
+++ b/hi_core/hi_modules/hardcoded/HardcodedModules.cpp
@@ -212,10 +212,10 @@ void HardcodedMasterFX::prepareToPlay(double sampleRate, int samplesPerBlock)
 
 	SimpleReadWriteLock::ScopedReadLock sl(lock);
 
+	extraMods.prepareToPlay(sampleRate, samplesPerBlock);
+
 	auto ok = prepareOpaqueNode(opaqueNode.get());
 	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
-
-	extraMods.prepareToPlay(sampleRate, samplesPerBlock);
 }
 
 juce::Path HardcodedMasterFX::getSpecialSymbol() const
@@ -420,11 +420,11 @@ void HardcodedPolyphonicFX::prepareToPlay(double sampleRate, int samplesPerBlock
 
 	VoiceEffectProcessor::prepareToPlay(sampleRate, samplesPerBlock);
 	SimpleReadWriteLock::ScopedReadLock sl(lock);
-	auto ok = prepareOpaqueNode(opaqueNode.get());
-
-	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
 
 	extraModSources.prepareToPlay(sampleRate, samplesPerBlock);
+
+	auto ok = prepareOpaqueNode(opaqueNode.get());
+	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
 }
 
 void HardcodedPolyphonicFX::startVoice(int voiceIndex, const HiseEvent& e)


### PR DESCRIPTION
Reorder HardcodedMasterFX::prepareToPlay and HardcodedPolyphonicFX::prepareToPlay to deliver the runtime-target signal (extraMods.prepareToPlay) before calling prepareOpaqueNode.

prepareOpaqueNode ends with the opaque node's reset(), which captures each extra_mod node's eventData read pointer from the currently delivered SignalSource. On a cold frontend load the runtime-target connection is established during preset restore at sampleRate==0, so an empty placeholder SignalSource is delivered. Preparing the node first pinned eventData to that dead pointer, and onValue() only refreshes signal/ok/sr, never re-capturing eventData. The result was no modulation reaching the network parameter in exported plugins (matrix modulator value and LFO both dead) while the IDE worked, since there the connection is made with audio already running.

Delivering the signal first matches the order setEffect() already uses and lets reset() capture the live eventData.