### PR TITLE
Add letterSpacing property to ScriptLabel

### DIFF
--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -1420,7 +1420,8 @@ void ScriptCreatedComponentWrappers::LabelWrapper::updateComponent(int propertyI
 		PROPERTY_CASE::ScriptLabel::FontName:
 		PROPERTY_CASE::ScriptLabel::FontSize :
 		PROPERTY_CASE::ScriptLabel::FontStyle :
-		PROPERTY_CASE::ScriptLabel::Alignment :		updateFont(sc, l); break;
+		PROPERTY_CASE::ScriptLabel::Alignment :
+		PROPERTY_CASE::ScriptLabel::LetterSpacing :	updateFont(sc, l); break;
 		PROPERTY_CASE::ScriptLabel::Editable:		 updateEditability(sc, l); break;
 		PROPERTY_CASE::ScriptLabel::Multiline:		l->setMultiline(newValue); break;
         PROPERTY_CASE::ScriptLabel::SendValueEachKeyPress: sendValueEachKey = (bool)newValue;break;
@@ -1464,21 +1465,24 @@ void ScriptCreatedComponentWrappers::LabelWrapper::updateFont(ScriptingApi::Cont
 	const String fontName = sl->getScriptObjectProperty(ScriptingApi::Content::ScriptLabel::FontName).toString();
 	const String fontStyle = sl->getScriptObjectProperty(ScriptingApi::Content::ScriptLabel::FontStyle).toString();
 	const float fontSize = (float)sl->getScriptObjectProperty(ScriptingApi::Content::ScriptLabel::FontSize);
+	const float letterSpacing = (float)sl->getScriptObjectProperty(ScriptingApi::Content::ScriptLabel::LetterSpacing);
+
+	Font font;
 
 	if (fontName == "Oxygen" || fontName == "Default")
 	{
 		if (fontStyle == "Bold")
 		{
-			l->setFont(GLOBAL_BOLD_FONT().withHeight(fontSize));
+			font = GLOBAL_BOLD_FONT().withHeight(fontSize);
 		}
 		else
 		{
-			l->setFont(GLOBAL_FONT().withHeight(fontSize));
+			font = GLOBAL_FONT().withHeight(fontSize);
 		}
 	}
 	else if (fontName == "Source Code Pro")
 	{
-		l->setFont(GLOBAL_MONOSPACE_FONT().withHeight(fontSize));
+		font = GLOBAL_MONOSPACE_FONT().withHeight(fontSize);
 	}
 	else
 	{
@@ -1486,16 +1490,17 @@ void ScriptCreatedComponentWrappers::LabelWrapper::updateFont(ScriptingApi::Cont
 
 		if (typeface != nullptr)
 		{
-			Font font = Font(typeface).withHeight(fontSize);
-			l->setFont(font);
+			font = Font(typeface).withHeight(fontSize);
 		}
 		else
 		{
-			Font font(fontName, fontStyle, fontSize);
-			l->setFont(font);
+			font = Font(fontName, fontStyle, fontSize);
 		}
 	}
-	
+
+	l->setFont(font.withExtraKerningFactor(letterSpacing));
+
+
 	l->setUsePasswordCharacter(fontStyle == "Password");
 
 	l->setJustificationForLabelAndTextEditor(sl->getJustification());

--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -2817,7 +2817,8 @@ ScriptComponent(base, name)
 	ADD_SCRIPT_PROPERTY(i05, "editable");	ADD_TO_TYPE_SELECTOR(SelectorTypes::ToggleSelector);
 	ADD_SCRIPT_PROPERTY(i06, "multiline");	ADD_TO_TYPE_SELECTOR(SelectorTypes::ToggleSelector);
     ADD_SCRIPT_PROPERTY(i07, "updateEachKey"); ADD_TO_TYPE_SELECTOR(SelectorTypes::ToggleSelector);
-    
+	ADD_NUMBER_PROPERTY(i08, "letterSpacing"); ADD_AS_SLIDER_TYPE(-0.5, 1.0, 0.01);
+
 	setDefaultValue(ScriptComponent::Properties::x, x);
 	setDefaultValue(ScriptComponent::Properties::y, y);
 	setDefaultValue(ScriptComponent::Properties::width, 128);
@@ -2834,6 +2835,7 @@ ScriptComponent(base, name)
 	setDefaultValue(Editable, true);
 	setDefaultValue(Multiline, false);
     setDefaultValue(SendValueEachKeyPress, false);
+	setDefaultValue(LetterSpacing, 0.0f);
 
 	handleDefaultDeactivatedProperties();
 

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -1343,6 +1343,7 @@ public:
 			Editable,
 			Multiline,
             SendValueEachKeyPress,
+			LetterSpacing,
 			numProperties
 		};
 


### PR DESCRIPTION
## Summary

Adds a `letterSpacing` float property to ScriptLabel, as requested on the forum: https://forum.hise.audio/topic/14953/letter-spacing-kerning-on-scriptlabel

`Graphics.setFontWithSpacing()` already supports letter spacing via `Font::setExtraKerningFactor()`, but that only helps for static text painted in a LAF or panel - labels with dynamic or editable text had no way to use it.

## Changes

- New `letterSpacing` property on ScriptLabel (float, default 0.0, shown as a slider from -0.5 to 1.0). Same semantics as the `spacing` argument of `Graphics.setFontWithSpacing()`.
- `LabelWrapper::updateFont()` now builds the font in a local variable across the existing branches (default fonts, monospace, project fonts, system fonts) and applies `withExtraKerningFactor()` once before `setFont()`.
- Property change case added so live edits in the interface designer and scripted `set("letterSpacing", ...)` calls refresh the font immediately.

The property is appended after the existing ones, so property indices and existing interface JSON are unaffected (default 0.0 renders identically to before). Editable labels keep the spacing while editing because `Label::showEditor()` copies the label font, including the kerning factor, into its TextEditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)