### PR TITLE
fixed mod matrix aux selector being hidden on connections without a source

### DIFF
--- a/hi_core/hi_modules/modulators/editors/MatrixModulatorComponents.cpp
+++ b/hi_core/hi_modules/modulators/editors/MatrixModulatorComponents.cpp
@@ -536,8 +536,6 @@ void MatrixContent::Row::updateValue(const Identifier& id, const var& newValue)
 			auto isEnabled = (int)newValue != -1;
 			intensitySlider.setEnabled(isEnabled);
 			auxSelector.setEnabled(isEnabled);
-			auto plotterIndex = 5;
-			setFlexChildVisibility(plotterIndex, false, !isEnabled);
 			rebuildLayout();
 		}
 		else if (id == MatrixIds::TargetId)


### PR DESCRIPTION
What — In the modulation matrix editor, a connection row's aux-source
  ▎ dropdown is hidden whenever the row has no primary source, reappearing only
  ▎ once a source is picked.
  ▎
  ▎ Cause — MatrixContent::Row::updateValue's SourceIndex branch hides flex
  ▎ child index 5 (meaning to hide the plotter), but the children are 0 source,
  ▎ 1 target, 2 mode, 3 inverted, 4 intensity, 5 aux selector, 6 aux intensity,
  ▎ 7 plotter, 8 delete — so it hides the aux selector, and the plotter (index
  ▎ 7) is never actually hidden.
  ▎
  ▎ Fix — Remove the incorrect hide. The aux selector stays visible (still
  ▎ disabled until a source is chosen, via the adjacent auxSelector.setEnabled),
  ▎ and the plotter's behaviour is unchanged.
  ▎
  ▎ Risk — UI/editor fix, 2-line removal. Only affects the aux-selector
  ▎ visibility on source-less rows; no parameter indices, API signatures,
  ▎ serialization, or DSP touched. (If hiding the plotter on source-less rows is
  ▎ actually wanted, the index should instead point at the plotter — happy to
  ▎ do that variant if preferred.)
