### PR TITLE
Fix Markdown parser eating numbers from non-list digit lines

### DIFF
--- a/hi_tools/hi_markdown/Markdown.h
+++ b/hi_tools/hi_markdown/Markdown.h
@@ -441,6 +441,7 @@ private:
 	RowContent parseTableRow();
 	bool isJavascriptBlock() const;
 	bool isImageLink() const;
+	bool isEnumeration() const;
 	void addCharacterToCurrentBlock(juce_wchar c);
 	void resetCurrentBlock();
 	void skipTagAndTrailingSpace();

--- a/hi_tools/hi_markdown/MarkdownParser.cpp
+++ b/hi_tools/hi_markdown/MarkdownParser.cpp
@@ -179,31 +179,23 @@ void MarkdownParser::parseEnumeration()
 
 	Array<Array<HyperLink>> links;
 
-	while (CharacterFunctions::isDigit(it.peek()))
+	while (isEnumeration())
 	{
-		while(CharacterFunctions::isDigit(it.peek()))
+		while (CharacterFunctions::isDigit(it.peek()))
 			skipTagAndTrailingSpace();
-		
-		if (it.peek() == '.')
+
+		skipTagAndTrailingSpace(); // the dot
+
+		resetCurrentBlock();
+		resetForNewLine();
+
+		while (!Helpers::isNewElement(it.peek()))
 		{
-			skipTagAndTrailingSpace(); // the dot
-
-			resetCurrentBlock();
-			resetForNewLine();
-
-			while (!Helpers::isNewElement(it.peek()))
-			{
-				parseText();
-			}
-
-			links.add(currentLinks);
-			listItems.add(currentlyParsedBlock);
+			parseText();
 		}
-		else
-		{
-			parseLine();
-			return;
-		}
+
+		links.add(currentLinks);
+		listItems.add(currentlyParsedBlock);
 	}
 
 	elements.add(new EnumerationList(this, line, listItems, links));
@@ -438,7 +430,11 @@ void MarkdownParser::parseBlock()
 	case '6':
 	case '7':
 	case '8':
-	case '9': parseEnumeration(); break;
+	case '9': if (isEnumeration())
+		parseEnumeration();
+			  else
+				  parseLine();
+		break;
 	case '#': parseHeadline();
 		break;
 	case '-': parseBulletList();
@@ -778,6 +774,21 @@ bool MarkdownParser::isImageLink() const
 {
 	auto restString = it.getRestString();
 	return restString.startsWith("![");
+}
+
+bool MarkdownParser::isEnumeration() const
+{
+	// Only treat a digit-leading line as an ordered list if it matches the
+	// pattern <digits>. - otherwise lines like "1 osc" or "1) osc" would have
+	// their leading number silently consumed by parseEnumeration().
+	auto restString = it.getRestString();
+
+	int numDigits = 0;
+
+	while (CharacterFunctions::isDigit(restString[numDigits]))
+		numDigits++;
+
+	return numDigits > 0 && restString[numDigits] == '.';
 }
 
 void MarkdownParser::addCharacterToCurrentBlock(juce_wchar c)


### PR DESCRIPTION
## Problem

In the markdown renderer, any block starting with a digit `1`-`9` is routed to `parseEnumeration()`. That function consumes the leading digit(s) *before* checking whether a `.` follows. When the line is not actually an ordered list, the fallback to `parseLine()` resumes *after* the already-consumed digits, so the leading number is silently dropped.

Symptoms:

| Source | Rendered (before) |
|--------|-------------------|
| `1. item` | numbered list (correct) |
| `1 item`  | `item` (number dropped) |
| `1) item` | `) item` (digit dropped) |
| `2 oscillators...` | routed into list parsing |

## Fix

Add a non-destructive `isEnumeration()` guard (matching the existing `isImageLink()` / `isJavascriptBlock()` pattern) that peeks the rest of the line for the `<digits>.` pattern via `getRestString()` without advancing the iterator.

- Use it in `parseBlock()` dispatch so only genuine ordered lists reach `parseEnumeration()`; any other digit-leading line falls through to `parseLine()` with its text intact.
- Use it as the `parseEnumeration()` loop condition, removing the destructive "consume digits, then check for dot, else parseLine()" branch. This also fixes the mid-list case where a digit-leading non-list line would lose its number.

No behavior change for genuine `<digits>.` lists: they still parse, renumber, and export to `<ol>` as before.

## Testing

Built the standalone IDE (Debug) and verified in a Markdown panel that `1. ` / `2. ` render as an ordered list while `1 `, `1)`, and `2 oscillators...` render as plain text with their numbers intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)