### PR TITLE
improved table drag point handle cursors and hid redundant mid points

### DIFF
--- a/hi_tools/hi_standalone_components/TableEditor.cpp
+++ b/hi_tools/hi_standalone_components/TableEditor.cpp
@@ -90,7 +90,7 @@ void TableEditor::refreshGraph()
 
 	mid_points.clear();
 
-	if (dragProperties.midPointSize > 0)
+	if (dragProperties.midPointSize > 0 && (drag_points.size() > 2 || !dragProperties.syncStartEnd))
 	{
 		auto width = (float)a.getWidth();
 		float w = (float)dragProperties.midPointSize;
@@ -733,7 +733,7 @@ void TableEditor::mouseMove(const MouseEvent& e)
 {
 	hoveredMidPointIndex = getDraggedMidPointIndex(e);
 
-	setMouseCursor(hoveredMidPointIndex != -1 ? MouseCursor::DraggingHandCursor : MouseCursor::NormalCursor);
+	setMouseCursor(hoveredMidPointIndex != -1 ? MouseCursor::UpDownResizeCursor : MouseCursor::NormalCursor);
 
 	if (e.eventComponent != this)
 	{
@@ -1351,12 +1351,14 @@ void TableEditor::DragPoint::mouseEnter(const MouseEvent& mouseEvent)
 	if (auto te = findParentComponentOfClass<TableEditor>())
 		te->pointAreaBetweenMouse = {};
 
+	setMouseCursor(MouseCursor::CrosshairCursor);
 	over = true;
 	repaint();
 }
 
 void TableEditor::DragPoint::mouseExit(const MouseEvent& mouseEvent)
 {
+	setMouseCursor(MouseCursor::NormalCursor);
 	over = false;
 	repaint();
 }


### PR DESCRIPTION
  ▎ What — Two small table-editor UX tweaks: (1) crosshair cursor over a draggable
  ▎ table point and an up/down resize cursor over a mid point (was a generic
  ▎ dragging-hand cursor); (2) don't create a mid point between the two end points
  ▎ when the table has only two points and syncStartEnd is on (redundant).
  ▎ Risk — 6-line table-editor UI change. Affects cursor feedback over handles +
  ▎ one redundant mid point in the 2-point/syncStartEnd case. No
  ▎ API/serialization/DSP. (Happy to split into two PRs — cursors vs mid-point
  ▎ visibility — if you'd prefer.)