### PR TITLE
Add MarkdownRenderer.getLinkAtPosition() for clickable links on ScriptPanels

### DIFF
--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -1530,6 +1530,7 @@ struct ScriptingObjects::MarkdownObject::Wrapper
 	API_VOID_METHOD_WRAPPER_1(MarkdownObject, setImageProvider);
 	API_METHOD_WRAPPER_1(MarkdownObject, setTextBounds);
 	API_METHOD_WRAPPER_0(MarkdownObject, getStyleData);
+	API_METHOD_WRAPPER_1(MarkdownObject, getLinkAtPosition);
 };
 
 ScriptingObjects::MarkdownObject::MarkdownObject(ProcessorWithScriptingContent* pwsc) :
@@ -1541,6 +1542,7 @@ ScriptingObjects::MarkdownObject::MarkdownObject(ProcessorWithScriptingContent* 
 	ADD_API_METHOD_1(setTextBounds);
 	ADD_API_METHOD_0(getStyleData);
 	ADD_API_METHOD_1(setImageProvider);
+	ADD_API_METHOD_1(getLinkAtPosition);
 }
 
 
@@ -1601,6 +1603,27 @@ void ScriptingObjects::MarkdownObject::setImageProvider(var data)
 	ScopedLock sl(obj->lock);
 	obj->renderer.clearResolvers();
 	obj->renderer.setImageProvider(newProvider);
+}
+
+String ScriptingObjects::MarkdownObject::getLinkAtPosition(var position)
+{
+	auto r = Result::ok();
+	auto p = ApiHelpers::getPointFromVar(position, &r);
+
+	if (r.failed())
+		reportScriptError(r.getErrorMessage());
+
+	ScopedLock sl(obj->lock);
+
+	if (obj->area.isEmpty())
+		return {};
+
+	auto link = obj->renderer.getHyperLinkForPoint(p - obj->area.getPosition(), obj->area.withZeroOrigin());
+
+	if (link.valid)
+		return link.url.toString(MarkdownLink::UrlFull);
+
+	return {};
 }
 
 struct ScriptingObjects::GraphicsObject::Wrapper

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -581,6 +581,9 @@ namespace ScriptingObjects
 		/** Creates an image provider from the given JSON data that resolves image links. */
 		void setImageProvider(var data);
 
+		/** Returns the URL of the hyperlink at the given position (a [x, y] array relative to the panel), or an empty string if there is no link. */
+		String getLinkAtPosition(var position);
+
 		// ============================================================================================================ API End
 
 		hise::DrawActions::MarkdownAction::Ptr obj;

--- a/hi_tools/hi_markdown/Markdown.cpp
+++ b/hi_tools/hi_markdown/Markdown.cpp
@@ -336,6 +336,11 @@ Array<MarkdownLink> MarkdownParser::getImageLinks() const
 
 hise::MarkdownParser::HyperLink MarkdownParser::getHyperLinkForEvent(const MouseEvent& event, Rectangle<float> area)
 {
+	return getHyperLinkForPoint(event.getPosition().toFloat(), area);
+}
+
+hise::MarkdownParser::HyperLink MarkdownParser::getHyperLinkForPoint(Point<float> position, Rectangle<float> area)
+{
 	if (!containsLinks)
 	{
 		return {};
@@ -349,9 +354,9 @@ hise::MarkdownParser::HyperLink MarkdownParser::getHyperLinkForEvent(const Mouse
 		heightToUse += e->getTopMargin();
 		Rectangle<float> eBounds(area.getX(), y, area.getWidth(), heightToUse);
 
-		if (eBounds.contains(event.getPosition().toFloat()))
+		if (eBounds.contains(position))
 		{
-			auto translatedPoint = event.getPosition().toFloat();
+			auto translatedPoint = position;
 			translatedPoint.addXY(eBounds.getX(), -eBounds.getY());
 
 			Array<HyperLink> matches;

--- a/hi_tools/hi_markdown/Markdown.h
+++ b/hi_tools/hi_markdown/Markdown.h
@@ -215,6 +215,8 @@ public:
 
 	HyperLink getHyperLinkForEvent(const MouseEvent& event, Rectangle<float> area);
 
+	HyperLink getHyperLinkForPoint(Point<float> position, Rectangle<float> area);
+
 	static void createDatabaseEntriesForFile(File root, MarkdownDataBase::Item* item, File f, Colour c);
 
 	struct SnippetTokeniser : public CodeTokeniser


### PR DESCRIPTION
Markdown text drawn on a ScriptPanel via `Content.createMarkdownRenderer()` and `Graphics.drawMarkdownText()` renders hyperlinks as underlined text, but there is no way for the script to detect clicks on them, so links are purely decorative.

This adds one scripting API method to the MarkdownRenderer object:

```javascript
Panel1.setMouseCallback(function(event)
{
	var link = md.getLinkAtPosition([event.x, event.y]);

	if (event.clicked && link.length > 0)
		Engine.openWebsite(link);
	else
		this.setMouseCursor(link.length > 0 ? "PointingHandCursor" : "NormalCursor", Colours.white, [0, 0]);
});
```

It returns the URL of the hyperlink at the given panel-relative `[x, y]` position, or an empty string. The script decides what to do with the link, and the same call drives a hand cursor on hover.

Implementation notes:

- The hit-test reuses the hyperlink rectangles the parser already stores: the body of `MarkdownParser::getHyperLinkForEvent` is extracted unchanged into a new point-based `getHyperLinkForPoint`, with the event version delegating to it, so all existing callers (doc browser etc.) behave identically.
- The new method translates the panel-local position into document space using the area set by `setTextBounds()` and takes the same lock as the other MarkdownRenderer scripting methods.
- Returns an empty string if `setTextBounds()` has not been called yet; a malformed position argument reports a script error via the existing `ApiHelpers::getPointFromVar` validation.

Tested in the IDE: clicking a rendered link opens the browser, clicks on plain text and empty space do nothing, hover cursor works, and internal and external links in the in-app documentation browser still work through the delegating code path.

Requested on the forum: https://forum.hise.audio/topic/14023/how-to-do-text-links-in-a-settings-panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)