### PR TITLE
Add opt-out flags for MIDI automation persistence (user presets + plugin state)

### DIFF
--- a/hi_backend/backend/PreprocessorDatabase.cpp
+++ b/hi_backend/backend/PreprocessorDatabase.cpp
@@ -1003,6 +1003,17 @@ PreprocessorDataBase::PreprocessorDataBase()
 		.withCrossReference(LinkType::Module, "MacroModulationSource", "every macro slot is mirrored as a front-of-list plugin parameter when this is on")
 		.withCrossReference(LinkType::Preprocessor, "HISE_NUM_MACROS", "determines how many macro plugin parameters the host sees");
 
+	data["HISE_MIDI_AUTOMATION_IN_USER_PRESETS"] = Entry()
+		.withCategory(Category::AutomationAndMacros)
+		.withBrief("Stores MIDI learn CC assignments inside user presets and restores them on preset load.")
+		.withDescriptionLine("When enabled (the default), every user preset save embeds the current MIDI CC assignments and every preset load replaces them with whatever the preset contains, including clearing them when the preset has none - the assignments behave like patch data. Disable this to decouple MIDI learn from the preset system: presets neither store nor touch CC assignments, so a mapping made by the end user survives preset browsing, which matches the per-instance convention of most synth plugins. The assignments are still saved and restored with the plugin instance state in the DAW session regardless of this setting.")
+		.withDescriptionLine("> Read at runtime from the Extra Definitions, so no HISE rebuild is required. Old presets that contain a MidiAutomation node are simply ignored on load when this is disabled.")
+		.withDefault(1)
+		.withValue(HISE_MIDI_AUTOMATION_IN_USER_PRESETS)
+		.withHotReload()
+		.withCrossReference(LinkType::ScriptingApi, "MidiAutomationHandler", "assignments can still be snapshotted/restored in script for global-file persistence")
+		.withCrossReference(LinkType::Preprocessor, "HISE_ENABLE_MIDI_LEARN", "controls whether MIDI learn assignments can be created at all");
+
 	data["HISE_NUM_MACROS"] = Entry()
 		.withCategory(Category::AutomationAndMacros)
 		.withBrief("Number of active macro control slots that the project exposes on the master chain.")

--- a/hi_backend/backend/PreprocessorDatabase.cpp
+++ b/hi_backend/backend/PreprocessorDatabase.cpp
@@ -1003,16 +1003,28 @@ PreprocessorDataBase::PreprocessorDataBase()
 		.withCrossReference(LinkType::Module, "MacroModulationSource", "every macro slot is mirrored as a front-of-list plugin parameter when this is on")
 		.withCrossReference(LinkType::Preprocessor, "HISE_NUM_MACROS", "determines how many macro plugin parameters the host sees");
 
+	data["HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE"] = Entry()
+		.withCategory(Category::AutomationAndMacros)
+		.withBrief("Stores MIDI learn CC assignments in the project and plugin instance state and restores them after script compilation.")
+		.withDescriptionLine("When enabled (the default), MIDI CC assignments live in the project file, the embedded plugin data and the DAW session chunk, and are restored from there after every project load, plugin instantiation and session load - including after the interface script's onInit has run. Disable this together with HISE_MIDI_AUTOMATION_IN_USER_PRESETS when the project script owns the assignments itself (for example persisting them to a global file through the MidiAutomationHandler scripting object), because the post-compilation restore would otherwise overwrite the script-applied assignments and re-trigger the update callback with the overwritten state.")
+		.withDescriptionLine("> Read at runtime from the Extra Definitions, so no HISE rebuild is required. With this disabled the project XML no longer contains a MidiAutomation node after the next save.")
+		.withDefault(1)
+		.withValue(HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE)
+		.withHotReload()
+		.withCrossReference(LinkType::ScriptingApi, "MidiAutomationHandler", "the scripting object that owns the assignments when this is disabled")
+		.withCrossReference(LinkType::Preprocessor, "HISE_MIDI_AUTOMATION_IN_USER_PRESETS", "companion flag covering user presets; set both to 0 for fully script-owned MIDI automation");
+
 	data["HISE_MIDI_AUTOMATION_IN_USER_PRESETS"] = Entry()
 		.withCategory(Category::AutomationAndMacros)
 		.withBrief("Stores MIDI learn CC assignments inside user presets and restores them on preset load.")
