### PR TITLE
Fix MIDI Learn Min/Max cells showing raw values until first edit

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -2066,6 +2066,9 @@ Component* TableFloatingTileBase::refreshComponentForCell(int rowNumber, int col
 		slider->slider->textFromValueFunction = vtc;
 		slider->slider->valueFromTextFunction = vtc;
 
+		// setRowAndColumn() sets the value before the converter functions exist,
+		// so the text box must be refreshed to show the converted text
+		slider->slider->updateText();
 
 		return slider;
 	}


### PR DESCRIPTION
## Symptom

Assign a MIDI CC to a knob whose Mode is e.g. NormalizedPercentage, then open the MIDI Learn floating tile:

1. The Min and Max cells initially display the raw normalized values `0.0` and `1.0`.
2. Typing `0.5` RETURN into Min (expecting "half") shows `1%`, because typed input is (correctly) parsed in the knob's display units - `0.5` means 0.5%.

The field looks like it switches format on the first edit. Only the initial paint is wrong: it should read `0%` / `100%`, and showing the raw value instead is what misleads the user into typing normalized values. The same applies to any converter mode (Decibel, Frequency, ...). Both the MidiLearnPanel and the FrontendMacroPanel are affected since they share `TableFloatingTileBase`.

## Cause

In `TableFloatingTileBase::refreshComponentForCell` (FrontendPanelTypes.cpp), `setRowAndColumn()` calls `slider->setValue()` while `textFromValueFunction` is still null on a freshly created cell component, so the text box renders with JUCE's default numeric formatting. The `ValueToTextConverter` is assigned right after, but assigning `Slider::textFromValueFunction` does not refresh the text box. The first user edit then goes through `setValue` with the converter in place, which reads as a format switch.

## Fix

Call `Slider::updateText()` after assigning the converter functions so the first paint already shows converted text. (Moving the converter assignment above `setRowAndColumn` would not be enough: `Slider::setValue` skips the text refresh when the new value equals the current one, e.g. Min = 0.0 on a freshly constructed slider.)

Unused rows are unaffected: their converter is default-constructed (`active == false`), so `getTextForValue` falls back to plain numbers.

## Verified

1. NormalizedPercentage knob assigned to CC1: MIDI Learn panel Min/Max now read `0%` / `100%` immediately; typing `50` RETURN into Min shows `50%`.
2. Rows without an assignment still show plain numeric text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)