### PR TITLE
Fix float casts corrupting numeric content properties with rounding dust

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -2208,11 +2208,11 @@ void ScriptingApi::Content::ScriptSlider::setScriptObjectPropertyWithChangeMessa
 	}
     else if (id == getIdFor(defaultValue))
     {
-        float v = (float)jlimit((double)getScriptObjectProperty(ScriptComponent::Properties::min),
-                                (double)getScriptObjectProperty(ScriptComponent::Properties::max),
-                                (double)newValue);
-        
-        v = FloatSanitizers::sanitizeFloatNumber(v);
+        double v = jlimit((double)getScriptObjectProperty(ScriptComponent::Properties::min),
+                          (double)getScriptObjectProperty(ScriptComponent::Properties::max),
+                          (double)newValue);
+
+        FloatSanitizers::sanitizeDoubleNumber(v);
         setScriptObjectProperty(defaultValue, var(v));
         
         return;
@@ -10059,8 +10059,12 @@ void ScriptingApi::Content::Helpers::sanitizeNumberProperties(juce::ValueTree co
 
 		if (isNumberProperty)
 		{
-			float valueAsNumber = (float)copy.getProperty(id);
-			valueAsNumber = FloatSanitizers::sanitizeFloatNumber(valueAsNumber);
+			// Sanitize in double precision - a float cast here contaminates
+			// every numeric property on load (0.1 -> 0.10000000149011612),
+			// warping the step-snap grid so a 0dB knob with a negative min
+			// can never store 0.0 again.
+			double valueAsNumber = (double)copy.getProperty(id);
+			FloatSanitizers::sanitizeDoubleNumber(valueAsNumber);
 			copy.setProperty(id, var(valueAsNumber), nullptr);
 		}
 	}


### PR DESCRIPTION
## Symptom

Stored control values in the project XML `<Content>` block and in `.preset` files show scientific notation dust instead of clean decimals:

```xml
<Control type="ScriptSlider" id="knbOutputLevel" value="1.490116119384766e-6"/>
```

Both of these knobs are sitting at exactly 0.0 dB. The dust also hides in plain decimal form on non-zero values (`3.299999952316284` for 3.3); it only turns into e-notation when the true value is 0 on a knob with a negative minimum, because then the dust IS the entire number.

Hand-cleaning the XML does not stick: HISE rewrites the dust on the next load/save cycle. Double-clicking the knob to reset it to 0 does not stick either - the reset value gets re-snapped onto the dusty grid.

## Root cause

`Content::Helpers::sanitizeNumberProperties` runs on every project load and casts every numeric property through `float`:

```cpp
float valueAsNumber = (float)copy.getProperty(id);
```

So `stepSize="0.1"` in the XML becomes `0.10000000149011612` in memory (and `0.1000000014901161` on the next save). This warps the snap grid: `NormalisableRange::snapToLegalValue` computes `min + n * step`, so for a Decibel knob with `min="-100"` the legal value nearest 0 dB is

```
-100 + 0.10000000149011612 * 1000 = 1.4901161193847656e-6
```

which is exactly the stored value. Clean 0.0 is not on the grid, so no amount of snapping or resetting can store it. With a clean double 0.1 the same arithmetic lands on exactly 0.0.

The same float cast pattern in the `ScriptSlider` `defaultValue` property setter re-dusts that property when it is set on load.

## Fix

Sanitize in `double` in both places, using the existing `FloatSanitizers::sanitizeDoubleNumber`. NaN/Inf protection is unchanged.

## Verification

Built and tested on macOS (Debug, standalone):

- A project whose XML has `stepSize="0.1"` on a Decibel slider (min -100) now survives a load/save cycle with `stepSize` intact (previously rewritten to `0.1000000014901161`).
- Setting that slider to 0 dB and saving now stores `0.0`, not `1.49e-6`.

Note that values already stored with dust in existing project files stay as they are until the control is next moved; this PR stops the contamination at its source. I have a small follow-up that self-heals existing files by rounding the serialised value to the step precision (mirroring what the value display already does) - happy to PR that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
