### PR TITLE
Fix locals/params/iterators shadowing namespace-qualified identifiers

### DIFF
--- a/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
+++ b/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
@@ -2427,7 +2427,7 @@ private:
 		return e.release();
 	}
 
-	Expression* parseFactor(JavascriptNamespace* ns=nullptr)
+	Expression* parseFactor(JavascriptNamespace* ns=nullptr, bool isQualified=false)
 	{
 		if (currentType == TokenTypes::identifier)
 		{
@@ -2444,86 +2444,91 @@ private:
 					match(TokenTypes::identifier);
 					match(TokenTypes::dot);
 					id = currentValue.toString();
+					isQualified = true;
 				}
 			}
 
-			LoopStatement* iteratorLoop = nullptr;
-
-			for (const auto& it : currentIterators)
+			// An identifier after an explicit namespace prefix (Palette.text) must
+			// resolve inside that namespace, so it is exempt from iterator /
+			// parameter / local shadowing.
+			if (!isQualified)
 			{
-				if (it.id == id)
+				LoopStatement* iteratorLoop = nullptr;
+
+				for (const auto& it : currentIterators)
 				{
-					iteratorLoop = it.loop;
-					break;
-				}
-			}
-
-			if (iteratorLoop != nullptr)
-			{
-				return parseSuffixes(new LoopStatement::IteratorName(location, iteratorLoop, parseIdentifier()));
-			}
-			else if (auto ob = dynamic_cast<InlineFunction::Object*>(outerInlineFunction))
-			{
-				const int inlineParameterIndex = ob->parameterNames.indexOf(id);
-				const int localParameterIndex = ob->localProperties->indexOf(id);
-
-				int captureIndex = -1;
-
-				if (auto fo = dynamic_cast<FunctionObject*>(currentFunctionObject))
-				{
-					captureIndex = fo->getCaptureIndex(id);
-				}
-
-				if (captureIndex == -1)
-				{
-					// Recovery sites #9 and #10: outer inline function params/locals in nested body
-					if (inlineParameterIndex != -1)
+					if (it.id == id)
 					{
-						String msg = "Cannot reference inline function parameter '" + id.toString() + "' in nested function body. Use a capture: function [" + id.toString() + "](params){}.";
-
-#if USE_BACKEND
-						if (isDiagnosticMode())
-						{
-							recordDiagnostic(location, msg, {}, SV::Error, CS::Language);
-							parseIdentifier();
-							return parseSuffixes(new DiagnosticPlaceholder(location, msg));
-						}
-#endif
-						location.throwError(msg);
-					}
-
-					if (localParameterIndex != -1)
-					{
-						String msg = "Cannot reference local variable '" + id.toString() + "' in nested function body. Use a capture: function [" + id.toString() + "](params){}.";
-
-#if USE_BACKEND
-						if (isDiagnosticMode())
-						{
-							recordDiagnostic(location, msg, {}, SV::Error, CS::Language);
-							parseIdentifier();
-							return parseSuffixes(new DiagnosticPlaceholder(location, msg));
-						}
-#endif
-						location.throwError(msg);
+						iteratorLoop = it.loop;
+						break;
 					}
 				}
-			}
-			else if (auto ob = dynamic_cast<InlineFunction::Object*>(currentInlineFunction))
-			{
-				
 
-				const int inlineParameterIndex = ob->parameterNames.indexOf(id);
-				const int localParameterIndex = ob->localProperties->indexOf(id);
-
-				if (inlineParameterIndex >= 0)
+				if (iteratorLoop != nullptr)
 				{
-					parseIdentifier();
-					return parseSuffixes(new InlineFunction::ParameterReference(location, ob, inlineParameterIndex));
+					return parseSuffixes(new LoopStatement::IteratorName(location, iteratorLoop, parseIdentifier()));
 				}
-				if (localParameterIndex >= 0)
+				else if (auto ob = dynamic_cast<InlineFunction::Object*>(outerInlineFunction))
 				{
-					parseIdentifier();
-					return parseSuffixes(new LocalReference(location, ob, id));
+					const int inlineParameterIndex = ob->parameterNames.indexOf(id);
+					const int localParameterIndex = ob->localProperties->indexOf(id);
+
+					int captureIndex = -1;
+
+					if (auto fo = dynamic_cast<FunctionObject*>(currentFunctionObject))
+					{
+						captureIndex = fo->getCaptureIndex(id);
+					}
+
+					if (captureIndex == -1)
+					{
+						// Recovery sites #9 and #10: outer inline function params/locals in nested body
+						if (inlineParameterIndex != -1)
+						{
+							String msg = "Cannot reference inline function parameter '" + id.toString() + "' in nested function body. Use a capture: function [" + id.toString() + "](params){}.";
+
+#if USE_BACKEND
+							if (isDiagnosticMode())
+							{
+								recordDiagnostic(location, msg, {}, SV::Error, CS::Language);
+								parseIdentifier();
+								return parseSuffixes(new DiagnosticPlaceholder(location, msg));
+							}
+#endif
+							location.throwError(msg);
+						}
+
+						if (localParameterIndex != -1)
+						{
+							String msg = "Cannot reference local variable '" + id.toString() + "' in nested function body. Use a capture: function [" + id.toString() + "](params){}.";
+
+#if USE_BACKEND
+							if (isDiagnosticMode())
+							{
+								recordDiagnostic(location, msg, {}, SV::Error, CS::Language);
+								parseIdentifier();
+								return parseSuffixes(new DiagnosticPlaceholder(location, msg));
+							}
+#endif
+							location.throwError(msg);
+						}
+					}
+				}
+				else if (auto ob = dynamic_cast<InlineFunction::Object*>(currentInlineFunction))
+				{
+					const int inlineParameterIndex = ob->parameterNames.indexOf(id);
+					const int localParameterIndex = ob->localProperties->indexOf(id);
+
+					if (inlineParameterIndex >= 0)
+					{
+						parseIdentifier();
+						return parseSuffixes(new InlineFunction::ParameterReference(location, ob, inlineParameterIndex));
+					}
+					if (localParameterIndex >= 0)
+					{
+						parseIdentifier();
+						return parseSuffixes(new LocalReference(location, ob, id));
+					}
 				}
 			}
 
