### PR TITLE
fixed exclusive modulation dragger not being removed when its connection is deleted

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -1252,8 +1252,8 @@ void HiSlider::mouseDoubleClick(const MouseEvent &e)
 }
 
 struct HiSlider::HoverPopup: public Component,
-							 public PooledUIUpdater::SimpleTimer
-	
+							 public PooledUIUpdater::SimpleTimer,
+							 public juce::ValueTree::Listener
 {
 	HoverPopup(HiSlider& slider, 
 	           const ValueTree& matrixData_, 
@@ -1349,6 +1349,11 @@ struct HiSlider::HoverPopup: public Component,
 			}, false);
 		}
 
+		// In exclusive mode the dragger is persistent, so watch the matrix data and
+		// tear it down when its connection is removed (it isn't driven by the source broadcaster).
+		if(exclusiveMode)
+			matrixData.addListener(this);
+
 		rebuild();
 	}
 
@@ -1362,6 +1367,9 @@ struct HiSlider::HoverPopup: public Component,
 		{
 			gc->currentMatrixSourceBroadcaster.removeListener(*this);
 		}
+
+		if(exclusiveMode)
+			matrixData.removeListener(this);
 
 		//jassert(!keepAlive);
 	}
@@ -1671,6 +1679,18 @@ struct HiSlider::HoverPopup: public Component,
 		currentHoverIndex = -1;
 		newList.swapWith(dragAreas);
 		rebuild();
+	}
+
+	void valueTreeChildRemoved(ValueTree&, ValueTree& removedChild, int) override
+	{
+		// The exclusive dragger represents one connection; close it when that
+		// connection's row is removed from the matrix (any removal path).
+		if(exclusiveMode &&
+		   removedChild[MatrixIds::TargetId].toString() == targetId &&
+		   sourceIndexes.contains((int)removedChild[MatrixIds::SourceIndex]))
+		{
+			clear();
+		}
 	}
 
 	void showEditor()


### PR DESCRIPTION
  ▎ What — With an exclusive modulation source selected (the persistent dragger 
  ▎ showing on a knob), removing that connection from the matrix leaves the 
  ▎ dragger on screen — it never disappears.
  ▎
  ▎ Cause — The exclusive dragger (HoverPopup) is only torn down by 
  ▎ onExclusiveSourceSelection, which fires when the selected source changes 
  ▎ (via currentMatrixSourceBroadcaster). Removing a connection doesn't fire it,
  ▎ so the popup lingers.
  ▎
  ▎ Fix — Make the HoverPopup a ValueTree::Listener on the matrix data in 
  ▎ exclusive mode, and have it close itself (async clear()) when its own 
  ▎ connection row is removed — matched by target id and source index so it 
  ▎ ignores other rows. Registered in the ctor, removed in the dtor.
  ▎
  ▎ Risk — UI fix, ~22 lines. Only affects the exclusive-mode dragger lifecycle 
  ▎ (now closes when its connection is deleted instead of lingering). clear() 
  ▎ defers destruction via the message manager, so it's safe from the listener 
  ▎ callback. No parameter indices, API signatures, serialization, or DSP 
  ▎ touched.