### PR TITLE
Fix the Tools latency check in IDE builds without input processing

### DIFF
--- a/hi_backend/backend/BackendProcessor.h
+++ b/hi_backend/backend/BackendProcessor.h
@@ -421,6 +421,8 @@ public:
 	void handleLatencyCheck(AudioSampleBuffer& buffer);
 	void handlePostLatencyCheck(AudioSampleBuffer& buffer);
 
+	bool isRunningLatencyCheck() const override { return latencyCheckState != LatencyCheckState::Idle; }
+
 	void logMessage(const String& message, bool isCritical) override;
 
 	void setStateInformation(const void *data,int sizeInBytes) override;

--- a/hi_core/hi_core/MainController.cpp
+++ b/hi_core/hi_core/MainController.cpp
@@ -1405,10 +1405,17 @@ void MainController::processBlockCommon(AudioSampleBuffer &buffer, MidiBuffer &m
 #if !FRONTEND_IS_PLUGIN
 
 #if !FORCE_INPUT_CHANNELS
+#if USE_BACKEND
+	// The latency check impulse is injected into the input buffer, so it must
+	// not be cleared while the measurement is running
+	if (!isRunningLatencyCheck())
+		buffer.clear();
+#else
 	buffer.clear();
 #endif
+#endif
 
-	
+
 
 #endif
 
@@ -1528,6 +1535,22 @@ void MainController::processBlockCommon(AudioSampleBuffer &buffer, MidiBuffer &m
     
 #else
 	thisMultiChannelBuffer.clear();
+
+#if USE_BACKEND
+	// Feed the input into the processing buffer during the latency check so the
+	// injected impulse can travel through the signal chain in channel
+	// configurations that do not process input audio
+	if (isRunningLatencyCheck())
+	{
+		int numChannelsToCopy = jmin(2, thisMultiChannelBuffer.getNumChannels(), buffer.getNumChannels());
+
+		for (int i = 0; i < numChannelsToCopy; i++)
+		{
+			FloatVectorOperations::copy(thisMultiChannelBuffer.getWritePointer(i),
+										buffer.getReadPointer(i), buffer.getNumSamples());
+		}
+	}
+#endif
 #endif
 
 	

--- a/hi_core/hi_core/MainController.h
+++ b/hi_core/hi_core/MainController.h
@@ -1879,6 +1879,11 @@ public:
 
 	virtual const ModulatorSynthChain *getMainSynthChain() const = 0;
 
+	/** Overwritten by the BackendProcessor to indicate an active Tools -> Check latency
+	    measurement. While this is true, the input buffer must survive into the signal
+	    chain even if the channel configuration does not process input audio. */
+	virtual bool isRunningLatencyCheck() const { return false; }
+
 	void resetLookAndFeelToDefault(Component* c);
 
 	void setCurrentScriptLookAndFeel(ReferenceCountedObject* newLaf) override;

--- a/hi_core/hi_dsp/modules/ModulatorSynthChain.cpp
+++ b/hi_core/hi_dsp/modules/ModulatorSynthChain.cpp
@@ -324,7 +324,7 @@ void ModulatorSynthChain::renderNextBlockWithModulators(AudioSampleBuffer &buffe
     if(isRoot)
     {
         int numChannels = jmin(buffer.getNumChannels(), internalBuffer.getNumChannels());
-        
+
         for(int i = 0; i < numChannels; i++)
         {
             FloatVectorOperations::copy(internalBuffer.getWritePointer(i),
@@ -334,6 +334,22 @@ void ModulatorSynthChain::renderNextBlockWithModulators(AudioSampleBuffer &buffe
 		// now clear the buffer
 		buffer.clear();
     }
+#elif USE_BACKEND
+	// Route the input through the effect chain during Tools -> Check latency so
+	// the injected impulse gets processed like in a FORCE_INPUT_CHANNELS build
+	if (isRoot && getMainController()->isRunningLatencyCheck())
+	{
+		int numChannels = jmin(buffer.getNumChannels(), internalBuffer.getNumChannels());
+
+		for (int i = 0; i < numChannels; i++)
+		{
+			FloatVectorOperations::copy(internalBuffer.getWritePointer(i),
+										buffer.getReadPointer(i), numSamples);
+		}
+
+		// now clear the buffer
+		buffer.clear();
+	}
 #endif
 
 	ScopedAnalyser sa(getMainController(), this, internalBuffer, buffer.getNumSamples());


### PR DESCRIPTION
Fixes the Tools -> Check latency function, which has been broken in the IDE since e429f19d1 (reported on the forum: https://forum.hise.audio/topic/14245/check-latency-broken-on-latest-develop-build).

## Root cause

e429f19d1 gated the FORCE_INPUT_CHANNELS default on `HISE_NUM_PLUGIN_CHANNELS == 2` and at the same time set the standalone IDE project to 16 channels. a6c5d9dd7 fixed the include-order half of the problem (the guard was evaluated before the macro was defined), but the IDE still builds with 16 channels, so FORCE_INPUT_CHANNELS remains disabled and the input buffer is discarded before it reaches the signal chain.

The latency check injects its test signal into the input buffer, so it never comes back: no result popup appears until a note is played manually, and the reported value is the elapsed time instead of the latency. (The same code path also swallows the audio input in multichannel IDE builds, which matches the "external audio playback" part of the original report.)

## Fix

Adds a `MainController::isRunningLatencyCheck()` hook (default false, overridden by the BackendProcessor) that keeps the input alive at the three points where it is otherwise dropped when FORCE_INPUT_CHANNELS is 0:

- the input buffer clear in `processBlockCommon`
- the copy into the multichannel processing buffer in `processBlockCommon`
- the copy into the root chain's `internalBuffer` in `ModulatorSynthChain::renderNextBlockWithModulators` (mirroring the adjacent FORCE_INPUT_CHANNELS block)

All three sites are guarded with `USE_BACKEND` and are no-ops unless a measurement is running, so exported plugins and normal IDE processing are unaffected.

## Verification

Tested in the standalone IDE (macOS, Debug, stock 16-channel configuration): a fully wet 333ms delay on the master chain reports 16000 samples at 48kHz, exactly and repeatably. An empty chain reports 0.

A companion PR improves the test signal itself (sine burst instead of an impulse) so that transient-smearing effects like `pitch_shift` become measurable; this PR alone restores the behavior the tool had before January.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
