### PR TITLE
Fix screenshotter

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -222,21 +222,40 @@ namespace hise { using namespace juce;
 
 	void MatrixPeakMeter::InternalComp::paint(Graphics& g)
 	{
-		if(data == nullptr || lastNumChannels == 0)
+		if(data == nullptr)
 		{
 			return;
 		}
-                
-            
+
+		// lastNumChannels is only updated by the timer callback, which will not have
+		// ticked yet if a screenshot is taken right after the interface was built (or
+		// while the component is not showing). Fall back to a direct calculation so the
+		// meter is still drawn (with the initial silent peak values) in that case.
+		auto numChannels = lastNumChannels;
+
+		if(numChannels == 0)
+		{
+			numChannels = getSource ? data->getNumSourceChannels() :
+			                           data->getNumDestinationChannels();
+
+			if(!channelIndexes.isEmpty())
+				numChannels = jmin(numChannels, channelIndexes.size());
+		}
+
+		if(numChannels == 0)
+		{
+			return;
+		}
+
 		auto lafToUse = dynamic_cast<LookAndFeelMethods*>(&getLookAndFeel());
-            
+
 		if(lafToUse == nullptr)
 			lafToUse = &fallback;
-            
+
 		lafToUse->drawMatrixPeakMeter(g,
 		                              currentPeaks,
 		                              showMaxPeaks ? maxPeaks : nullptr,
-		                              lastNumChannels,
+		                              numChannels,
 		                              getWidth() < getHeight(),
 		                              segmentSize,
 		                              paddingSize,

--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -8769,7 +8769,7 @@ var ScriptingApi::Content::createShader(const String& fileName)
 	return var(f);
 }
 
-void ScriptingApi::Content::createScreenshot(var area, var directory, String name)
+void ScriptingApi::Content::createScreenshot(var area, var directory, String name, var scale)
 {
 	if (!screenshotListeners.isEmpty())
 	{
@@ -8801,6 +8801,9 @@ void ScriptingApi::Content::createScreenshot(var area, var directory, String nam
 						reportScriptError(r.getErrorMessage());
 				}
 
+				// A value <= 0 tells the listeners to fall back to the display's native scale factor
+				auto scaleFactor = (scale.isUndefined() || scale.isVoid()) ? -1.0f : (float)scale;
+
 				// Send a message to all listeners
 				for (auto sc : screenshotListeners)
 				{
@@ -8820,7 +8823,7 @@ void ScriptingApi::Content::createScreenshot(var area, var directory, String nam
 				for (auto sc : screenshotListeners)
 				{
 					if (sc != nullptr)
-						sc->makeScreenshot(target, a);
+						sc->makeScreenshot(target, a, scaleFactor);
 				}
 			}
 		}

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -3115,8 +3115,10 @@ public:
 	/** Sets the height of the content. */
 	void setWidth(int newWidth) noexcept;
 
-	/** Creates a screenshot of the area relative to the content's origin. */
-	void createScreenshot(var area, var directory, String name);
+	/** Creates a screenshot of the area relative to the content's origin. The optional scale
+	    argument (eg. 2.0 for 200%) renders the screenshot at that resolution instead of the
+	    display's native scale factor. */
+	void createScreenshot(var area, var directory, String name, var scale = var());
 
 	/** Creates either a line or rectangle with the given colour. */
 	void addVisualGuide(var guideData, var colour);

--- a/hi_scripting/scripting/api/ScriptingApiWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiWrappers.cpp
@@ -1084,7 +1084,8 @@ var ScriptingApi::Content::Wrapper::createScreenshot(const var::NativeFunctionAr
 	if (auto thisObject = GET_OBJECT(Content))
 	{
 		CHECK_ARGUMENTS("createScreenshot()", 3);
-		thisObject->createScreenshot(args.arguments[0], args.arguments[1], args.arguments[2]);
+		thisObject->createScreenshot(args.arguments[0], args.arguments[1], args.arguments[2],
+		                              args.numArguments > 3 ? args.arguments[3] : var());
 	}
 
 	return var();

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -49,7 +49,8 @@ struct ScreenshotListener
 
 	virtual ~ScreenshotListener() {};
 
-	virtual void makeScreenshot(const File& targetFile, Rectangle<float> area) {};
+	/** scaleFactor <= 0.0f means "use the display's native scale factor". */
+	virtual void makeScreenshot(const File& targetFile, Rectangle<float> area, float scaleFactor = -1.0f) {};
 
 	/** This will be called on the scripting thread and can be used by listeners to prepare the screenshot. */
 	virtual void prepareScreenshot() {};

--- a/hi_scripting/scripting/components/ScriptingContentComponent.cpp
+++ b/hi_scripting/scripting/components/ScriptingContentComponent.cpp
@@ -559,15 +559,15 @@ void ScriptContentComponent::scriptWasCompiled(JavascriptProcessor *jp)
 	}
 }
 
-void ScriptContentComponent::makeScreenshot(const File& target, Rectangle<float> area)
+void ScriptContentComponent::makeScreenshot(const File& target, Rectangle<float> area, float scaleFactor)
 {
 	WeakReference<ScriptContentComponent> safeThis(this);
 
-	SafeAsyncCall::callAsyncIfNotOnMessageThread<ScriptContentComponent>(*this, [target, area](ScriptContentComponent& st)
+	SafeAsyncCall::callAsyncIfNotOnMessageThread<ScriptContentComponent>(*this, [target, area, scaleFactor](ScriptContentComponent& st)
 	{
 		ScriptingObjects::ScriptShader::ScopedScreenshotRenderer ssr;
 
-		auto sf = UnblurryGraphics::getScaleFactorForComponent(&st);
+		auto sf = scaleFactor > 0.0f ? scaleFactor : UnblurryGraphics::getScaleFactorForComponent(&st);
 
 		st.repaint();
 

--- a/hi_scripting/scripting/components/ScriptingContentComponent.h
+++ b/hi_scripting/scripting/components/ScriptingContentComponent.h
@@ -200,7 +200,7 @@ public:
 	
     void paintOverChildren(Graphics& g) override;
     
-	void makeScreenshot(const File& target, Rectangle<float> area) override;
+	void makeScreenshot(const File& target, Rectangle<float> area, float scaleFactor = -1.0f) override;
 
 	void visualGuidesChanged() override;
 


### PR DESCRIPTION
A couple of little things for the createScreenshot function.

1) Matrix peak meter floating tile now shows up in screenshots.
2) Added optional 4th parameter to function to set scale factor for the screenshot.