### PR TITLE
added a LinearAbsolute range preset to the modulation matrix

### DIFF
--- a/hi_core/hi_dsp/modules/ModulationMatrixTools.cpp
+++ b/hi_core/hi_dsp/modules/ModulationMatrixTools.cpp
@@ -250,6 +250,7 @@ StringArray Helpers::getRangePresetNames()
 		"FilterFreq",
 		"FilterFreqLog",
 		"Stereo",
+		"LinearAbsolute",
 	};
 
 	return names;
@@ -332,6 +333,10 @@ Helpers::Properties::RangeData Helpers::getRangePreset(RangePresets p)
 		rd.outputRange = { 0.0, 1.0 };
 		rd.converter = "Pan";
 		rd.useMidPositionAsZero = true;
+		break;
+	case RangePresets::LinearAbsolute:
+		rd.converter = "";
+		break;
 	case RangePresets::numPresets:
 		break;
 	default: ;

--- a/hi_core/hi_dsp/modules/ModulationMatrixTools.h
+++ b/hi_core/hi_dsp/modules/ModulationMatrixTools.h
@@ -89,6 +89,7 @@ struct Helpers
 		FilterFreq,
 		FilterFreqLog,
 		Stereo,
+		LinearAbsolute,
 		numPresets
 	};
 


### PR DESCRIPTION
  ▎ What — Adds a LinearAbsolute range preset to the modulation-matrix range
  ▎ presets (a linear 0..1 range with no value converter).
  ▎ Details — Appended LinearAbsolute to the RangePresets enum and the
  ▎ getRangePresetNames list (appended at the end, so existing preset indices are
  ▎ unchanged → backwards-compatible with saved presets); added its getRangePreset 
  ▎ case (empty converter); added an explicit break; to the Stereo case (required
  ▎ so it no longer falls through into the new case).
  ▎ Risk — Additive feature, 6 lines. New selectable preset; enum appended so no
  ▎ stored index shifts. No API signature changes, DSP, or reordering.