-		.withDescriptionLine("When enabled (the default), every user preset save embeds the current MIDI CC assignments and every preset load replaces them with whatever the preset contains, including clearing them when the preset has none - the assignments behave like patch data. Disable this to decouple MIDI learn from the preset system: presets neither store nor touch CC assignments, so a mapping made by the end user survives preset browsing, which matches the per-instance convention of most synth plugins. The assignments are still saved and restored with the plugin instance state in the DAW session regardless of this setting.")
+		.withDescriptionLine("When enabled (the default), every user preset save embeds the current MIDI CC assignments and every preset load replaces them with whatever the preset contains, including clearing them when the preset has none - the assignments behave like patch data. Disable this to decouple MIDI learn from the preset system: presets neither store nor touch CC assignments, so a mapping made by the end user survives preset browsing, which matches the per-instance convention of most synth plugins. The assignments are still saved and restored with the plugin instance state in the DAW session as long as HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE is enabled.")
 		.withDescriptionLine("> Read at runtime from the Extra Definitions, so no HISE rebuild is required. Old presets that contain a MidiAutomation node are simply ignored on load when this is disabled.")
 		.withDefault(1)
 		.withValue(HISE_MIDI_AUTOMATION_IN_USER_PRESETS)
 		.withHotReload()
 		.withCrossReference(LinkType::ScriptingApi, "MidiAutomationHandler", "assignments can still be snapshotted/restored in script for global-file persistence")
-		.withCrossReference(LinkType::Preprocessor, "HISE_ENABLE_MIDI_LEARN", "controls whether MIDI learn assignments can be created at all");
+		.withCrossReference(LinkType::Preprocessor, "HISE_ENABLE_MIDI_LEARN", "controls whether MIDI learn assignments can be created at all")
+		.withCrossReference(LinkType::Preprocessor, "HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE", "companion flag covering project and DAW session state; set both to 0 for fully script-owned MIDI automation");
 
 	data["HISE_NUM_MACROS"] = Entry()
 		.withCategory(Category::AutomationAndMacros)

--- a/hi_core/hi_core.h
+++ b/hi_core/hi_core.h
@@ -567,12 +567,22 @@ Note that this is a dynamic preprocessor so you don't need to recompile HISE to 
 
 /** Config: HISE_MIDI_AUTOMATION_IN_USER_PRESETS
 
-If enabled (default), MIDI CC assignments made through MIDI learn are stored in every user preset and restored (or cleared) whenever a preset is loaded - the assignments behave like patch data. Disable this to make MIDI learn assignments independent of the preset system: presets no longer contain a MidiAutomation node and loading a preset leaves the current assignments untouched. The assignments are still saved in the plugin instance state (DAW session) either way. Disable this if your end users expect controller mappings to survive preset browsing (the convention in most synth plugins).
+If enabled (default), MIDI CC assignments made through MIDI learn are stored in every user preset and restored (or cleared) whenever a preset is loaded - the assignments behave like patch data. Disable this to make MIDI learn assignments independent of the preset system: presets no longer contain a MidiAutomation node and loading a preset leaves the current assignments untouched. The assignments are still saved in the plugin instance state (DAW session) as long as HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE is enabled. Disable this if your end users expect controller mappings to survive preset browsing (the convention in most synth plugins).
 
 Note that this is a dynamic preprocessor so you don't need to recompile HISE to use this functionality, but just add HISE_MIDI_AUTOMATION_IN_USER_PRESETS=0 to your ExtraDefinitions.
 */
 #ifndef HISE_MIDI_AUTOMATION_IN_USER_PRESETS
 #define HISE_MIDI_AUTOMATION_IN_USER_PRESETS 1
