### PR TITLE
fixed lfo phase offset not applying to the running lfo until the next cycle

### DIFF
--- a/hi_core/hi_modules/modulators/mods/LFOModulator.cpp
+++ b/hi_core/hi_modules/modulators/mods/LFOModulator.cpp
@@ -376,9 +376,22 @@ void LfoModulator::setInternalAttribute (int parameter_index, float newValue)
 		loopEnabled = newValue > 0.5f;
 		break;
 	case Parameters::PhaseOffset:
+	{
+		double phaseChange = (double)newValue - phaseOffset;
 		phaseOffset = (double)newValue;
+
+		uptime += phaseChange * (double)SAMPLE_LOOKUP_TABLE_SIZE;
+
+		while (uptime >= (double)SAMPLE_LOOKUP_TABLE_SIZE)
+			uptime -= (double)SAMPLE_LOOKUP_TABLE_SIZE;
+		while (uptime < 0.0)
+			uptime += (double)SAMPLE_LOOKUP_TABLE_SIZE;
+
+		lastCycleIndex = (int)floor(uptime * (1.0 / (double)SAMPLE_LOOKUP_TABLE_SIZE));
+
 		triggerWaveformUpdate();
 		break;
+	}
 	case Parameters::SyncToMasterClock:
 	{
 		auto shouldSync = newValue > 0.5f;


### PR DESCRIPTION
  ▎ What — Changing an LFO's Phase Offset while it's running has no effect until
  ▎ the next cycle.
  ▎ Cause — LfoModulator::setInternalAttribute(PhaseOffset) only updates
  ▎ phaseOffset (applied at the start of the next cycle); the running uptime isn't
  ▎ touched.
  ▎ Fix — Also nudge the running uptime by the phase delta (wrapped to table size)
  ▎ and update lastCycleIndex, so it takes effect immediately.
  ▎ Risk — 13-line LFO behaviour fix, PhaseOffset only. Live phase changes now
  ▎ apply immediately; start-of-cycle behaviour and other params unchanged. No
  ▎ API/serialization/index changes.