### PR TITLE
fixed null-parent crash when assigning an exclusive mod source before the slider is shown

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -1821,6 +1821,13 @@ struct HiSlider::HoverPopup: public Component,
 void HiSlider::ModUpdater::onExclusiveSourceSelection(ModUpdater& mu, int index)
 {
 	auto& slider = mu.parent;
+
+	// The hover popup attaches to the slider's parent component, so don't build it if the slider
+	// isn't in a component hierarchy yet (e.g. during preset load) - that would dereference a null
+	// parent in the HoverPopup constructor.
+	if(slider.getParentComponent() == nullptr)
+		return;
+
 	auto matrixData = MatrixIds::Helpers::getMatrixDataFromGlobalContainer(slider.getProcessor()->getMainController());
 	auto targetId = slider.getProcessor()->getModulationTargetId(slider.getParameter());
 	auto hasConnection = MatrixIds::Helpers::getConnection(matrixData, index, targetId).isValid();


### PR DESCRIPTION
What
  ▎ HiSlider::ModUpdater::onExclusiveSourceSelection builds the modulation hover
  ▎ popup unconditionally. If it runs while the target slider isn't in a 
  ▎ component hierarchy yet (e.g. during preset load), the HoverPopup 
  ▎ constructor dereferences a null parent 
  ▎ (parentToUse->getIndexOfChildComponent(parent)) and crashes. This guards 
  ▎ against it.
  ▎
  ▎ Precedent
  ▎ This exact null-parent crash was already fixed in bac1fca58 ("fixed a few 
  ▎ mod-matrix UI crashes"), which wrapped the parenting in if(auto pp = 
  ▎ parent->getParentComponent()) { … }. The alwaysOnTop refactor in 678f40e1a 
  ▎ rewrote that constructor to use 
  ▎ parentToUse->getIndexOfChildComponent(parent) and dropped the check, 
  ▎ reintroducing the crash. This restores the guard, placed in the caller since
  ▎ the refactored constructor uses the parent in several spots.
  ▎
  ▎ Risk
  ▎ - Type: null-pointer guard (UI), no behaviour change on the normal path.
  ▎ - Affected: only the no-parent case (previously a crash; now a no-op — the 
  ▎ dragger appears once the slider is in the UI and the source is reselected). 
  ▎ No parameter indices, API signatures, serialization, or DSP touched.
  ▎ - Evidence: restores the null-check from bac1fca58, removed by 678f40e1a.