+#endif
+
+/** Config: HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE
+
+If enabled (default), MIDI CC assignments are stored in the project/instance state (project file, embedded plugin data, DAW session chunk) and restored from it after script compilation. Disable this together with HISE_MIDI_AUTOMATION_IN_USER_PRESETS to make the project script the single owner of MIDI CC assignments (e.g. persisting them to a global file in the app data folder through the MidiAutomationHandler scripting object) - the post-compilation restore would otherwise overwrite the assignments the script applied in onInit.
+
+Note that this is a dynamic preprocessor so you don't need to recompile HISE to use this functionality, but just add HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE=0 to your ExtraDefinitions.
+*/
+#ifndef HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE
+#define HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE 1
 #endif
 
 /** Config: HISE_USE_MIDI_CHANNELS_FOR_AUTOMATION

--- a/hi_core/hi_core.h
+++ b/hi_core/hi_core.h
@@ -565,6 +565,16 @@ Note that this is a dynamic preprocessor so you don't need to recompile HISE to 
 #define HISE_MACROS_ARE_PLUGIN_PARAMETERS 0
 #endif
 
+/** Config: HISE_MIDI_AUTOMATION_IN_USER_PRESETS
+
+If enabled (default), MIDI CC assignments made through MIDI learn are stored in every user preset and restored (or cleared) whenever a preset is loaded - the assignments behave like patch data. Disable this to make MIDI learn assignments independent of the preset system: presets no longer contain a MidiAutomation node and loading a preset leaves the current assignments untouched. The assignments are still saved in the plugin instance state (DAW session) either way. Disable this if your end users expect controller mappings to survive preset browsing (the convention in most synth plugins).
+
+Note that this is a dynamic preprocessor so you don't need to recompile HISE to use this functionality, but just add HISE_MIDI_AUTOMATION_IN_USER_PRESETS=0 to your ExtraDefinitions.
+*/
+#ifndef HISE_MIDI_AUTOMATION_IN_USER_PRESETS
+#define HISE_MIDI_AUTOMATION_IN_USER_PRESETS 1
+#endif
+
 /** Config: HISE_USE_MIDI_CHANNELS_FOR_AUTOMATION
 
 If enabled, the plugin will use the MIDI channel information from CC messages when assigning a CC to a control. The default is disabled for backwards compatibility

--- a/hi_core/hi_core/MainController.cpp
+++ b/hi_core/hi_core/MainController.cpp
@@ -559,7 +559,8 @@ void MainController::loadPresetInternal(const ValueTree& valueTreeToLoad)
 			{
 				auto sp2 = loadProfile.profile(2); // compileScripts();
 				getSampleManager().setCurrentPreloadMessage("Compiling scripts...");
-				getMacroManager().getMidiControlAutomationHandler()->setUnloadedData(v.getChildWithName("MidiAutomation"));
+				if (HISE_GET_PREPROCESSOR(this, HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE))
+					getMacroManager().getMidiControlAutomationHandler()->setUnloadedData(v.getChildWithName("MidiAutomation"));
 				synthChain->compileAllScripts();
 			}
 
@@ -2374,8 +2375,9 @@ void MainController::savePluginState(MemoryBlock& destData, int currentlyLoadedP
 	//synthChain->saveMacroValuesToValueTree(v);
 
     getUserPresetHandler().saveStateManager(v, UserPresetIds::Modules);
-    
-    getUserPresetHandler().saveStateManager(v, UserPresetIds::MidiAutomation);
+
+    if (HISE_GET_PREPROCESSOR(this, HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE))
+        getUserPresetHandler().saveStateManager(v, UserPresetIds::MidiAutomation);
 
 	if (getUserPresetHandler().isUsingCustomDataModel())
     {

--- a/hi_core/hi_core/PresetHandler.cpp
+++ b/hi_core/hi_core/PresetHandler.cpp
@@ -133,7 +133,9 @@ juce::ValueTree UserPresetHelpers::createUserPreset(ModulatorSynthChain* chain)
 	}
 #endif
 
-	chain->getMainController()->getUserPresetHandler().saveStateManager(preset, UserPresetIds::MidiAutomation);
+	if (HISE_GET_PREPROCESSOR(chain->getMainController(), HISE_MIDI_AUTOMATION_IN_USER_PRESETS))
+		chain->getMainController()->getUserPresetHandler().saveStateManager(preset, UserPresetIds::MidiAutomation);
+
 	chain->getMainController()->getUserPresetHandler().saveStateManager(preset, UserPresetIds::MPEData);
 
 	preset.setProperty("Version", getCurrentVersionNumber(chain), nullptr);

--- a/hi_core/hi_core/UserPresetHandler.cpp
+++ b/hi_core/hi_core/UserPresetHandler.cpp
@@ -662,7 +662,9 @@ void MainController::UserPresetHandler::loadUserPresetInternal()
 
 #endif
 
-		restoreStateManager(userPresetToLoad, UserPresetIds::MidiAutomation);
+		if (HISE_GET_PREPROCESSOR(mc, HISE_MIDI_AUTOMATION_IN_USER_PRESETS))
+			restoreStateManager(userPresetToLoad, UserPresetIds::MidiAutomation);
+
 		restoreStateManager(userPresetToLoad, UserPresetIds::MPEData);
 
 		// Now we can restore the values of the macro controls

--- a/hi_core/hi_dsp/modules/ModulatorSynthChain.cpp
+++ b/hi_core/hi_dsp/modules/ModulatorSynthChain.cpp
@@ -207,7 +207,8 @@ ValueTree ModulatorSynthChain::exportAsValueTree() const
 
 		MacroControlBroadcaster::saveMacrosToValueTree(v);
 
-		v.addChild(getMainController()->getMacroManager().getMidiControlAutomationHandler()->exportAsValueTree(), -1, nullptr);
+		if (HISE_GET_PREPROCESSOR(getMainController(), HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE))
+			v.addChild(getMainController()->getMacroManager().getMidiControlAutomationHandler()->exportAsValueTree(), -1, nullptr);
 
 		v.addChild(getMainController()->getMacroManager().getMidiControlAutomationHandler()->getMPEData().exportAsValueTree(), -1, nullptr);
 	}
@@ -412,7 +413,8 @@ void ModulatorSynthChain::restoreFromValueTree(const ValueTree &v)
 
 	ModulatorSynth::restoreFromValueTree(v);
 
-	if (!getMainController()->shouldSkipCompiling())
+	if (!getMainController()->shouldSkipCompiling()
+		&& HISE_GET_PREPROCESSOR(getMainController(), HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE))
 	{
 		ValueTree autoData = v.getChildWithName("MidiAutomation");
 

--- a/hi_frontend/frontend/FrontEndProcessor.cpp
+++ b/hi_frontend/frontend/FrontEndProcessor.cpp
@@ -455,10 +455,12 @@ void FrontendProcessor::createPreset(const ValueTree& synthData)
 	}
 
 
+#if HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE
 	ValueTree autoData = synthData.getChildWithName("MidiAutomation");
 
 	if (autoData.isValid())
 		getMacroManager().getMidiControlAutomationHandler()->restoreFromValueTree(autoData);
+#endif
 
 	synthChain->loadMacrosFromValueTree(synthData);
 
@@ -573,7 +575,9 @@ void FrontendProcessor::setStateInformation(const void *data, int sizeInBytes)
 	if (getMacroManager().isMacroEnabledOnFrontend())
 		getMacroManager().getMacroChain()->loadMacrosFromValueTree(v, false);
 
+#if HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE
     getUserPresetHandler().restoreStateManager(v, UserPresetIds::MidiAutomation);
+#endif
 
 	channelData = v.getProperty("MidiChannelFilterData", -1);
 	if (channelData != -1) synthChain->getActiveChannelData()->restoreFromData(channelData);


### PR DESCRIPTION
## Problem

MIDI CC assignments made through MIDI learn behave like patch data: every user preset save embeds them, every preset load replaces them (including a full clear when the preset has none), and the project/instance state restores them after script compilation on every project load, plugin instantiation and DAW session load. There is no way to opt out of either behaviour, so:

- An end user's controller mapping is silently wiped by preset browsing (most synth plugins treat CC mappings as per-instance or global configuration, not patch data).
- A project that manages assignments itself in onInit (e.g. a global per-machine mapping file via the MidiAutomationHandler scripting object) gets them overwritten by the post-compilation restore - and each restore fires the update callback, so a write-on-change persistence scheme then saves the overwritten state back to its own file. Script code cannot distinguish these restores from real user edits.

Discussion: https://forum.hise.audio/topic/14914/saving-midi-cc-assignments-in-user-presets

## Why not a script-level solution?

The forum thread explored two: re-applying the assignments in the post-load callback (guarded by `isInternalPresetLoad()`), and stamping the incoming tree via `setEnableUserPresetPreprocessing` + `setPreCallback`. Both were rejected for the same underlying reason - script can only react to the persistence, not opt out of it:

- **The save side is unreachable.** No hook prevents the MidiAutomation node being written into presets, the project XML or the session chunk, so the data is always stored even when the project ignores it - misleading for anyone inspecting a preset, and it leaks the preset author's controller setup.
- **Re-applying after the restore is a race, not a fix.** The wipe still happens and still fires the update callback before the script can re-apply, so file-based persistence keeps getting the wiped state written back into it.
- **The preprocessing hook can only substitute, never skip**, requires mirroring the full assignment state in script just to have something to stamp, also fires on DAW state loads (not just preset loads), and round-trips the entire preset through JSON on every load once enabled.
- **Some restore points have no hook at all**, e.g. the editor's post-compilation restore on project load.

An opt-out flag at the source is a two-line gate per site; the default keeps the data model exactly as it is for every existing project.

## Change

Two dynamic preprocessors, both defaulting to 1 (= current behaviour, fully backwards compatible), following the HISE_MACROS_ARE_PLUGIN_PARAMETERS pattern: set them in the project's ExtraDefinitions, no HISE rebuild needed. The editor reads them at runtime via HISE_GET_PREPROCESSOR; exported plugins collapse them to compile-time constants.

**`HISE_MIDI_AUTOMATION_IN_USER_PRESETS`** - are CC assignments patch data? At 0, user presets neither store nor restore the MidiAutomation node; old presets that still contain one are ignored on load.

**`HISE_MIDI_AUTOMATION_IN_PLUGIN_STATE`** - does HISE persist CC assignments natively at all? At 0, the MidiAutomation node is neither written to nor restored from the project XML, the embedded plugin data or the DAW session chunk.

The flags are orthogonal, so all four combinations are meaningful:

| USER_PRESETS | PLUGIN_STATE | Behaviour |
|---|---|---|
| 1 | 1 | Current behaviour (default): mappings are patch data and also persist with the DAW session |
| 0 | 1 | Mappings survive preset browsing, persist per instance in the DAW session - no script needed |
| 0 | 0 | HISE never persists mappings; the project script owns them (e.g. global mapping file in AppData) |
| 1 | 0 | Mappings are purely patch data: they load with each preset, and the session keeps no separate copy that could drift from the loaded preset |

MPEData handling is untouched throughout. Both flags are registered in the preprocessor database with cross-references.

## Testing

All four flag combinations verified in the editor and in exported plugins:

- Defaults: byte-identical behaviour to current HISE (node written/restored everywhere, preset-load wipe intact).
- USER_PRESETS=0: presets contain no MidiAutomation node; mappings survive browsing any preset (including old presets with stale nodes); DAW session persistence unaffected.
- Both 0: no MidiAutomation node in preset, project XML or session state; onInit-applied assignments survive project load, plugin instantiation and session reload; the automation update callback no longer fires from restores.
- USER_PRESETS=1 with PLUGIN_STATE=0: presets still store/restore assignments; project and session state carry none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)