### PR TITLE
make table point handle cursors optional

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1582,6 +1582,12 @@ ScriptCreatedComponentWrapper(content, index)
 	table->dragProperties.addListener(*t, [](TableEditor& te, const var& p)
 	{
 		te.setMouseDragProperties(p);
+
+		if (p.hasProperty("dragPointCursor"))
+			te.setDragPointCursor(ApiHelpers::getMouseCursorFromString(p["dragPointCursor"].toString(), nullptr));
+
+		if (p.hasProperty("midPointCursor"))
+			te.setMidPointCursor(ApiHelpers::getMouseCursorFromString(p["midPointCursor"].toString(), nullptr));
 	});
 
 	table->getSourceWatcher().addSourceListener(this);
@@ -1635,6 +1641,16 @@ void ScriptCreatedComponentWrappers::TableWrapper::updateComponent(int propertyI
 		PROPERTY_CASE::ScriptComponent::itemColour2: t->setColour(TableEditor::ColourIds::lineColour, GET_OBJECT_COLOUR(itemColour2)); t->repaint(); break;
 		PROPERTY_CASE::ScriptComponent::tooltip: t->setTooltip(GET_SCRIPT_PROPERTY(tooltip)); break;
 		PROPERTY_CASE::ScriptTable::Properties::customColours: t->setUseFlatDesign(newValue); break;
+		// "ParentCursor" is the no-override default: leave the cursor to setMouseHandlingProperties (script)
+		// or the TableEditor's built-in default instead of clobbering it from the property editor.
+		PROPERTY_CASE::ScriptTable::Properties::dragPointCursor:
+			if (newValue.toString() != "ParentCursor")
+				t->setDragPointCursor(ApiHelpers::getMouseCursorFromString(newValue.toString(), nullptr));
+			break;
+		PROPERTY_CASE::ScriptTable::Properties::midPointCursor:
+			if (newValue.toString() != "ParentCursor")
+				t->setMidPointCursor(ApiHelpers::getMouseCursorFromString(newValue.toString(), nullptr));
+			break;
 		PROPERTY_CASE::ScriptComponent::parameterId: t->setSnapValues(st->snapValues);
 													  break;
 	default:

--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -3357,6 +3357,14 @@ void ScriptingApi::Content::ScriptTable::handleDefaultDeactivatedProperties()
 	deactivatedProperties.addIfNotAlreadyThere(getIdFor(ScriptComponent::Properties::textColour));
 }
 
