### PR TITLE
Add ShowFolderRows option to the single column PresetBrowser

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1009,6 +1009,7 @@ var PresetBrowserPanel::toDynamicObject() const
 	storePropertyInObject(obj, SpecialPanelIds::FullPathFavorites, options.fullPathFavorites);
 	storePropertyInObject(obj, SpecialPanelIds::ButtonsInsideBorder, options.buttonsInsideBorder);
 	storePropertyInObject(obj, SpecialPanelIds::NumColumns, options.numColumns);
+	storePropertyInObject(obj, SpecialPanelIds::ShowFolderRows, options.showFolderRows);
 	storePropertyInObject(obj, SpecialPanelIds::ColumnWidthRatio, var(options.columnWidthRatios));
 	storePropertyInObject(obj, SpecialPanelIds::ListAreaOffset, var(options.listAreaOffset));
 	storePropertyInObject(obj, SpecialPanelIds::ColumnRowPadding, var(options.columnRowPadding));
@@ -1038,6 +1039,7 @@ void PresetBrowserPanel::fromDynamicObject(const var& object)
 	options.editButtonOffset = getPropertyWithDefault(object, SpecialPanelIds::EditButtonOffset);
 	options.showExpansions = getPropertyWithDefault(object, SpecialPanelIds::ShowExpansionsAsColumn);
 	options.numColumns = getPropertyWithDefault(object, SpecialPanelIds::NumColumns);
+	options.showFolderRows = getPropertyWithDefault(object, SpecialPanelIds::ShowFolderRows);
 
 	auto ratios = getPropertyWithDefault(object, SpecialPanelIds::ColumnWidthRatio);
 	if (ratios.isArray())
@@ -1132,6 +1134,7 @@ juce::Identifier PresetBrowserPanel::getDefaultablePropertyId(int index) const
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::SaveButtonBounds, "SaveButtonBounds");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::MoreButtonBounds, "MoreButtonBounds");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::NumColumns, "NumColumns");
+	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowFolderRows, "ShowFolderRows");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ColumnWidthRatio, "ColumnWidthRatio");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowExpansionsAsColumn, "ShowExpansionsAsColumn");
 	RETURN_DEFAULT_PROPERTY_ID(index, SpecialPanelIds::ShowFavoriteIcon, "ShowFavoriteIcon");
@@ -1163,6 +1166,7 @@ var PresetBrowserPanel::getDefaultProperty(int index) const
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ButtonsInsideBorder, false);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::EditButtonOffset, 10);
 	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::NumColumns, 3);
+	RETURN_DEFAULT_PROPERTY(index, SpecialPanelIds::ShowFolderRows, false);
 
 	Array<var> defaultRatios;
 	defaultRatios.insertMultiple(0, 1.0 / 3.0, 3);

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -506,6 +506,7 @@ public:
 		FavoriteButtonBounds,
     FullPathFavorites,
     FavoriteIconOffset,
+		ShowFolderRows,
 		numSpecialProperties
 	};
 

--- a/hi_core/hi_components/plugin_components/PresetBrowser.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.cpp
@@ -1293,6 +1293,15 @@ void PresetBrowser::setOptions(const Options& newOptions)
 
 	getPresetBrowserLookAndFeel().textColour = newOptions.textColour;
 	setNumColumns(newOptions.numColumns);
+
+	// Folder rows are only supported in the single column layout
+	showFolderRows = newOptions.showFolderRows;
+	presetColumn->setShowFolderRows(showFolderRows && numColumns == 1);
+
+	// Toggling folder rows shifts the row indexes, so re-sync the selection
+	if (numColumns == 1 && currentlyLoadedPreset != -1)
+		presetColumn->setSelectedFile(allPresets[currentlyLoadedPreset]);
+
 	columnWidthRatios.clear();
 	columnWidthRatios.addArray(newOptions.columnWidthRatios);
 	