@@ -2535,7 +2540,7 @@ private:
 				match(TokenTypes::identifier);
 				match(TokenTypes::dot);
 				
-				return parseFactor(namespaceForId);
+				return parseFactor(namespaceForId, true);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #997 (forum thread: https://forum.hise.audio/topic/14920/bug-inline-function-locals-params-shadow-namespace-members-palette-text-resolves-to-local-text)

### Problem

In `parseFactor()`, the member identifier of a qualified namespace access (`Palette.text`) runs through the same iterator / inline function parameter / local resolution as a bare identifier, because the namespace recursion (`return parseFactor(namespaceForId);`) re-enters the function with no indication that the next identifier is qualified. As a result:

- `local text` or a parameter `text` inside an inline function silently hijacks `Palette.text`
- a loop iterator named `text` does the same, even at top level outside any inline function
- `Palette.text` inside a nested function body within an inline function throws the spurious compile error "Cannot reference inline function parameter 'text' in nested function body. Use a capture: ..."

### Fix

Thread a `bool isQualified` parameter through `parseFactor()`. It is set at the namespace recursion site and in the in-namespace prefix path (where `Palette.` is consumed inside `namespace Palette { ... }`), and when set, the iterator / parameter / local resolution block is skipped so the identifier resolves inside the namespace as intended.

Guarding on the existing `ns != nullptr` alone would be wrong: `ns` is also set for *unqualified* identifiers anywhere inside a namespace body, where locals and params must keep shadowing (e.g. the parameters of an inline function declared inside a namespace).

The diff is larger than the logic change because the resolution block is now wrapped in `if (!isQualified)` and reindented; there are no changes inside it.

### Verification

Ran this script before and after (via REST repro on a Debug build):

```javascript
namespace Palette { const var text = 123; }

inline function withLocal()  { local text = "local value"; Console.print(Palette.text); }
inline function withParam(text) { Console.print(Palette.text); }
inline function withIterator() { for (text in [1]) Console.print(Palette.text); }

withLocal();          // before: "local value"  after: 123
withParam("pv");      // before: "pv"           after: 123
withIterator();       // before: 1              after: 123
for (text in [1])
    Console.print(Palette.text);   // before: 1  after: 123
```

Regression checks all unchanged:

- unqualified `text` still resolves to the param / local / iterator inside inline functions and loops
- inline functions declared inside a namespace still resolve their params unqualified while `NS.member` resolves qualified
- qualified access in a nested function body now compiles and resolves correctly instead of throwing
- a large real-world project script recompiles clean on the patched engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
