### PR TITLE
Expose patch/expansion load completion to scripting

### DIFF
--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -38,6 +38,7 @@ struct ScriptUserPresetHandler::Wrapper
 	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setPreCallback);
 	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setPostCallback);
 	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setPostSaveCallback);
+	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setPatchLoadedCallback);
 	API_VOID_METHOD_WRAPPER_2(ScriptUserPresetHandler, setEnableUserPresetPreprocessing);
 	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setCustomAutomation);
 	API_VOID_METHOD_WRAPPER_3(ScriptUserPresetHandler, setUseCustomUserPresetModel);
@@ -69,11 +70,13 @@ ScriptUserPresetHandler::ScriptUserPresetHandler(ProcessorWithScriptingContent* 
 	preCallback(pwsc, nullptr, var(), 1),
 	postCallback(pwsc, nullptr, var(), 1),
 	postSaveCallback(pwsc, nullptr, var(), 1),
+	patchLoadedCallback(pwsc, nullptr, var(), 0),
 	customLoadCallback(pwsc, nullptr, var(), 1),
 	customSaveCallback(pwsc, nullptr, var(), 1),
 	parameterGestureCallback(pwsc, nullptr, var(), 2)
 {
 	getMainController()->getUserPresetHandler().addListener(this);
+	getMainController()->getLockFreeDispatcher().addPresetLoadListener(this);
 
 	ADD_API_METHOD_1(isOldVersion);
     ADD_API_METHOD_0(isInternalPresetLoad);
@@ -82,6 +85,8 @@ ScriptUserPresetHandler::ScriptUserPresetHandler(ProcessorWithScriptingContent* 
 	ADD_CALLBACK_DIAGNOSTIC(postCallback, setPostCallback, 0);
 	ADD_TYPED_API_METHOD_1(setPostSaveCallback, VarTypeChecker::Function);
 	ADD_CALLBACK_DIAGNOSTIC(postSaveCallback, setPostSaveCallback, 0);
+	ADD_TYPED_API_METHOD_1(setPatchLoadedCallback, VarTypeChecker::Function);
+	ADD_CALLBACK_DIAGNOSTIC(patchLoadedCallback, setPatchLoadedCallback, 0);
 	ADD_TYPED_API_METHOD_1(setPreCallback, VarTypeChecker::Function);
 	ADD_CALLBACK_DIAGNOSTIC(preCallback, setPreCallback, 0);
 	ADD_API_METHOD_2(setEnableUserPresetPreprocessing);
@@ -112,6 +117,7 @@ ScriptUserPresetHandler::~ScriptUserPresetHandler()
 {
 	clearAttachedCallbacks();
 	getMainController()->getUserPresetHandler().removeListener(this);
+	getMainController()->getLockFreeDispatcher().removePresetLoadListener(this);
 }
 
 Identifier ScriptUserPresetHandler::getObjectName() const
@@ -222,6 +228,14 @@ void ScriptUserPresetHandler::setPostSaveCallback(var presetPostSaveCallback)
 	postSaveCallback.incRefCount();
 	postSaveCallback.addAsSource(this, "postCallback");
 	postSaveCallback.setThisObject(this);
+}
+
+void ScriptUserPresetHandler::setPatchLoadedCallback(var patchLoadedCallbackFunction)
+{
+	patchLoadedCallback = WeakCallbackHolder(getScriptProcessor(), this, patchLoadedCallbackFunction, 0);
+	patchLoadedCallback.incRefCount();
+	patchLoadedCallback.addAsSource(this, "patchLoadedCallback");
+	patchLoadedCallback.setThisObject(this);
 }
 
 void ScriptUserPresetHandler::setEnableUserPresetPreprocessing(bool processBeforeLoading, bool shouldUnpackComplexData)
@@ -1102,6 +1116,12 @@ void ScriptUserPresetHandler::presetChanged(const File& newPreset)
 
 		postCallback.call(&f, 1);
 	}
+}
+
+void ScriptUserPresetHandler::newHisePresetLoaded()
+{
+	if (patchLoadedCallback)
+		patchLoadedCallback.call(nullptr, 0);
 }
 
 

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -41,7 +41,8 @@ namespace hise { using namespace juce;
 
 class ScriptUserPresetHandler : public ConstScriptingObject,
 								public ControlledObject,
-								public MainController::UserPresetHandler::Listener
+								public MainController::UserPresetHandler::Listener,
+								public MainController::LockFreeDispatcher::PresetLoadListener
 {
 public:
 
@@ -68,6 +69,9 @@ public:
 
 	/** Sets a callback that will be executed after a preset has been saved. */
 	void setPostSaveCallback(var presetPostSaveCallback);
+
+	/** Sets a callback that will be executed after any patch, expansion or preset (re)load has finished, including loads that don't go through the regular user preset system (eg. loading a Full Instrument Expansion). Applies to instrument, effect and MIDI effect plugins alike. */
+	void setPatchLoadedCallback(var patchLoadedCallbackFunction);
 
 	/** Enables a preprocessing of every user preset that is being loaded. */
 	void setEnableUserPresetPreprocessing(bool processBeforeLoading, bool shouldUnpackComplexData);
@@ -148,6 +152,8 @@ public:
 	void presetListUpdated() override;
 	void loadCustomUserPreset(const var& dataObject) override;
 
+	void newHisePresetLoaded() override;
+
 	void onParameterGesture(bool startGesture, int parameterIndex) override;
 
 	var saveCustomUserPreset(const String& presetName) override;
@@ -185,6 +191,7 @@ private:
 	WeakCallbackHolder preCallback;
 	WeakCallbackHolder postCallback;
 	WeakCallbackHolder postSaveCallback;
+	WeakCallbackHolder patchLoadedCallback;
 
 	WeakCallbackHolder customLoadCallback;
 	WeakCallbackHolder customSaveCallback;


### PR DESCRIPTION
Adds ScriptUserPresetHandler.setPatchLoadedCallback(), which wires up the existing MainController::LockFreeDispatcher::PresetLoadListener interface (already used internally by preset/patch browser UI) to a HiseScript callback.

Unlike setPostCallback (tied to UserPresetHandler::loadUserPresetInternal and DAW state restore only), this fires after every full load via MainController::loadPresetInternal, including Full Instrument Expansion swaps and the initial default preset - the one load path that currently has no scripting hook after MIDI automation (and other deferred state) has been resolved. Applies equally to instrument, effect and MIDI effect plugins, hence "patch" rather than "instrument" in the name, matching the terminology PatchBrowser already uses for this same signal.

No existing behavior is changed: this only adds a new listener onto an already-unconditional, already-correctly-ordered broadcaster.