### PR TITLE
Fix int colour values dropped in FloatingTileContent::ColourHolder::f…

### DIFF
--- a/hi_core/hi_components/floating_layout/FloatingTileContent.cpp
+++ b/hi_core/hi_components/floating_layout/FloatingTileContent.cpp
@@ -385,7 +385,7 @@ void FloatingTileContent::ColourHolder::fromDynamicObject(const var& object)
 				colours[i] = Colour((uint32)normal);
 			}
 		}
-		else if (colourVar.isInt64() || colourVar.isInt64())
+		else if (colourVar.isInt() || colourVar.isInt64())
 		{
 			colours[i] = Colour((uint32)(int64)colourVar);
 		}


### PR DESCRIPTION
…romDynamicObject

The isInt64() check was duplicated instead of checking isInt(), so a plain int var (e.g. the return value of Colours.withMultipliedBrightness and similar HISEScript API calls) never matched and the colour silently fell back to transparent black.