### PR TITLE
Make Plotter right-click menu respect script look-and-feel

### DIFF
--- a/hi_core/hi_components/floating_layout/MiscFloatingPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/MiscFloatingPanelTypes.cpp
@@ -556,6 +556,7 @@ void ComplexDataEditorPanel::fillIndexList(StringArray& indexList)
 Component* PlotterPanel::createContentComponent(int)
 {
 	auto p = new Plotter(getMainController()->getGlobalUIUpdater());
+	p->setMainController(getMainController());
 	if (auto mod = dynamic_cast<Modulation*>(getConnectedProcessor()))
 	{
 		mod->setPlotter(p);

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -6125,6 +6125,29 @@ LookAndFeel* HiseColourScheme::createAlertWindowLookAndFeel(void* mainController
 
 	return new hise::AlertWindowLookAndFeel();
 }
+
+LookAndFeel* HiseColourScheme::createPopupMenuLookAndFeel(void* mainController, Component* c)
+{
+	// Check local script LAF first. FloatingTileWrapper::updateLookAndFeel sets
+	// the local LAF recursively on all child components, so getLookAndFeel() on
+	// any child of a styled FloatingTile returns a LafBase-derived type.
+	if (c != nullptr)
+	{
+		if (auto lafBase = dynamic_cast<ScriptingObjects::ScriptedLookAndFeel::LafBase*>(&c->getLookAndFeel()))
+		{
+			if (auto scriptLaf = lafBase->get())
+				return new ScriptingObjects::ScriptedLookAndFeel::LocalLaf(scriptLaf);
+		}
+	}
+
+	if (auto mc = reinterpret_cast<MainController*>(mainController))
+	{
+		if (mc->getCurrentScriptLookAndFeel() != nullptr)
+			return new ScriptingObjects::ScriptedLookAndFeel::Laf(mc);
+	}
+
+	return new hise::PopupLookAndFeel();
+}
 #endif
 
 

--- a/hi_tools/Macros.h
+++ b/hi_tools/Macros.h
@@ -378,6 +378,10 @@ struct HiseColourScheme
 	// Override this and return the look and feel to be used by all alert windows
 	static LookAndFeel* createAlertWindowLookAndFeel(void* mainController);
 
+	// Returns a ScriptedLookAndFeel::Laf if a script LAF is active, otherwise a PopupLookAndFeel.
+	// Pass the component that is showing the menu to check for a local script LAF first.
+	static LookAndFeel* createPopupMenuLookAndFeel(void* mainController, Component* c = nullptr);
+
 	static Colour getColour(ColourIds id)
 	{
 		switch (id)

--- a/hi_tools/hi_standalone_components/Plotter.cpp
+++ b/hi_tools/hi_standalone_components/Plotter.cpp
@@ -232,9 +232,9 @@ void Plotter::mouseDown(const MouseEvent& m)
 {
 	if (m.mods.isRightButtonDown())
 	{
-		PopupLookAndFeel plaf;
+		ScopedPointer<LookAndFeel> menuLaf = HiseColourScheme::createPopupMenuLookAndFeel(mainController, this);
 		PopupMenu menu;
-		menu.setLookAndFeel(&plaf);
+		menu.setLookAndFeel(menuLaf);
 
 
 		menu.addItem(1024, "Freeze", true, !active);

--- a/hi_tools/hi_standalone_components/Plotter.h
+++ b/hi_tools/hi_standalone_components/Plotter.h
@@ -101,6 +101,8 @@ public:
 		cleanupFunction = cf;
 	}
 
+	void setMainController(void* mc) { mainController = mc; }
+
 	virtual void refresh() override
 	{
 		rebuildPath();
@@ -127,6 +129,8 @@ private:
 	bool stickPopup = false;
 
 	Table::ValueTextConverter yConverter;
+
+	void* mainController = nullptr;
 
 	Mode currentMode;
 


### PR DESCRIPTION
The Plotter's context menu hardcoded PopupLookAndFeel, bypassing any script look-and-feel functions (drawPopupMenuBackground, drawPopupMenuItem, etc.) set by the user via global or local script LAF.

- Add HiseColourScheme::createPopupMenuLookAndFeel(void* mc, Component* c) alongside createAlertWindowLookAndFeel(). Falls back to PopupLookAndFeel (not AlertWindowLookAndFeel) to preserve the existing visual default. Priority: local script LAF -> global script LAF -> PopupLookAndFeel.
- Local LAF detection: FloatingTileWrapper::updateLookAndFeel already sets the LAF recursively on all FloatingTile children, so getLookAndFeel() on the Plotter returns a LafBase-derived type when setLocalLookAndFeel() is active. A fresh LocalLaf is created from it for the popup.
- Add void* mainController member and setter to Plotter (void* avoids introducing a hi_tools -> hi_core dependency).
- PlotterPanel::createContentComponent passes the MainController to the Plotter it creates.
- Plotter::mouseDown uses createPopupMenuLookAndFeel(mainController, this).

https://claude.ai/code/session_01DH4Kk8EVDrjZNjpdBBc8CC