### PR TITLE
Decouple filter display registry size from voice count

### DIFF
--- a/hi_tools/hi_standalone_components/eq_plot/FilterInfo.h
+++ b/hi_tools/hi_standalone_components/eq_plot/FilterInfo.h
@@ -231,7 +231,12 @@ private:
 	
 	double sampleRate = -1.0;
 
-	UnorderedStack<InternalData> internalData;
+	// The number of filters that can register for display must NOT be tied to the
+	// voice count (the default UnorderedStack size = NUM_POLYPHONIC_VOICES). A single
+	// shared FilterDataObject can collect many filter nodes (e.g. a multi-mode filter
+	// rack feeding one graph); with a low voice count the later filters overflowed and
+	// vanished from the graph. Use an explicit, polyphony-independent capacity.
+	UnorderedStack<InternalData, 64> internalData;
 
 	JUCE_DECLARE_WEAK_REFERENCEABLE(FilterDataObject);
 };


### PR DESCRIPTION
  ### Problem
  When many filter nodes share one filter-coefficient display object (e.g. a
  multi-mode filter rack feeding a single filter graph), filters beyond the polyphonic voice
  count never appear in the graph.
  
  ### Cause
  FilterDataObject's broadcaster registry is an UnorderedStack<InternalData> whose
  default size is UNORDERED_STACK_SIZE (= NUM_POLYPHONIC_VOICES). Each filter node
  registers as a broadcaster in that shared stack, so once the voice count is reached additional
  filters overflow and are dropped. Display capacity shouldn't depend on polyphony.
  
  ### Fix
  Give the registry an explicit, polyphony-independent size (UnorderedStack<InternalData, 64>).
  
  ### Evidence
  With a 14-filter shared display object at NUM_POLYPHONIC_VOICES=8, only the first
  8 filter types rendered; the rest froze on the previous curve. With the explicit size all
  render correctly. Audio was always fine — display only.