### PR TITLE
Close streaming file handles after preload instead of holding them open

### DIFF
--- a/hi_streaming/hi_streaming/StreamingSamplerSound.cpp
+++ b/hi_streaming/hi_streaming/StreamingSamplerSound.cpp
@@ -171,6 +171,8 @@ void StreamingSamplerSound::setPreloadSize(int newPreloadSize, bool forceReload)
 		entireSampleLoaded = false;
 		preloadBuffer = hlac::HiseSampleBuffer(!fileReader.isMonolithic(), fileReader.isStereo() ? 2 : 1, 0);
 
+		fileReader.closeFileHandles();
+
 		return;
 	}
 
@@ -224,6 +226,7 @@ void StreamingSamplerSound::setPreloadSize(int newPreloadSize, bool forceReload)
 
 	if (preloadBuffer.getNumSamples() == 0)
 	{
+		fileReader.closeFileHandles();
 		return;
 	}
 
@@ -308,6 +311,8 @@ void StreamingSamplerSound::setPreloadSize(int newPreloadSize, bool forceReload)
 #endif
 
 	applyCrossfadeToInternalBuffers();
+
+	fileReader.closeFileHandles();
 }
 
 


### PR DESCRIPTION
StreamingSamplerSound::setPreloadSize() opened a file handle to read the preload buffer but never closed it afterward, so every sample in every loaded sample map kept its own OS file handle open for the entire session, regardless of whether it was ever played. Large projects with many individual sample files can exceed the process's file descriptor limit this way, causing failures in unrelated code that tries to open a new file afterward (e.g. saving a preset).

closeFileHandles() already refuses to close while a voice is using the sound (voiceCount check), and readFromDisk() already transparently reopens a closed handle on the background sample-loading thread when actually needed. This change just calls closeFileHandles() after the preload read completes (and on the sample-deactivated and empty-preload-buffer early return paths), so a handle is only held open transiently during preload and again only while a note using that sample is actually sounding, instead of for the sampler's entire lifetime.