### PR TITLE
Fix preprocessor string scanner mishandling escaped backslash before quote

### DIFF
--- a/hi_snex/snex_parser/snex_jit_PreProcessor.cpp
+++ b/hi_snex/snex_parser/snex_jit_PreProcessor.cpp
@@ -590,8 +590,10 @@ Preprocessor::TextBlockList Preprocessor::parseTextBlocks()
                         lineNumber++;
                     }
                     
-                    // skip escaped quoted (\")
-                    if(*start == '\\' && *(start + 1) == quoteChar)
+                    // skip any escaped character (\\, \", \n, ...) so that
+                    // an escaped backslash before the closing quote doesn't
+                    // swallow the quote (e.g. "\\")
+                    if(*start == '\\' && (start + 1) != end)
                     {
                         start++;
                         start++;


### PR DESCRIPTION
## Problem

The string-skipping loop in the SNEX preprocessor (`snex_jit_PreProcessor.cpp`) only special-cases an escaped quote (`\"`) when scanning over string literals. It never considers that the backslash itself might be escaped, so a literal with an escaped backslash directly before the closing quote is misparsed:

```javascript
const var PATH_SEPARATOR = Engine.getOS() == "OSX" ? "/" : "\\"; // scanner treats the closing quote as escaped
const var someStringWithHashtag = "#"; // this quote 'closes' the line above, so # is in the wild...
```

The scanner skips past the real closing quote, the string/code regions are inverted for the rest of the file, and the `#` inside the second string literal leaks out and gets parsed as a preprocessor directive.

This affects HiseJavascript whenever the preprocessor pass runs (global preprocessor enabled in the project settings, or a local switch at the top of the script) as well as SNEX code. The actual Javascript tokenizer handles the escape correctly, which is why the line compiles fine with the preprocessor off.

## Fix

Skip any two-character escape sequence (`\\`, `\"`, `\n`, ...) instead of only `\"`. This also removes an unchecked read past the end of the buffer when a backslash is the last character of the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)