+StringArray ScriptingApi::Content::ScriptTable::getOptionsFor(const Identifier &id)
+{
+	if (id == getIdFor(dragPointCursor) || id == getIdFor(midPointCursor))
+		return ApiHelpers::getMouseCursorNames();
+
+	return ComplexDataScriptComponent::getOptionsFor(id);
+}
+
 struct ScriptingApi::Content::ScriptTable::Wrapper
 {
 	API_VOID_METHOD_WRAPPER_0(ScriptTable, reset);
@@ -3376,6 +3384,8 @@ ComplexDataScriptComponent(base, name, snex::ExternalData::DataType::Table)
 {
 	propertyIds.add("tableIndex");
 	propertyIds.add("customColours"); ADD_TO_TYPE_SELECTOR(SelectorTypes::ToggleSelector);
+	propertyIds.add("dragPointCursor"); ADD_TO_TYPE_SELECTOR(SelectorTypes::ChoiceSelector);
+	propertyIds.add("midPointCursor"); ADD_TO_TYPE_SELECTOR(SelectorTypes::ChoiceSelector);
 
 	setDefaultValue(ScriptComponent::Properties::x, x);
 	setDefaultValue(ScriptComponent::Properties::y, y);
@@ -3383,6 +3393,8 @@ ComplexDataScriptComponent(base, name, snex::ExternalData::DataType::Table)
 	setDefaultValue(ScriptComponent::Properties::height, 50);
 	setDefaultValue(ScriptTable::Properties::TableIndex, 0);
 	setDefaultValue(ScriptTable::Properties::customColours, 0);
+	setDefaultValue(ScriptTable::Properties::dragPointCursor, "ParentCursor");
+	setDefaultValue(ScriptTable::Properties::midPointCursor, "ParentCursor");
 
 	handleDefaultDeactivatedProperties();
 	

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -1471,6 +1471,8 @@ public:
 		{
 			TableIndex = ScriptComponent::Properties::numProperties,
 			customColours,
+			dragPointCursor,
+			midPointCursor,
 			numProperties
 		};
 
@@ -1486,6 +1488,7 @@ public:
 		virtual Identifier 	getObjectName() const override { return getStaticObjectName(); }
 		ScriptCreatedComponentWrapper *createComponentWrapper(ScriptContentComponent *content, int index) override;
 		void handleDefaultDeactivatedProperties() override;
+		StringArray getOptionsFor(const Identifier &id) override;
 
 		void resetValueToDefault() override;
 

--- a/hi_tools/hi_standalone_components/TableEditor.cpp
+++ b/hi_tools/hi_standalone_components/TableEditor.cpp
@@ -90,7 +90,7 @@ void TableEditor::refreshGraph()
 
 	mid_points.clear();
 
-	if (dragProperties.midPointSize > 0)
+	if (dragProperties.midPointSize > 0 && (drag_points.size() > 2 || !dragProperties.syncStartEnd))
 	{
 		auto width = (float)a.getWidth();
 		float w = (float)dragProperties.midPointSize;
@@ -733,7 +733,7 @@ void TableEditor::mouseMove(const MouseEvent& e)
 {
 	hoveredMidPointIndex = getDraggedMidPointIndex(e);
 
-	setMouseCursor(hoveredMidPointIndex != -1 ? MouseCursor::DraggingHandCursor : MouseCursor::NormalCursor);
+	setMouseCursor(hoveredMidPointIndex != -1 ? MouseCursor(dragProperties.midPointCursor) : MouseCursor::NormalCursor);
 
 	if (e.eventComponent != this)
 	{
@@ -1349,7 +1349,10 @@ void TableEditor::DragPoint::setTableEditorSize(Rectangle<float> tableEditorBoun
 void TableEditor::DragPoint::mouseEnter(const MouseEvent& mouseEvent)
 {
 	if (auto te = findParentComponentOfClass<TableEditor>())
+	{
 		te->pointAreaBetweenMouse = {};
+		setMouseCursor(MouseCursor(te->dragProperties.dragPointCursor));
+	}
 
 	over = true;
 	repaint();
@@ -1357,6 +1360,7 @@ void TableEditor::DragPoint::mouseEnter(const MouseEvent& mouseEvent)
 
 void TableEditor::DragPoint::mouseExit(const MouseEvent& mouseEvent)
 {
+	setMouseCursor(MouseCursor::NormalCursor);
 	over = false;
 	repaint();
 }

--- a/hi_tools/hi_standalone_components/TableEditor.h
+++ b/hi_tools/hi_standalone_components/TableEditor.h
@@ -214,9 +214,20 @@ public:
 		int endPointSize = 20;
 		float margin = 0.0f;
 		bool closePath = true;
+
+		// The cursors default to the previous behaviour (normal arrow on drag points,
+		// dragging hand on mid points) so existing tables keep their look.
+		MouseCursor::StandardCursorType dragPointCursor = MouseCursor::NormalCursor;
+		MouseCursor::StandardCursorType midPointCursor = MouseCursor::DraggingHandCursor;
 	};
 
 	void setMouseDragProperties(const var& obj);;
+
+	/** Sets the cursor shown when hovering a draggable table point. */
+	void setDragPointCursor(MouseCursor::StandardCursorType c) { dragProperties.dragPointCursor = c; }
+
+	/** Sets the cursor shown when hovering a curve mid point handle. */
+	void setMidPointCursor(MouseCursor::StandardCursorType c) { dragProperties.midPointCursor = c; }
 
     void setDrawTableValueLabel(bool shouldBeDisplayed);
 


### PR DESCRIPTION
  The previous version changed the drag point and mid point cursors for every
  TableEditor unconditionally (crosshair on drag points, up/down resize on mid
  points). Since TableEditor is shared by script tables, envelope editors, sample
  maps etc. that was a breaking visual change, so I closed that PR.
  
  This makes the cursors configurable instead, defaulting to the previous
  behaviour (normal arrow on drag points, dragging hand on mid points) so existing
  projects are unaffected.
  
  They can be set two ways, matching how other components already work:
  - ScriptTable property editor: dragPointCursor / midPointCursor choice properties
    (options come from ApiHelpers::getMouseCursorNames()), like ScriptButton.
  - From script via setMouseHandlingProperties({ dragPointCursor:
  "CrosshairCursor",
    midPointCursor: "UpDownResizeCursor" }), like ScriptPanel cursors.
    
  "ParentCursor" is the no-override default for the property so it never clobbers a
  cursor set from the script side.
  
  Also keeps the small fix from the original PR that hides mid points when
  syncStartEnd is on and there are 2 or fewer points (you can't place one there).
  
  Tested: built into a plugin with several tables driven by
  setMouseHandlingProperties
  - default (no keys) shows the original arrow + dragging-hand cursors
  - setting the keys shows crosshair on points and up/down on curve handles
  - confirmed the property route and script route no longer fight each other