### PR TITLE
Use a noise burst with onset detection for the latency check

### DIFF
--- a/hi_backend/backend/BackendProcessor.cpp
+++ b/hi_backend/backend/BackendProcessor.cpp
@@ -1070,11 +1070,14 @@ void BackendProcessor::handleLatencyCheck(AudioSampleBuffer& buffer)
 			killCounter = 0;
 			latencyCheckState = LatencyCheckState::WaitingForProcessBlock;
 
-			// Use a 20ms sine burst instead of a single impulse so that effects
-			// which smear transients (eg. pitch shifters) still pass a
-			// detectable signal level to the output
+			// Use a 20ms broadband noise burst instead of a single impulse so
+			// that effects which smear transients (eg. pitch shifters) or
+			// remove parts of the spectrum (eg. filters) still pass a
+			// detectable signal level to the output. The generator is reseeded
+			// for every run so that the measurement is repeatable.
 			burstSamplesRemaining = roundToInt(getMainSynthChain()->getSampleRate() * 0.02);
-			burstUptime = 0.0;
+			burstNoise.setSeed(0x4C415445);
+			burstStarted = false;
 		}
 	}
 
@@ -1090,16 +1093,22 @@ void BackendProcessor::handleLatencyCheck(AudioSampleBuffer& buffer)
 
 		if(burstSamplesRemaining > 0)
 		{
-			auto delta = 2.0 * double_Pi * 1000.0 / getMainSynthChain()->getSampleRate();
-
 			int numThisTime = jmin(burstSamplesRemaining, buffer.getNumSamples());
 
 			for(int i = 0; i < numThisTime; i++)
 			{
-				// start the phase one sample in so that the first sample of the
-				// burst is already above the detection threshold
-				burstUptime += delta;
-				buffer.setSample(0, i, (float)std::sin(burstUptime));
+				auto value = burstNoise.nextFloat() * 2.0f - 1.0f;
+
+				// force the very first sample of the burst to full scale so
+				// that it is guaranteed to be above the detection threshold
+				// and a zero-latency chain reports exactly 0
+				if(!burstStarted)
+				{
+					value = 1.0f;
+					burstStarted = true;
+				}
+
+				buffer.setSample(0, i, value);
 			}
 
 			burstSamplesRemaining -= numThisTime;
@@ -1117,7 +1126,7 @@ void BackendProcessor::handlePostLatencyCheck(AudioSampleBuffer& buffer)
 
 	if(latencyCheckState == LatencyCheckState::WaitingForImpulse)
 	{
-		// The latency is the onset of the sine burst at the output, so look
+		// The latency is the onset of the noise burst at the output, so look
 		// for the first sample above the threshold instead of the peak
 		int onsetIndex = -1;
 

--- a/hi_backend/backend/BackendProcessor.cpp
+++ b/hi_backend/backend/BackendProcessor.cpp
@@ -1069,14 +1069,35 @@ void BackendProcessor::handleLatencyCheck(AudioSampleBuffer& buffer)
 		{
 			killCounter = 0;
 			latencyCheckState = LatencyCheckState::WaitingForProcessBlock;
+
+			// Use a 20ms sine burst instead of a single impulse so that effects
+			// which smear transients (eg. pitch shifters) still pass a
+			// detectable signal level to the output
+			burstSamplesRemaining = roundToInt(getMainSynthChain()->getSampleRate() * 0.02);
+			burstUptime = 0.0;
 		}
 	}
 
 	if(latencyCheckState == LatencyCheckState::WaitingForProcessBlock)
-	{
 		reportedLatency = 0.0;
-		buffer.setSample(0, 0, 1.0f);
-		buffer.setSample(0, 1, 1.0f);
+
+	if((latencyCheckState == LatencyCheckState::WaitingForProcessBlock ||
+	    latencyCheckState == LatencyCheckState::WaitingForImpulse) &&
+	    burstSamplesRemaining > 0)
+	{
+		auto delta = 2.0 * double_Pi * 1000.0 / getMainSynthChain()->getSampleRate();
+
+		int numThisTime = jmin(burstSamplesRemaining, buffer.getNumSamples());
+
+		for(int i = 0; i < numThisTime; i++)
+		{
+			// start the phase one sample in so that the first sample of the
+			// burst is already above the detection threshold
+			burstUptime += delta;
+			buffer.setSample(0, i, (float)std::sin(burstUptime));
+		}
+
+		burstSamplesRemaining -= numThisTime;
 	}
 }
 
@@ -1090,22 +1111,22 @@ void BackendProcessor::handlePostLatencyCheck(AudioSampleBuffer& buffer)
 
 	if(latencyCheckState == LatencyCheckState::WaitingForImpulse)
 	{
-		if(buffer.getMagnitude(0, 0, buffer.getNumSamples()) > 0.01f)
+		// The latency is the onset of the sine burst at the output, so look
+		// for the first sample above the threshold instead of the peak
+		int onsetIndex = -1;
+
+		for(int i = 0; i < buffer.getNumSamples(); i++)
 		{
-			float maxPeak = 0.0f;
-			float indexOfPeak = 0.0f;
-
-			for(int i = 0; i < buffer.getNumSamples(); i++)
+			if(std::abs(buffer.getSample(0, i)) > 0.01f)
 			{
-				auto value = buffer.getSample(0, i);
-				if(value > maxPeak)
-				{
-					maxPeak = value;
-					indexOfPeak = i;
-				}
+				onsetIndex = i;
+				break;
 			}
+		}
 
-			reportedLatency += (double)indexOfPeak;
+		if(onsetIndex != -1)
+		{
+			reportedLatency += (double)onsetIndex;
 
 			latencyCheckState = LatencyCheckState::Done;
 

--- a/hi_backend/backend/BackendProcessor.cpp
+++ b/hi_backend/backend/BackendProcessor.cpp
@@ -1081,23 +1081,29 @@ void BackendProcessor::handleLatencyCheck(AudioSampleBuffer& buffer)
 	if(latencyCheckState == LatencyCheckState::WaitingForProcessBlock)
 		reportedLatency = 0.0;
 
-	if((latencyCheckState == LatencyCheckState::WaitingForProcessBlock ||
-	    latencyCheckState == LatencyCheckState::WaitingForImpulse) &&
-	    burstSamplesRemaining > 0)
+	if(latencyCheckState == LatencyCheckState::WaitingForProcessBlock ||
+	   latencyCheckState == LatencyCheckState::WaitingForImpulse)
 	{
-		auto delta = 2.0 * double_Pi * 1000.0 / getMainSynthChain()->getSampleRate();
+		// suppress the live input during the measurement so that it cannot
+		// trigger a false onset detection
+		buffer.clear();
 
-		int numThisTime = jmin(burstSamplesRemaining, buffer.getNumSamples());
-
-		for(int i = 0; i < numThisTime; i++)
+		if(burstSamplesRemaining > 0)
 		{
-			// start the phase one sample in so that the first sample of the
-			// burst is already above the detection threshold
-			burstUptime += delta;
-			buffer.setSample(0, i, (float)std::sin(burstUptime));
-		}
+			auto delta = 2.0 * double_Pi * 1000.0 / getMainSynthChain()->getSampleRate();
 
-		burstSamplesRemaining -= numThisTime;
+			int numThisTime = jmin(burstSamplesRemaining, buffer.getNumSamples());
+
+			for(int i = 0; i < numThisTime; i++)
+			{
+				// start the phase one sample in so that the first sample of the
+				// burst is already above the detection threshold
+				burstUptime += delta;
+				buffer.setSample(0, i, (float)std::sin(burstUptime));
+			}
+
+			burstSamplesRemaining -= numThisTime;
+		}
 	}
 }
 
@@ -1140,6 +1146,18 @@ void BackendProcessor::handlePostLatencyCheck(AudioSampleBuffer& buffer)
 		else
 		{
 			reportedLatency += buffer.getNumSamples();
+
+			if(reportedLatency > 2.0 * getMainSynthChain()->getSampleRate())
+			{
+				latencyCheckState = LatencyCheckState::Done;
+
+				MessageManager::callAsync([this]()
+				{
+					PresetHandler::showMessageWindow("No signal detected", "The test signal was not detected at the output within 2 seconds. The signal chain might be muting or heavily attenuating the input signal.", PresetHandler::IconType::Error);
+					latencyCheckState = LatencyCheckState::Idle;
+					reportedLatency = 0;
+				});
+			}
 		}
 
 		buffer.clear();

--- a/hi_backend/backend/BackendProcessor.h
+++ b/hi_backend/backend/BackendProcessor.h
@@ -667,6 +667,8 @@ private:
 	LatencyCheckState latencyCheckState = LatencyCheckState::Idle;
 	double reportedLatency = 0.0;
 	int killCounter = 0;
+	int burstSamplesRemaining = 0;
+	double burstUptime = 0.0;
 
 	int currentNoteNumber = -1;
 

--- a/hi_backend/backend/BackendProcessor.h
+++ b/hi_backend/backend/BackendProcessor.h
@@ -668,7 +668,8 @@ private:
 	double reportedLatency = 0.0;
 	int killCounter = 0;
 	int burstSamplesRemaining = 0;
-	double burstUptime = 0.0;
+	bool burstStarted = false;
+	Random burstNoise;
 
 	int currentNoteNumber = -1;
 


### PR DESCRIPTION
Improves the Tools -> Check latency test signal. Companion to #1013, which restores the signal path the test signal travels on; the two merge independently in either order, but the tool only becomes fully functional in the stock IDE build with both.

## Problem

The check injected a two-sample impulse and reported the peak position of the first output block whose magnitude exceeded 0.01. Effects with a time-frequency analysis window (eg. the `pitch_shift` node with its ~120ms stretcher window) smear that impulse over thousands of samples, dropping the output peak to around 0.0002, so the threshold never fires and the tool waits forever. When a manually played note finally triggered it, the reported number was the elapsed time, not the latency. Peak detection also made the result depend on where the smeared blob peaks, which varies run to run.

## Change

- Inject a 20ms broadband noise burst instead of the impulse. A sustained signal passes through smearing effects at near-full level, and a full-spectrum burst leaves energy at the output even when the chain contains filters that would remove a narrowband probe (the first version of this PR used a 1kHz sine burst; switched to noise on review). The generator is reseeded on every run so the measurement is repeatable, and the first sample of the burst is forced to full scale so a zero-latency chain reports exactly 0. The burst spans multiple blocks if needed.
- Report the first threshold crossing at the output (the burst onset) instead of the block peak, which is the correct measure for a burst and stays sample-exact for pure delay chains.
- Show an explicit "No signal detected" error popup when nothing crosses the threshold within two seconds, instead of waiting indefinitely.
- Mute the live audio input during the measurement so a microphone or line signal cannot trigger a false onset.

## Verification

Tested in the standalone IDE (macOS, Debug, 48kHz) on top of #1013:

| Chain | Result |
|---|---|
| Empty module tree | 0 samples |
| Fully wet 333ms delay | 16000 samples, exact and repeatable |
| Convolution reverb, zero pre-delay IR | 2 samples (the IR's first tap), exact and repeatable |
| ScriptFX with `pitch_shift` at 0.25 | 1651 samples, exact and repeatable |
| ScriptFX with `pitch_shift` at 0.50 | 2076 samples, exact and repeatable |
| ScriptFX with `pitch_shift` at 2.00 | 4839 samples, exact and repeatable |
| ScriptFX with `pitch_shift` at 4.00 | 4871 / 4649 / 4845 / 4747 samples |
| 4x `pitch_shift` at 4.00 in series (256x) | 34467 / 33923 / 34386 / 34395 samples |
| Muted chain | "No signal detected" popup after two seconds |

The impulse produced no result at all for any of the `pitch_shift` chains. The remaining spread at the 4.00 ratio is the stretcher's own timing indeterminacy (one analysis hop), not measurement noise: four cascaded nodes only roughly double the spread of one, and the burst still clears the threshold after 256x of stretching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
