### PR TITLE
fixed quadratic memory growth when building the patch browser module list

### DIFF
--- a/hi_backend/backend/debug_components/PatchBrowser.cpp
+++ b/hi_backend/backend/debug_components/PatchBrowser.cpp
@@ -930,7 +930,13 @@ idUpdater(p->getMainController()->getRootDispatcher(), *this, BIND_MEMBER_FUNCTI
 
 	static Path soloPath;
 
-	soloPath.loadPathFromData(BackendBinaryData::PopupSymbols::soloShape, SIZE_OF_PATH(BackendBinaryData::PopupSymbols::soloShape));
+	// Path::loadPathFromData appends to the path, so a static must only be filled once:
+	// reloading it for every ModuleDragTarget grows the shared path by one copy per module
+	// and setShape() then copies that path into each button, which is quadratic in the
+	// number of modules.
+	if (soloPath.isEmpty())
+		soloPath.loadPathFromData(BackendBinaryData::PopupSymbols::soloShape, SIZE_OF_PATH(BackendBinaryData::PopupSymbols::soloShape));
+
 	soloButton->setShape(soloPath, false, true, false);
 	soloButton->addListener(this);
 
@@ -938,7 +944,9 @@ idUpdater(p->getMainController()->getRootDispatcher(), *this, BIND_MEMBER_FUNCTI
 
 	static Path hidePath;
 
-	hidePath.loadPathFromData(BackendBinaryData::ToolbarIcons::viewPanel, SIZE_OF_PATH(BackendBinaryData::ToolbarIcons::viewPanel));
+	if (hidePath.isEmpty())
+		hidePath.loadPathFromData(BackendBinaryData::ToolbarIcons::viewPanel, SIZE_OF_PATH(BackendBinaryData::ToolbarIcons::viewPanel));
+
 	hideButton->setShape(hidePath, false, true, false);
 	hideButton->addListener(this);
  


### PR DESCRIPTION
---What

PatchBrowser::ModuleDragTarget's constructor fills two static Path objects with Path::loadPathFromData() on every construction. loadPathFromData() appends to the path (Path::loadPathFromStream() never calls clear()), so each new ModuleDragTarget adds another copy of the icon to the shared static, and ShapeButton::setShape() then copies that ever-growing path into the button. Memory used by the module list is therefore quadratic in the number of modules, and because the statics outlive SearchableListComponent::rebuildModuleList(), every rebuild compounds the previous one.

Guarding both loads with if (path.isEmpty()) fills each static exactly once.

Evidence test

Opening a large project (a synth with several hundred modules: hardcoded FX slots, matrix modulators, modulation chains) made the backend climb to 35-49 GB and stall. A stack sample during the climb showed the main thread in rebuildModuleList -> PatchBrowser::createCollection -> ModuleDragTarget::ModuleDragTarget -> ShapeButton::setShape -> memmove, with the allocations coming from _xzm_malloc_large_huge. With this patch the same project opens in a few seconds at ~5 GB.

Risk

Very low, and confined to the backend.

- The rendered result is unchanged: the appended copies were the same shape at the same coordinates, so each button was simply drawing the same glyph on top of itself N times. The path bounds are also unchanged, so maintainShapeProportions scales it identically.
- Only these two sites in the codebase use the static Path + loadPathFromData pattern; every other loadPathFromData call in PatchBrowser.cpp uses a local Path.
- No DSP, no parameter indices, no scripting API, no serialization.