### PR TITLE
avoid rebuilding the exclusive modulation dragger when the same source is reselected

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -1821,6 +1821,13 @@ struct HiSlider::HoverPopup: public Component,
 void HiSlider::ModUpdater::onExclusiveSourceSelection(ModUpdater& mu, int index)
 {
 	auto& slider = mu.parent;
+
+	// If this slider already shows the dragger for this exclusive source, leave it untouched.
+	// Reselecting the same source would otherwise rebuild the popup and re-insert it into the
+	// parent's child list, creeping it up the z-order on every reselect.
+	if(index >= 0 && mu.currentExlusiveIndex == index && slider.currentHoverPopup != nullptr)
+		return;
+
 	auto matrixData = MatrixIds::Helpers::getMatrixDataFromGlobalContainer(slider.getProcessor()->getMainController());
 	auto targetId = slider.getProcessor()->getModulationTargetId(slider.getParameter());
 	auto hasConnection = MatrixIds::Helpers::getConnection(matrixData, index, targetId).isValid();


### PR DESCRIPTION
  ▎ What — onExclusiveSourceSelection rebuilds the exclusive-mode dragger 
  ▎ (HoverPopup) every time it runs, including when the currently-selected 
  ▎ source is reselected unchanged.
  ▎
  ▎ Problem — Besides being wasteful, each rebuild re-inserts the popup into its
  ▎ parent's child list, so it creeps up the z-order on every reselect, 
  ▎ eventually sitting over unrelated UI. (Distinct from the initial-placement 
  ▎ fix in 6de7c97b5; this is about repeated reselects.)
  ▎
  ▎ Fix — Skip the rebuild when the dragger for this exclusive source is already
  ▎ shown.
  ▎
  ▎ Risk — 7-line early-return guard. Reselecting the same source is now a no-op
  ▎ instead of a rebuild; selecting a different source / removing the 
  ▎ connection are unchanged. The popup reads live data in paint(), so no stale 
  ▎ display. No indices, API, serialization, or DSP touched.