### PR TITLE
Add LineSpacing and LetterSpacing properties to the markdown StyleData

### DIFF
--- a/hi_tools/hi_markdown/MarkdownElements.cpp
+++ b/hi_tools/hi_markdown/MarkdownElements.cpp
@@ -66,7 +66,7 @@ struct MarkdownParser::TextBlock : public MarkdownParser::Element
 		}
 		else
 		{
-			l = { content, width, parent->stringWidthFunction };
+			l = { content, width, parent->stringWidthFunction, false, parent->styleData.lineSpacing };
 
 			l.addYOffset((float)getTopMargin());
 			l.styleData = parent->styleData;
@@ -308,8 +308,8 @@ struct MarkdownParser::Headline : public MarkdownParser::Element
 
 	float getHeightForWidth(float width) override
 	{
-		l = { content, width, parent->stringWidthFunction};
-		
+		l = { content, width, parent->stringWidthFunction, false, parent->styleData.lineSpacing };
+
 		l.styleData = parent->styleData;
 
 		auto idx = jlimit(0, 4, headlineLevel-1);
@@ -506,7 +506,7 @@ struct MarkdownParser::BulletPointList : public MarkdownParser::Element
 
 		for (auto& r : rows)
 		{
-			r.l = { r.content, width - bulletPointIntendation, parent->stringWidthFunction };
+			r.l = { r.content, width - bulletPointIntendation, parent->stringWidthFunction, false, parent->styleData.lineSpacing };
 			r.l.addXOffset(bulletPointIntendation);
 			r.l.styleData = parent->styleData;
 
@@ -642,7 +642,7 @@ struct MarkdownParser::Comment : public MarkdownParser::Element
 		{
 			lastWidth = widthToUse;
 
-			l = { content, widthToUse - thisIndentation, parent->stringWidthFunction };
+			l = { content, widthToUse - thisIndentation, parent->stringWidthFunction, false, parent->styleData.lineSpacing };
 			l.addYOffset((float)getTopMargin() + thisIndentation);
 			l.addXOffset(thisIndentation);
 			l.styleData = parent->styleData;
@@ -1275,7 +1275,7 @@ struct MarkdownParser::MarkdownTable : public MarkdownParser::Element
 				float w = getColumnWidth(width, h.index);
 				auto contentWidth = w - 2.0f * intendation;
 
-				h.l = MarkdownLayout(h.content, contentWidth, parser->stringWidthFunction);
+				h.l = MarkdownLayout(h.content, contentWidth, parser->stringWidthFunction, false, parser->styleData.lineSpacing);
 				h.l.styleData = parser->styleData;
 				
 				rowHeight = jmax(rowHeight, calculateHeightForCell(h, contentWidth, parser) + 2.0f * intendation);

--- a/hi_tools/hi_markdown/MarkdownLayout.cpp
+++ b/hi_tools/hi_markdown/MarkdownLayout.cpp
@@ -33,7 +33,7 @@
 namespace hise {
 using namespace juce;
 
-MarkdownLayout::MarkdownLayout(const AttributedString& s, float width, const StringWidthFunction& f, bool allInOne)
+MarkdownLayout::MarkdownLayout(const AttributedString& s, float width, const StringWidthFunction& f, bool allInOne, float lineSpacing)
 {
 	stringWidthFunction = f;
 
@@ -103,7 +103,7 @@ MarkdownLayout::MarkdownLayout(const AttributedString& s, float width, const Str
 
 				if (allowedToWrap && ((wordEndX > width + 1.0f) || isNewLine))
 				{
-					yPos += a.font.getHeight() * 1.5f;
+					yPos += a.font.getHeight() * lineSpacing;
 					currentX = marginBetweenAttributes;
 					allowedToWrap = false;
 
@@ -289,6 +289,8 @@ bool MarkdownLayout::StyleData::fromDynamicObject(var obj, const std::function<F
 	auto bName = obj.getProperty(MarkdownStyleIds::BoldFont, "default");
 	useSpecialBoldFont = obj.getProperty(MarkdownStyleIds::UseSpecialBoldFont, useSpecialBoldFont);
 	fontSize = obj.getProperty(MarkdownStyleIds::FontSize, fontSize);
+	lineSpacing = obj.getProperty(MarkdownStyleIds::LineSpacing, lineSpacing);
+	letterSpacing = obj.getProperty(MarkdownStyleIds::LetterSpacing, letterSpacing);
 
 	if(fName == "default")
 		f = GLOBAL_FONT();
@@ -340,6 +342,8 @@ juce::var MarkdownLayout::StyleData::toDynamicObject(bool colourAsString) const
 	obj->setProperty(MarkdownStyleIds::Font, f.getTypefaceName());
 	obj->setProperty(MarkdownStyleIds::BoldFont, boldFont.getTypefaceName());
 	obj->setProperty(MarkdownStyleIds::FontSize, fontSize);
+	obj->setProperty(MarkdownStyleIds::LineSpacing, lineSpacing);
+	obj->setProperty(MarkdownStyleIds::LetterSpacing, letterSpacing);
 	obj->setProperty(MarkdownStyleIds::bgColour, getColour(backgroundColour));
 	obj->setProperty(MarkdownStyleIds::codeBgColour, getColour(codebackgroundColour));
 	obj->setProperty(MarkdownStyleIds::linkBgColour, getColour(linkBackgroundColour));

--- a/hi_tools/hi_markdown/MarkdownLayout.h
+++ b/hi_tools/hi_markdown/MarkdownLayout.h
@@ -41,6 +41,8 @@ namespace MarkdownStyleIds
 	DECLARE_ID(Font);
 	DECLARE_ID(BoldFont);
 	DECLARE_ID(FontSize);
+	DECLARE_ID(LineSpacing);
+	DECLARE_ID(LetterSpacing);
 	DECLARE_ID(bgColour);
 	DECLARE_ID(codeBgColour);
 	DECLARE_ID(linkBgColour);
@@ -61,7 +63,7 @@ struct MarkdownLayout
 	// our own getStringWidth function...
 	using StringWidthFunction = std::function<float(const Font&, const String&)>;
 
-	MarkdownLayout(const AttributedString& s, float width, const StringWidthFunction& f, bool allInOne=false);
+	MarkdownLayout(const AttributedString& s, float width, const StringWidthFunction& f, bool allInOne=false, float lineSpacing=1.5f);
 
 	struct StyleData
 	{
@@ -83,6 +85,10 @@ struct MarkdownLayout
 		Colour tableLineColour;
 
 		bool useSpecialBoldFont = false;
+
+		float lineSpacing = 1.5f;
+
+		float letterSpacing = 0.0f;
 
 		std::array<float, 4> headlineFontSize = { 2.375f, 1.9375f, 1.5f, 1.2f };
 
@@ -113,12 +119,12 @@ struct MarkdownLayout
 		Font getBoldFont() const
 		{
 			if (useSpecialBoldFont)
-				return boldFont;
+				return boldFont.withExtraKerningFactor(letterSpacing);
 
-            return FontHelpers::getFontBoldened(getFont());
+            return FontHelpers::getFontBoldened(getFont()).withExtraKerningFactor(letterSpacing);
 		}
 
-		Font getFont() const { return f.withHeight(fontSize); }
+		Font getFont() const { return f.withHeight(fontSize).withExtraKerningFactor(letterSpacing); }
 	};
 
 	void addYOffset(float delta);


### PR DESCRIPTION
The line advance in the markdown glyph layout is hardcoded to 1.5x the font height, and there is no way to adjust letter spacing in markdown text at all. This adds both as style properties, settable from HISEScript:

```javascript
const var md = Content.createMarkdownRenderer();
md.setStyleData({"LineSpacing": 1.25, "LetterSpacing": 0.02});
```

Implementation notes:

- **LineSpacing** (default 1.5, so unchanged behavior when not set): the factor is passed into the `MarkdownLayout` constructor from the element re-layout sites, since the glyph positioning loop runs in the constructor before `styleData` is assigned to the layout. The zero-width constructor-time layouts are unaffected because the constructor returns early at width 0.
- **LetterSpacing** (default 0.0): applied as a `Font` extra kerning factor in `StyleData::getFont()` and `getBoldFont()`, so it flows automatically through all derived fonts (headlines, bold runs), the wrap-width measurement (which already forwards `getExtraKerningFactor()`), and the hyperlink hit rectangles. The value has the same semantics as `Graphics.setFontWithSpacing` and the ScriptLabel `letterSpacing` property from #1006. Inline code spans keep the monospace font untouched.
- Both properties round-trip through `StyleData::toDynamicObject()` / `fromDynamicObject()`.

Anything that does not set the properties (docs browser, MarkdownPanel floating tiles, multipage dialogs) renders exactly as before.

Tested in the IDE with a ScriptPanel markdown renderer: both properties apply to regular and bold text, defaults render identically to the previous hardcoded values, and link hit-testing (with #1007 applied) stays aligned with the adjusted glyph positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)