### PR TITLE
Fix false missing-sample error when sample maps share a monolith

### DIFF
--- a/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
+++ b/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
@@ -914,7 +914,7 @@ juce::String SampleMap::checkReferences(MainController* mc, ValueTree& v, const 
 	const std::string channelNames = v.getProperty("MicPositions").toString().toStdString();
 	const size_t numChannels = std::count(channelNames.begin(), channelNames.end(), ';');
 
-	const String sampleMapName = v.getProperty("ID").toString().replace("/", "_");
+	const String sampleMapName = MonolithFileReference::getIdFromValueTree(v).replace("/", "_");
 
 	if (isMonolith)
 	{


### PR DESCRIPTION
SampleMap::checkReferences() was building the expected monolith filename from the sample map's own ID, ignoring the MonolithReference property that points to the shared monolith. Now uses
MonolithFileReference::getIdFromValueTree() which correctly prefers MonolithReference over ID, consistent with the rest of the monolith loading code.


Claude-Session: https://claude.ai/code/session_01X1B1kATSPCpoyz4JEdRo1T