### PR TITLE
fixed modulation connection not engaging when the source is set after the target row

### DIFF
--- a/hi_core/hi_modules/modulators/editors/MatrixModulatorComponents.cpp
+++ b/hi_core/hi_modules/modulators/editors/MatrixModulatorComponents.cpp
@@ -625,6 +625,19 @@ void MatrixContent::Row::comboBoxChanged(ComboBox* cb)
 	auto id = Identifier(cb->getName());
 	auto idx = cb->getSelectedItemIndex();
 	data.setProperty(id, comboBoxIndexToValue(id, idx), um);
+
+	// Re-assert the selected exclusive source so target sliders refresh their modulation
+	// dragger when a connection's source or target changes in the matrix.
+	if(id == MatrixIds::SourceIndex || id == MatrixIds::TargetId)
+	{
+		if(auto gc = ProcessorHelpers::getFirstProcessorWithType<GlobalModulatorContainer>(getMainController()->getMainSynthChain()))
+		{
+			auto selectedIndex = gc->getExclusiveMatrixSource();
+
+			if(selectedIndex != -1)
+				gc->setExlusiveMatrixSource(selectedIndex, sendNotificationSync);
+		}
+	}
 }
 
 void MatrixContent::Row::sliderValueChanged(Slider* slider)

--- a/hi_scripting/scripting/api/ScriptModulationMatrix.cpp
+++ b/hi_scripting/scripting/api/ScriptModulationMatrix.cpp
@@ -246,8 +246,8 @@ ScriptingApi::Content::ScriptSlider::MatrixCableConnection::MatrixCableConnectio
 	                               valuetree::AsyncMode::Synchronously, 
 	                               BIND_MEMBER_FUNCTION_2(MatrixCableConnection::onUpdate));
 
-	sourceTargetListener.setCallback(matrixData, 
-	                                 { MatrixIds::TargetId }, 
+	sourceTargetListener.setCallback(matrixData,
+	                                 { MatrixIds::TargetId, MatrixIds::SourceIndex },
 	                                 valuetree::AsyncMode::Asynchronously,
 	                                 BIND_MEMBER_FUNCTION_2(MatrixCableConnection::onSourceTargetChange));
 }
@@ -395,6 +395,16 @@ void ScriptingApi::Content::ScriptSlider::MatrixCableConnection::onSourceTargetC
 {
 	auto isTarget = MatrixIds::Helpers::matchesTarget(v, targetId);
 
+	if(id == MatrixIds::SourceIndex)
+	{
+		// When the source becomes valid on a row that already targets this slider, create the
+		// connection (handles the target-selected-first case). addConnection is idempotent.
+		if(isTarget && isPositiveAndBelow((int)v[MatrixIds::SourceIndex], sourceNames.size()))
+			addConnection(v);
+
+		return;
+	}
+
 	if(isTarget)
 		addConnection(v);
 	else
@@ -403,6 +413,11 @@ void ScriptingApi::Content::ScriptSlider::MatrixCableConnection::onSourceTargetC
 
 void ScriptingApi::Content::ScriptSlider::MatrixCableConnection::addConnection(const ValueTree& v)
 {
+	// Don't create a duplicate Target for a connection row that's already tracked.
+	for(auto t: allTargets)
+		if(t->propertyListener.isRegisteredTo(v))
+			return;
+
 	auto idx = (int)v[MatrixIds::SourceIndex];
 
 	if(isPositiveAndBelow(idx, sourceNames.size()))


### PR DESCRIPTION
  ▎ What — Creating a modulation connection in the matrix by choosing the target
  ▎ first and then the source: the modulation doesn't engage (knob doesn't show
  ▎ as modulated, no signal) until reload, and the exclusive-source dragger
  ▎ only appears after a second click on the source button.
  ▎
  ▎ Cause — (1) The per-slider MatrixCableConnection only listens to TargetId. A
  ▎ new row is created with the target set but SourceIndex == -1; assigning the
  ▎ source later changes SourceIndex on the existing row, which fires nothing,
  ▎ so the Target is never created. (2) Changing a row's source/target in the
  ▎ editor doesn't refresh the exclusive-source dragger.
  ▎
  ▎ Fix — (1) sourceTargetListener also watches SourceIndex; when the source
  ▎ becomes valid for a matching target it creates the connection, and
  ▎ addConnection is made idempotent (skips if a Target already tracks the row)
  ▎ so the new path can't duplicate. (2) comboBoxChanged re-asserts the selected
  ▎ exclusive source so the dragger refreshes.
  ▎
  ▎ Risk — Modulation-matrix bug fix (script-side cable connection + matrix
  ▎ editor), ~30 lines. Connections created target-first now engage immediately;
  ▎ dragger refreshes on matrix edits. No parameter indices, API signatures,
  ▎ serialization, or DSP touched.