@@ -1381,7 +1390,10 @@ void PresetBrowser::selectionChanged(int columnIndex, int /*rowIndex*/, const Fi
 		auto pc = new PresetBrowserColumn::ColumnListModel(this, 2, this);
 		pc->setDisplayDirectories(false);
 		presetColumn->setModel(pc, rootFile);
-		
+
+		// The freshly created model needs the folder row setting reapplied
+		presetColumn->setShowFolderRows(showFolderRows && numColumns == 1);
+
 		loadPresetDatabase(rootFile);
 		presetColumn->setDatabase(getDataBase());
 		rebuildAllPresets();

--- a/hi_core/hi_components/plugin_components/PresetBrowser.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowser.h
@@ -96,6 +96,7 @@ public:
 		bool showFavoriteIcons = true;
 		bool fullPathFavorites = false;
 		bool showExpansions = false;
+		bool showFolderRows = false;
 	};
 
 	// ============================================================================================
@@ -272,6 +273,7 @@ private:
 	// ============================================================================================
 
 	int numColumns = 3;
+	bool showFolderRows = false;
 	Array<var> columnWidthRatios;
 	Array<var> searchBarBounds;
 	Array<var> favoriteButtonBounds;

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.cpp
@@ -232,6 +232,7 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		if (!rootToUse.isDirectory())
 		{
 			entries.clear();
+			folderRowMap.clearQuick();
 			return 0;
 		}
 
@@ -253,7 +254,12 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		}
 
 		entries.sort();
+		rebuildFolderRows();
 		empty = entries.isEmpty();
+
+		if (!folderRowMap.isEmpty())
+			return folderRowMap.size();
+
 		return entries.size();
 	}
 	else
@@ -312,41 +318,123 @@ int PresetBrowserColumn::ColumnListModel::getNumRows()
 		}
 
 		entries.sort();
+
+		// No folder rows in search / tag / favorite result lists
+		folderRowMap.clearQuick();
+
 		empty = entries.isEmpty();
 		return entries.size();
 	}
 }
 
