### PR TITLE
Range slider

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -712,7 +712,9 @@ void HiSlider::sliderValueChanged(Slider *s)
 	{
 		if (getSliderStyle() == Slider::TwoValueHorizontal)
 		{
-			//setMinAndMaxValues(minValue, maxValue, dontSendNotification);
+			// Range sliders have no single Processor attribute to push here; the
+			// two values are synced back to the ScriptSlider by ScriptCreatedComponentWrappers::SliderWrapper,
+			// which is also registered as a listener on this component.
 		}
 		else
 		{

--- a/hi_core/hi_core/MacroControlledComponents.cpp
+++ b/hi_core/hi_core/MacroControlledComponents.cpp
@@ -1968,6 +1968,22 @@ void HiSlider::mouseDown(const MouseEvent &e)
 
         if (!isConnectedToModulator())
         {
+            if (getSliderStyle() == Slider::TwoValueHorizontal)
+            {
+                auto minPos = (int)getPositionOfValue(getMinValue());
+                auto maxPos = (int)getPositionOfValue(getMaxValue());
+                auto clickX = e.getPosition().x;
+
+                if (clickX > minPos + edgeGrabMargin && clickX < maxPos - edgeGrabMargin)
+                {
+                    isDraggingWholeRange = true;
+                    rangeDragStartMin = getMinValue();
+                    rangeDragStartMax = getMaxValue();
+                    rangeDragStartPosition = e.getPosition();
+                    return;
+                }
+            }
+
             Slider::mouseDown(e);
             startTouch(e.getMouseDownPosition());
         }
@@ -1991,6 +2007,21 @@ void HiSlider::mouseDrag(const MouseEvent& e)
 	if(performModifierAction(e, false, false))
 		return;
 
+	if (isDraggingWholeRange)
+	{
+		auto width = jmax(1, getWidth());
+		auto valuesPerPixel = (getMaximum() - getMinimum()) / (double)width;
+
+		auto deltaValue = (double)(e.getPosition().x - rangeDragStartPosition.x) * valuesPerPixel;
+		auto rangeWidth = rangeDragStartMax - rangeDragStartMin;
+
+		auto newMin = jlimit(getMinimum(), getMaximum() - rangeWidth, rangeDragStartMin + deltaValue);
+		auto newMax = newMin + rangeWidth;
+
+		setMinAndMaxValues(newMin, newMax, sendNotificationAsync);
+		return;
+	}
+
 	Slider::mouseDrag(e);
 }
 
@@ -2001,6 +2032,12 @@ void HiSlider::mouseUp(const MouseEvent& e)
 	abortTouch();
 
 	showModHoverPopup(true, false);
+
+	if (isDraggingWholeRange)
+	{
+		isDraggingWholeRange = false;
+		return;
+	}
 
 	if(performModifierAction(e, false, false))
 		return;

--- a/hi_core/hi_core/MacroControlledComponents.h
+++ b/hi_core/hi_core/MacroControlledComponents.h
@@ -990,6 +990,15 @@ private:
 	HoverPopupLookandFeel fallback;
 
 	bool skipGestureActive = false;
+
+	// Clicking between the two edges of a Range (TwoValueHorizontal) slider (outside
+	// the edgeGrabMargin around each edge) moves both thumbs together instead of
+	// dragging the nearest one, keeping their distance constant.
+	static constexpr int edgeGrabMargin = 6;
+	bool isDraggingWholeRange = false;
+	double rangeDragStartMin = 0.0;
+	double rangeDragStartMax = 0.0;
+	Point<int> rangeDragStartPosition;
 };
 
 

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -812,7 +812,14 @@ void ScriptCreatedComponentWrappers::SliderWrapper::updateValue(var newValue)
 
 void ScriptCreatedComponentWrappers::SliderWrapper::sliderValueChanged(Slider *s)
 {
-	
+	if (s->getSliderStyle() == Slider::TwoValueHorizontal)
+	{
+		if (auto sc = dynamic_cast<ScriptingApi::Content::ScriptSlider*>(getScriptComponent()))
+		{
+			sc->setMinValue(s->getMinValue());
+			sc->setMaxValue(s->getMaxValue());
+		}
+	}
 }
 
 void ScriptCreatedComponentWrappers::SliderWrapper::updateTooltip(Slider * s)

--- a/hi_scripting/scripting/components/ScriptingContentComponent.cpp
+++ b/hi_scripting/scripting/components/ScriptingContentComponent.cpp
@@ -178,8 +178,10 @@ void ScriptContentComponent::updateValue(int i)
 			const double min = dynamic_cast<ScriptingApi::Content::ScriptSlider*>(contentData->components[i].get())->getMinValue();
 			const double max = dynamic_cast<ScriptingApi::Content::ScriptSlider*>(contentData->components[i].get())->getMaxValue();
 
-			s->setMinValue(min, dontSendNotification);
-			s->setMaxValue(max, dontSendNotification);
+			// Setting min and max separately clamps against whatever the other value
+			// currently is (eg. min gets pinned to a stale valueMax of 0 on a freshly
+			// created slider), so both must be applied atomically here.
+			s->setMinAndMaxValues(min, max, dontSendNotification);
 		}
 	}
 }


### PR DESCRIPTION
I noticed that every time I hit compile the values I set for my range slider were lost. I had Claude fix it. I also added the functionality that clicking away from the edges of the slider moves the entire range as one.