### PR TITLE
Fix external MIDI automation file being wiped on preset reload

### DIFF
--- a/hi_core/hi_core/MainControllerHelpers.cpp
+++ b/hi_core/hi_core/MainControllerHelpers.cpp
@@ -839,7 +839,8 @@ void MidiControllerAutomationHandler::loadUnloadedData()
 	{
 		SimpleReadWriteLock::ScopedReadLock sl(unloadLock);
 
-		if(unloadedData.isValid())
+		// skip when external: the preset data would clear the persistent external state
+		if(unloadedData.isValid() && !matchesStateTarget(UserPresetStateManager::StateTarget::External))
 			restoreFromValueTree(unloadedData);
 	}
 


### PR DESCRIPTION
MidiControllerAutomationHandler::loadUnloadedData() unconditionally restored the MidiAutomation node embedded in whatever preset ValueTree was being loaded, even when the handler's state target is set to External via setStateManagerProperties(). Since that embedded node is normally empty once automation is routed to an external file, restoring it cleared the in-memory automation data and, through the change notification in restoreFromValueTree(), caused the ExternalSaver listener to immediately flush that empty state back to the external XML file.

This is most visible when closing an expansion (setCurrentExpansion("")) triggers a reload of the default/base preset: that reload doesn't re-run the expansion's setStateManagerProperties() call, so the existing guard in setStateManagerProperties() (which clears unloadedData when not targeting PluginState) never re-applies, and the stale empty automation data slips through.

Guard loadUnloadedData() the same way ModulatorSynthChain::restoreFromValueTree() already guards its own MidiAutomation/MPEData restoration, by skipping the restore when the handler's state target is External.