+void PresetBrowserColumn::ColumnListModel::rebuildFolderRows()
+{
+	folderRowMap.clearQuick();
+
+	if (!showFolderRows || showFavoritesOnly)
+		return;
+
+	File lastParent;
+
+	for (int i = 0; i < entries.size(); i++)
+	{
+		auto parentDirectory = entries[i].getParentDirectory();
+
+		// Presets sitting directly in the root don't get a folder row
+		if (parentDirectory != lastParent && parentDirectory != root)
+		{
+			lastParent = parentDirectory;
+
+			RowEntry folderRow;
+			folderRow.folderName = parentDirectory.getFileName();
+			folderRowMap.add(folderRow);
+		}
+
+		RowEntry presetRow;
+		presetRow.entryIndex = i;
+		folderRowMap.add(presetRow);
+	}
+}
+
+int PresetBrowserColumn::ColumnListModel::getEntryIndexForRow(int rowIndex) const
+{
+	if (folderRowMap.isEmpty())
+		return rowIndex;
+
+	if (isPositiveAndBelow(rowIndex, folderRowMap.size()))
+		return folderRowMap[rowIndex].entryIndex;
+
+	return -1;
+}
+
+int PresetBrowserColumn::ColumnListModel::getRowForEntryIndex(int entryIndex) const
+{
+	if (folderRowMap.isEmpty() || entryIndex < 0)
+		return entryIndex;
+
+	for (int i = 0; i < folderRowMap.size(); i++)
+	{
+		if (folderRowMap[i].entryIndex == entryIndex)
+			return i;
+	}
+
+	return -1;
+}
+
 void PresetBrowserColumn::ColumnListModel::listBoxItemClicked(int row, const MouseEvent &e)
 {
+	const int entryIndex = getEntryIndexForRow(row);
+
+	if (entryIndex == -1)
+	{
+		// Folder rows are display-only: undo the listbox selection caused by the click
+		if (auto lb = dynamic_cast<ListBox*>(parent->getColumn(index)))
+		{
+			auto currentFile = parent->getMainController()->getUserPresetHandler().getCurrentlyLoadedFile();
+			const int rowToSelect = getIndexForFile(currentFile);
+
+			if (rowToSelect != -1)
+				lb->selectRow(rowToSelect);
+			else
+				lb->deselectRow(row);
+		}
+
+		return;
+	}
+
 	auto maxWidth = e.eventComponent->getWidth() - e.eventComponent->getHeight();
 	bool deleteAction = deleteOnClick && e.getMouseDownX() > maxWidth;
 
 	if (deleteAction)
 	{
 		const String title = index != 2 ? "Directory" : "Preset";
-		auto name = entries[row].getFileNameWithoutExtension();
+		auto name = entries[entryIndex].getFileNameWithoutExtension();
 		auto pb = dynamic_cast<PresetBrowser*>(listener);
 
 		if (pb == nullptr)
 			return;
 
-		pb->openModalAction(PresetBrowser::ModalWindow::Action::Delete, name, entries[row], index, row);
+		pb->openModalAction(PresetBrowser::ModalWindow::Action::Delete, name, entries[entryIndex], index, row);
 
 	}
 	else
 	{
 		if (listener != nullptr && !e.mouseWasDraggedSinceMouseDown())
-			listener->selectionChanged(index, row, entries[row], false);
+			listener->selectionChanged(index, row, entries[entryIndex], false);
 	}
 }
 
 
 void PresetBrowserColumn::ColumnListModel::returnKeyPressed(int row)
 {
+	const int entryIndex = getEntryIndexForRow(row);
+
+	if (entryIndex == -1)
+		return;
+
 	if (listener != nullptr)
 	{
-		listener->selectionChanged(index, row, entries[row], false);
+		listener->selectionChanged(index, row, entries[entryIndex], false);
 	}
 }
 
