### PR TITLE
Fix FullInstrumentExpansion default snapshot being overwritten on exp…

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -346,8 +346,6 @@ bool ExpansionHandler::setCurrentExpansion(const String& expansionName)
 		return true;
 	}
 
-	currentExpansion = nullptr;
-
 	for (auto e : expansionList)
 	{
 		if (e->getProperty(ExpansionIds::Name) == expansionName)
@@ -357,6 +355,7 @@ bool ExpansionHandler::setCurrentExpansion(const String& expansionName)
 		}
 	}
 
+	currentExpansion = nullptr;
 	return false;
 }
 


### PR DESCRIPTION
…ansion switch

When setCurrentExpansion(const String&) was called to switch between expansions, it nulled currentExpansion before calling the pointer overload. This caused the pointer overload to always see currentExpansion == nullptr and call setNewDefault(), overwriting the original player snapshot with the intermediate expansion's state. Moving the null to the not-found path preserves the transition context so setNewDefault() only fires on the true null->first-expansion transition.

https://claude.ai/code/session_01SdLbGfPc2eotXSKHqDBYDa

Forum thread: https://forum.hise.audio/topic/14833/full-expansions-again-massive-problems-warning-swearing-in-the-message/21