### PR TITLE
Midi learn popup

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -154,7 +154,7 @@ void MacroControlledObject::enableMidiLearnWithPopup()
 
 	auto ccName = handler->getCCName();
 
-	if (!isOnHiseModuleUI)
+	if (!isOnHiseModuleUI && !midiController.isValid())
 	{
 		auto addNumbersToMenu = [&](PopupMenu& mToUse)
 		{

--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -154,7 +154,7 @@ void MacroControlledObject::enableMidiLearnWithPopup()
 
 	auto ccName = handler->getCCName();
 
-	if (!isOnHiseModuleUI && getMacroIndex() == -1)
+	if (!isOnHiseModuleUI)
 	{
 		auto addNumbersToMenu = [&](PopupMenu& mToUse)
 		{


### PR DESCRIPTION
Two little changes that I think have come up on the forum before.

1) When a macro was assigned to a knob via the right-click menu, it was no longer possible to also use MIDI learn on that control or assign a CC directly until the macro assignment was removed.

2) Once a CC was assigned to a control it was possible to assign another CC without removing the first, but it wasn't clearly shown which CC was assigned. This PR removes the option of assigning a second CC to a control until the first is removed.