@@ -386,17 +474,29 @@ void PresetBrowserColumn::ColumnListModel::updateTags(const StringArray& newSele
 
 void PresetBrowserColumn::ColumnListModel::paintListBoxItem(int rowNumber, Graphics &g, int width, int height, bool rowIsSelected)
 {
-	if (rowNumber < entries.size())
+	auto position = Rectangle<int>(0, 1, width, height - 2);
+
+	if (isFolderRow(rowNumber))
 	{
-		auto itemName = entries[rowNumber].getFileNameWithoutExtension();
-		auto position = Rectangle<int>(0, 1, width, height - 2);
+		auto column = parent->getColumn(index);
+		jassert(dynamic_cast<ListBox*>(column)->getModel() == this);
+
+		getPresetBrowserLookAndFeel().drawFolderRow(g, *column, index, rowNumber, folderRowMap[rowNumber].folderName, position);
+		return;
+	}
+
+	const int entryIndex = getEntryIndexForRow(rowNumber);
+
+	if (entryIndex >= 0 && entryIndex < entries.size())
+	{
+		auto itemName = entries[entryIndex].getFileNameWithoutExtension();
 
 		auto column = parent->getColumn(index);
 		jassert(dynamic_cast<ListBox*>(column)->getModel() == this);
-		
+
     if (showFavoritesOnly && parent.getComponent()->shouldShowFullPathFavorites())
-			itemName = entries[rowNumber].getRelativePathFrom(totalRoot);
-    
+			itemName = entries[entryIndex].getRelativePathFrom(totalRoot);
+
 		getPresetBrowserLookAndFeel().drawListItem(g, *column, index, rowNumber, itemName, position, rowIsSelected, deleteOnClick, isMouseHover(rowNumber));
 	}
 }
@@ -417,7 +517,7 @@ Component* PresetBrowserColumn::ColumnListModel::refreshComponentForRow(int rowN
 	if (existingComponentToUpdate != nullptr)
 		delete existingComponentToUpdate;
 
-	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton())
+	if (index == 2 && parent.getComponent()->shouldShowFavoritesButton() && !isFolderRow(rowNumber))
 	{
 		return new FavoriteOverlay(*this, rowNumber);
 	}
@@ -427,8 +527,12 @@ Component* PresetBrowserColumn::ColumnListModel::refreshComponentForRow(int rowN
 
 void PresetBrowserColumn::ColumnListModel::sendRowChangeMessage(int row)
 {
+	if (isFolderRow(row))
+		return;
+
+	// A row of -1 must keep sending a notification with an empty file (used by the expansion column)
 	if (listener != nullptr)
-		listener->selectionChanged(index, row, entries[row], false);
+		listener->selectionChanged(index, row, entries[getEntryIndexForRow(row)], false);
 }
 
 
@@ -802,6 +906,11 @@ void PresetBrowserColumn::timerCallback()
 
 void PresetBrowserColumn::setSelectedFile(const File& file, NotificationType notifyListeners)
 {
+	// The listbox rebuilds its rows asynchronously, so refresh the model here to
+	// resolve the file against the row mapping that will actually be displayed
+	if (listModel->isShowingFolderRows())
+		listModel->getNumRows();
+
 	const int rowIndex = listModel->getIndexForFile(file);
 
 	if (auto ec = dynamic_cast<ExpansionColumnModel*>(listModel.get()))

--- a/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
+++ b/hi_core/hi_components/plugin_components/PresetBrowserComponents.h
@@ -310,14 +310,31 @@ public:
 			showFavoritesOnly = shouldShowFavoritesOnly;
 		}
 
+		/** Enables display-only folder rows between the presets of different subfolders (single column layout only). */
+		void setShowFolderRows(bool shouldShowFolderRows)
+		{
+			showFolderRows = shouldShowFolderRows;
+		}
+
+		/** Returns true if the given listbox row is a display-only folder row. */
+		bool isFolderRow(int rowIndex) const
+		{
+			return !folderRowMap.isEmpty() && getEntryIndexForRow(rowIndex) == -1;
+		}
+
+		bool isShowingFolderRows() const
+		{
+			return showFolderRows;
+		}
+
 		File getFileForIndex(int fileIndex) const
 		{
-			return entries[fileIndex];
+			return entries[getEntryIndexForRow(fileIndex)];
 		};
 
 		int getIndexForFile(const File& f) const
 		{
-			return entries.indexOf(f);
+			return getRowForEntryIndex(entries.indexOf(f));
 		}
 		
 		String wildcard;
@@ -337,9 +354,27 @@ public:
 
 	protected:
 
+		/** A row in the listbox: either a regular entry or a display-only folder row. */
+		struct RowEntry
+		{
+			int entryIndex = -1;
+			String folderName;
+		};
+
+		/** Rebuilds the row map after entries have been scanned and sorted. Empty when folder rows are inactive. */
+		void rebuildFolderRows();
+
+		/** Maps a listbox row to an index into entries. Returns -1 for folder rows. Identity when folder rows are inactive. */
+		int getEntryIndexForRow(int rowIndex) const;
+
+		/** Maps an index into entries to its listbox row. Identity when folder rows are inactive. */
+		int getRowForEntryIndex(int entryIndex) const;
+
 		bool empty = false;
 		bool showFavoritesOnly = false;
-		
+		bool showFolderRows = false;
+		Array<RowEntry> folderRowMap;
+
 		Listener* listener;
 		bool editMode = false;
 		bool displayDirectories = true;
@@ -404,6 +439,12 @@ public:
 	void setAllowRecursiveFileSearch(bool shouldAllow)
 	{
 		listModel->allowRecursiveSearch = shouldAllow;
+		listbox->updateContent();
+	}
+
+	void setShowFolderRows(bool shouldShowFolderRows)
+	{
+		listModel->setShowFolderRows(shouldShowFolderRows);
 		listbox->updateContent();
 	}
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2684,6 +2684,7 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
         "drawPresetBrowserDialog",
 		"drawPresetBrowserColumnBackground",
 		"drawPresetBrowserListItem",
+		"drawPresetBrowserFolderRow",
 		"drawPresetBrowserSearchBar",
 		"drawPresetBrowserTag",
 		"drawWavetableBackground",
@@ -4886,6 +4887,29 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawListItem(Graphics& g_, Comp
 	}
 
 	PresetBrowserLookAndFeelMethods::drawListItem(g_, column, columnIndex, rowIndex, itemName, position, rowIsSelected, deleteMode, hover);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFolderRow(Graphics& g_, Component& column, int columnIndex, int rowIndex, const String& folderName, Rectangle<int> position)
+{
+	if (functionDefined("drawPresetBrowserFolderRow"))
+	{
+		auto obj = new DynamicObject();
+		obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, position.toFloat()));
+		obj->setProperty("columnIndex", columnIndex);
+		obj->setProperty("rowIndex", rowIndex);
+		obj->setProperty("text", folderName);
+		obj->setProperty("bgColour", backgroundColour.getARGB());
+		obj->setProperty("itemColour", highlightColour.getARGB());
+		obj->setProperty("itemColour2", modalBackgroundColour.getARGB());
+		obj->setProperty("textColour", textColour.getARGB());
+		obj->setProperty("font", font.getTypefaceName());
+		obj->setProperty("fontSize", font.getHeight());
+
+		if (get()->callWithGraphics(g_, "drawPresetBrowserFolderRow", var(obj), nullptr))
+			return;
+	}
+
+	PresetBrowserLookAndFeelMethods::drawFolderRow(g_, column, columnIndex, rowIndex, folderName, position);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawSearchBar(Graphics& g_, Component& label, Rectangle<int> area)

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -894,6 +894,7 @@ namespace ScriptingObjects
 			void drawTag(Graphics& g, Component& tagButton, bool hover, bool blinking, bool active, bool selected, const String& name, Rectangle<int> position) override;
 			void drawModalOverlay(Graphics& g, Component& modalWindow, Rectangle<int> area, Rectangle<int> labelArea, const String& title, const String& command) override;
 			void drawListItem(Graphics& g, Component& column, int columnIndex, int, const String& itemName, Rectangle<int> position, bool rowIsSelected, bool deleteMode, bool hover) override;
+			void drawFolderRow(Graphics& g, Component& column, int columnIndex, int rowIndex, const String& folderName, Rectangle<int> position) override;
 			void drawSearchBar(Graphics& g, Component& label, Rectangle<int> area) override;
 
 			void drawTableBackground(Graphics& g, TableEditor& te, Rectangle<float> area, double rulerPosition) override;
@@ -1221,6 +1222,11 @@ namespace ScriptingObjects
 			void drawListItem(Graphics& g, Component& column, int columnIndex, int i, const String& itemName, Rectangle<int> position, bool rowIsSelected, bool deleteMode, bool hover) override
 			{
 				CALL_LAF_ID("drawPresetBrowserListItem", drawListItem, g, column, columnIndex, i, itemName, position, rowIsSelected, deleteMode, hover);
+			}
+
+			void drawFolderRow(Graphics& g, Component& column, int columnIndex, int i, const String& folderName, Rectangle<int> position) override
+			{
+				CALL_LAF_ID("drawPresetBrowserFolderRow", drawFolderRow, g, column, columnIndex, i, folderName, position);
 			}
 			
 			void drawButtonText(Graphics& g, TextButton& tb, bool over, bool down) override

--- a/hi_tools/hi_tools/HI_LookAndFeels.cpp
+++ b/hi_tools/hi_tools/HI_LookAndFeels.cpp
@@ -2325,6 +2325,15 @@ void PresetBrowserLookAndFeelMethods::drawListItem(Graphics& g, Component& colum
 #endif
 }
 
+void PresetBrowserLookAndFeelMethods::drawFolderRow(Graphics& g, Component& column, int columnIndex, int rowIndex, const String& folderName, Rectangle<int> position)
+{
+#if !HISE_NO_GUI_TOOLS
+    g.setColour(textColour.withAlpha(0.6f));
+    g.setFont(font.withHeight(14.0f));
+    g.drawText(folderName, 10, 0, position.getWidth() - 20, position.getHeight(), Justification::centredLeft);
+#endif
+}
+
 void PresetBrowserLookAndFeelMethods::drawPresetBrowserButtonText(Graphics& g, TextButton& button, bool isMouseOverButton, bool isButtonDown)
 {
     g.setColour(highlightColour.withAlpha(isMouseOverButton || button.getToggleState() ? 1.0f : 0.7f));

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -319,6 +319,7 @@ public:
 	virtual void drawTag(Graphics& g, Component& tagButton, bool hover, bool blinking, bool active, bool selected, const String& name, Rectangle<int> position);
 	virtual void drawModalOverlay(Graphics& g, Component& modalWindow, Rectangle<int> area, Rectangle<int> labelArea, const String& title, const String& command);
 	virtual void drawListItem(Graphics& g, Component& column, int columnIndex, int, const String& itemName, Rectangle<int> position, bool rowIsSelected, bool deleteMode, bool hover);
+	virtual void drawFolderRow(Graphics& g, Component& column, int columnIndex, int rowIndex, const String& folderName, Rectangle<int> position);
 	virtual void drawSearchBar(Graphics& g, Component& labelComponent, Rectangle<int> area);
 
 	Font getFont(bool fontForTitle);


### PR DESCRIPTION
This adds an opt-in `ShowFolderRows` JSON property to the PresetBrowser floating tile. When enabled together with `"NumColumns": 1`, the preset column inserts a display-only row above each group of presets showing the name of their parent folder:

```
One          <- folder row
  Classy
  Sassy
Two          <- folder row
  Dirty
  Flirty
```

### Motivation

The single column layout is great for projects with a small number of preset folders where a full multi-column browser is overkill, but the flat list loses all folder context. Currently the only workaround is faking folder headers inside `drawPresetBrowserListItem`, which breaks down because the header has to share a row with the first preset of each folder.

### Behavior

- Folder rows are display-only: clicking one restores the selection to the loaded preset, keyboard return is ignored, and they get no favorite icon.
- Next/prev preset navigation is unaffected (it operates on the file list, not the list rows).
- Folder rows disappear while searching, filtering by tags, or showing favorites only, and reappear when the filter is cleared.
- Presets sitting directly in the preset root get no folder row.
- The folder row label is the immediate parent folder name, so intermediate levels (e.g. a Bank folder above the Category folders) do not produce rows.

### Rendering

Folder rows are drawn by a new `PresetBrowserLookAndFeelMethods::drawFolderRow()` virtual with a plain default look (dimmed folder name in the browser font). A matching scripted LAF hook `drawPresetBrowserFolderRow` is registered, receiving the same object properties as `drawPresetBrowserListItem` (`area`, `columnIndex`, `rowIndex`, `text`, colours, font), so the look is fully customizable from HiseScript.

### Compatibility

The option defaults to `false` and is ignored unless `NumColumns` is 1. With the flag off, the row mapping is empty and every code path short-circuits to the existing 1:1 row-to-file behavior, so existing projects are unaffected. The property is appended to the end of the `SpecialPanelIds` enum, keeping all existing serialized property indices stable.

Verified in the IDE and in an exported plugin with a two-folder factory preset structure: row grouping, selection highlight after preset load, next/prev skipping, search/favorites transitions, and the scripted LAF hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
