### PR TITLE
fix dead extra_mod modulation on exported/standalone cold load (incl.   HardcodedSynthesiser) 

### DIFF
--- a/hi_core/hi_modules/hardcoded/HardcodedModules.cpp
+++ b/hi_core/hi_modules/hardcoded/HardcodedModules.cpp
@@ -212,10 +212,14 @@ void HardcodedMasterFX::prepareToPlay(double sampleRate, int samplesPerBlock)
 
 	SimpleReadWriteLock::ScopedReadLock sl(lock);
 
+	// PR #965: prepare the extra mod sources BEFORE the opaque node so reset()
+	// captures live eventData read pointers. Otherwise, on cold standalone/exported
+	// load the connection is established at sampleRate==0 and reset() pins a dead
+	// pointer, leaving extra_mod modulation permanently stuck.
+	extraMods.prepareToPlay(sampleRate, samplesPerBlock);
+
 	auto ok = prepareOpaqueNode(opaqueNode.get());
 	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
-
-	extraMods.prepareToPlay(sampleRate, samplesPerBlock);
 }
 
 juce::Path HardcodedMasterFX::getSpecialSymbol() const
@@ -420,11 +424,12 @@ void HardcodedPolyphonicFX::prepareToPlay(double sampleRate, int samplesPerBlock
 
 	VoiceEffectProcessor::prepareToPlay(sampleRate, samplesPerBlock);
 	SimpleReadWriteLock::ScopedReadLock sl(lock);
-	auto ok = prepareOpaqueNode(opaqueNode.get());
 
-	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
-
+	// PR #965: prepare extra mod sources before the opaque node (see HardcodedMasterFX).
 	extraModSources.prepareToPlay(sampleRate, samplesPerBlock);
+
+	auto ok = prepareOpaqueNode(opaqueNode.get());
+	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
 }
 
 void HardcodedPolyphonicFX::startVoice(int voiceIndex, const HiseEvent& e)
@@ -1066,11 +1071,15 @@ void HardcodedSynthesiser::prepareToPlay(double sampleRate, int samplesPerBlock)
 
 	
 	SimpleReadWriteLock::ScopedReadLock sl(HardcodedSwappableEffect::lock);
-	auto ok = prepareOpaqueNode(opaqueNode.get());
 
-	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
-
+	// Same fix as PR #965, extended to the synth wrapper (which that PR does not
+	// cover): prepare the extra mod sources before the opaque node so reset()
+	// captures live eventData. This is what fixes osc pitch/gain extra_mod that
+	// loads dead in the compiled standalone synth.
 	extraModSources.prepareToPlay(sampleRate, samplesPerBlock);
+
+	auto ok = prepareOpaqueNode(opaqueNode.get());
+	errorBroadcaster.sendMessage(sendNotificationAsync, ok.getErrorMessage());
 }
 
 Processor* HardcodedSynthesiser::getChildProcessor(int processorIndex)


### PR DESCRIPTION
This extends USTK's PR #965 to cover Hardcoded Synth as well...

### Problem
  On a cold load of an exported plugin/standalone, modulation routed through
  extra_mod 
  nodes (matrix mods / LFOs) delivers no signal. The IDE works because audio is
  already
  running when the connections are established.
  
  ### Cause
  At cold startup the runtime-target connection for the extra mod sources is set up
  while
  sampleRate == 0. prepareOpaqueNode() then runs with only a dead placeholder
  SignalSource, 
  and the opaque node's reset() captures each extra_mod's eventData read pointer
  from that
  empty source — permanently pinning a dead pointer. onValue() refreshes
  signal/ok/sr but
  never re-captures eventData.

  ### Fix
  Call the extra-mod prepareToPlay() before prepareOpaqueNode() in
  HardcodedMasterFX,
  HardcodedPolyphonicFX and HardcodedSynthesiser, so reset() captures the live
  eventData
  (matches the existing order in setEffect()).
  
  ### Relation to #965
  Supersedes #965 (USTK): same reorder for the two FX wrappers #965
  covers,
  plus HardcodedSynthesiser, which #965 does not — that's the case that breaks
  pitch/gain
  modulation in exported hardcoded synths.

  ### Evidence
  Reproduced in an exported AU/standalone synth: osc pitch and output-gain
  modulation were
  dead on cold load and only engaged after touching a control. With the reorder,
  modulation
  is live on load. Verified in HISE, standalone, and AU (Logic).
