### PR TITLE
fixed scriptnode reverb width parameter writing to the damping field

### DIFF
--- a/hi_dsp_library/dsp_nodes/FXNodes.cpp
+++ b/hi_dsp_library/dsp_nodes/FXNodes.cpp
@@ -93,7 +93,7 @@ void reverb::setDamping(double newDamping)
 void reverb::setWidth(double width)
 {
 	auto p = r.getParameters();
-	p.damping = jlimit(0.0f, 1.0f, (float)width);
+	p.width = jlimit(0.0f, 1.0f, (float)width);
 	r.setParameters(p);
 }
 


### PR DESCRIPTION
What — The scriptnode reverb node's Width parameter changes the damping 
  ▎ instead of the stereo width; width is never updated.
  ▎
  ▎ Cause — reverb::setWidth assigns to the wrong field: p.damping = jlimit(…, 
  ▎ (float)width) — should be p.width.
  ▎
  ▎ Fix — Assign to p.width.
  ▎
  ▎ Risk — 1-line DSP parameter fix. The Width control now sets stereo width and
  ▎ no longer alters damping (damping is still set correctly by setDamping). No
  ▎ API, serialization, or index changes.
