### PR TITLE
Set currentlyLoadedFile for frontend default preset

### DIFF
--- a/hi_core/hi_core/MainController.cpp
+++ b/hi_core/hi_core/MainController.cpp
@@ -2604,9 +2604,24 @@ void MainController::UserPresetHandler::DefaultPresetManager::init(const ValueTr
 
 	
 #else
-	
+
 	if (v.isValid())
 		defaultPreset = v;
+
+	// Mirror the USE_BACKEND branch: resolve the default preset file on disk so that
+	// resetToDefault() sets currentlyLoadedFile. Without this, the exported plugin loads
+	// the default preset's values but leaves currentlyLoadedFile empty, so
+	// Engine.getCurrentUserPresetName() returns "" on first launch (and incPreset() takes
+	// its "no current file" branch on the first prev/next). The embedded presets are
+	// already extracted to disk at this point (FrontEndProcessor.cpp calls
+	// extractUserPresets() before constructing the processor), so the file resolves here.
+	auto userPresetRoot = FrontendHandler::getUserPresetDirectory();
+	auto f = userPresetRoot.getChildFile(defaultValue).withFileExtension(".preset");
+
+	// only set the default file if it's a child of the user preset directory
+	// (in order to allow a "hidden" default user preset)
+	if (f.existsAsFile() && f.isAChildOf(userPresetRoot))
+		defaultFile = f;
 
 #endif
 


### PR DESCRIPTION
## Problem

In an **exported plugin**, the `<DefaultUserPreset>` project setting loads the default preset's *values* but leaves `UserPresetHandler::currentlyLoadedFile` empty. On first launch:

- `Engine.getCurrentUserPresetName()` returns `""`.
- A preset-name display bound to it paints blank.
- `incPreset()` takes its "no current file" branch on the first prev/next press, snapping to the first preset instead of advancing relative to the default.

The backend (editor) does not have this problem because it sets `defaultFile`. The bug is frontend-only.

## Root cause

`DefaultPresetManager::init()` resolves and stores `defaultFile` only in the `USE_BACKEND` branch. The frontend `#else` branch sets `defaultPreset` from the embedded ValueTree but never assigns `defaultFile`, so `resetToDefault()` passes an empty file through to `loadUserPresetFromValueTree(...)`.

By the time `init()` runs, the embedded presets have already been extracted to disk: `FrontEndProcessor.cpp` calls `extractUserPresets(...)` before the `FrontendProcessor` is constructed, and the ctor is what later inits the default preset manager. So the on-disk file can be resolved here, exactly as the backend branch does.

## Fix

Mirror the `USE_BACKEND` branch in the frontend `#else`: resolve the default preset file under `FrontendHandler::getUserPresetDirectory()` and assign `defaultFile`, keeping the same `isAChildOf` guard that preserves the "hidden default user preset" capability (a default that isn't on disk simply leaves `defaultFile` empty and behaves as today).

## Testing

- **Frontend:** exported a plugin with `<DefaultUserPreset>` set to an existing preset. On a clean first launch, `Engine.getCurrentUserPresetName()` now returns that name, the preset-name bar shows it, and the first prev/next advances relative to the default.
- **Hidden-default regression:** with a default not present on disk, values still load and the name stays blank (unchanged).
- **Editor:** backend path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)