### PR TITLE
Flex ahdsr laf improvements

### DIFF
--- a/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.cpp
+++ b/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.cpp
@@ -557,6 +557,7 @@ juce::Component* FlexAhdsrEnvelope::Panel::createContentComponent(int index)
 					g->setColour(RingBufferComponentBase::bgColour, findPanelColour(FloatingTileContent::PanelColourId::bgColour));
 					g->setColour(RingBufferComponentBase::fillColour, findPanelColour(FloatingTileContent::PanelColourId::itemColour1));
 					g->setColour(RingBufferComponentBase::lineColour, findPanelColour(FloatingTileContent::PanelColourId::itemColour2));
+					g->setColour(RingBufferComponentBase::outlineColour, findPanelColour(FloatingTileContent::PanelColourId::itemColour3));
 					g->setColour(HiseColourScheme::ColourIds::ComponentTextColourId, findPanelColour(FloatingTileContent::PanelColourId::textColour));
 
 					if (g->findColour(RingBufferComponentBase::bgColour).isOpaque())

--- a/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.h
+++ b/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.h
@@ -102,6 +102,7 @@ public:
 		{
 			UseOneDimensionDrag = PanelWithProcessorConnection::SpecialPanelIds::numSpecialPanelIds,
 			CurvePointTolerance,
+			ShowBall,
 			numFlexPanelIds
 		};
 
@@ -128,6 +129,7 @@ public:
 
 			storePropertyInObject(v, (int)FlexPanelIds::CurvePointTolerance, c != nullptr ? var(c->curveTolerance) : var());
 			storePropertyInObject(v, (int)FlexPanelIds::UseOneDimensionDrag, c != nullptr ? var(c->useOneDimensionalDrag) : var());
+			storePropertyInObject(v, (int)FlexPanelIds::ShowBall, c != nullptr ? var(c->showBall) : var());
 
 			return v;
 		}
@@ -139,6 +141,7 @@ public:
 			{
 				c->curveTolerance = (float)getPropertyWithDefault(object, (int)FlexPanelIds::CurvePointTolerance);
 				c->useOneDimensionalDrag = (bool)getPropertyWithDefault(object, (int)FlexPanelIds::UseOneDimensionDrag);
+				c->showBall = (bool)getPropertyWithDefault(object, (int)FlexPanelIds::ShowBall);
 			}
 		}
 		int getNumDefaultableProperties() const override { return (int)FlexPanelIds::numFlexPanelIds; }
@@ -150,7 +153,8 @@ public:
 
 			RETURN_DEFAULT_PROPERTY_ID(index, FlexPanelIds::CurvePointTolerance, "CurvePointTolerance");
 			RETURN_DEFAULT_PROPERTY_ID(index, FlexPanelIds::UseOneDimensionDrag, "UseOneDimensionDrag");
-            
+			RETURN_DEFAULT_PROPERTY_ID(index, FlexPanelIds::ShowBall, "ShowBall");
+
             jassertfalse;
             return Identifier();
 		}
@@ -162,7 +166,8 @@ public:
 
 			RETURN_DEFAULT_PROPERTY(index, FlexPanelIds::CurvePointTolerance, 20);
 			RETURN_DEFAULT_PROPERTY(index, FlexPanelIds::UseOneDimensionDrag, true);
-            
+			RETURN_DEFAULT_PROPERTY(index, FlexPanelIds::ShowBall, false);
+
             jassertfalse;
             return var();
 		}

--- a/hi_dsp_library/node_ui/complex_ui_laf.cpp
+++ b/hi_dsp_library/node_ui/complex_ui_laf.cpp
@@ -570,6 +570,22 @@ void complex_ui_laf::drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhd
 	g.strokePath(graph.fullPath, PathStrokeType(3.0f));
 }
 
+void complex_ui_laf::drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph,
+	flex_ahdsr_base::State s, Point<float> pointOnPath)
+{
+	if(s == flex_ahdsr_base::State::SUSTAIN || s == flex_ahdsr_base::State::IDLE)
+		return;
+
+	LODManager::LODGraphics lg(g, graph);
+
+	if (lg.drawFullDetails())
+	{
+		g.setColour(getNodeColour(&graph).withAlpha(1.0f));
+		Rectangle<float> a(pointOnPath, pointOnPath);
+		g.fillEllipse(a.withSizeKeepingCentre(6.0f, 6.0f));
+	}
+}
+
 void complex_ui_laf::drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph,
 	flex_ahdsr_base::State s, const Path& segment, bool hover, bool active)
 {

--- a/hi_dsp_library/node_ui/complex_ui_laf.cpp
+++ b/hi_dsp_library/node_ui/complex_ui_laf.cpp
@@ -613,4 +613,16 @@ void complex_ui_laf::drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexA
 	g.fillEllipse(curvePoint.x - margin * 0.5f, curvePoint.y - margin * 0.5f, margin, margin);
 }
 
+void complex_ui_laf::drawFlexAhdsrDragPoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph,
+	flex_ahdsr_base::State s, Point<float> dragPoint, bool hover, bool down)
+{
+	g.setColour(getNodeColour(&graph));
+	auto margin = hover ? 10.0f : 7.0f;
+
+	if (down)
+		margin -= 1.0f;
+
+	g.drawRect(dragPoint.x - margin * 0.5f, dragPoint.y - margin * 0.5f, margin, margin);
+}
+
 }

--- a/hi_dsp_library/node_ui/complex_ui_laf.cpp
+++ b/hi_dsp_library/node_ui/complex_ui_laf.cpp
@@ -570,7 +570,7 @@ void complex_ui_laf::drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhd
 	g.strokePath(graph.fullPath, PathStrokeType(3.0f));
 }
 
-void complex_ui_laf::drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph,
+void complex_ui_laf::drawFlexAhdsrBall(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph,
 	flex_ahdsr_base::State s, Point<float> pointOnPath)
 {
 	if(s == flex_ahdsr_base::State::SUSTAIN || s == flex_ahdsr_base::State::IDLE)

--- a/hi_dsp_library/node_ui/complex_ui_laf.h
+++ b/hi_dsp_library/node_ui/complex_ui_laf.h
@@ -89,7 +89,7 @@ struct complex_ui_laf : public ScriptnodeComboBoxLookAndFeel,
 	void drawFlexAhdsrBackground(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 	void drawFlexAhdsrFullPath(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 	void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
-	void drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
+	void drawFlexAhdsrBall(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 	void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 	void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
 	void drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> curvePoint, bool hover, bool down) override;

--- a/hi_dsp_library/node_ui/complex_ui_laf.h
+++ b/hi_dsp_library/node_ui/complex_ui_laf.h
@@ -89,6 +89,7 @@ struct complex_ui_laf : public ScriptnodeComboBoxLookAndFeel,
 	void drawFlexAhdsrBackground(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 	void drawFlexAhdsrFullPath(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 	void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
+	void drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 	void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 	void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
 	void drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> curvePoint, bool hover, bool down) override;

--- a/hi_dsp_library/node_ui/complex_ui_laf.h
+++ b/hi_dsp_library/node_ui/complex_ui_laf.h
@@ -93,6 +93,7 @@ struct complex_ui_laf : public ScriptnodeComboBoxLookAndFeel,
 	void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 	void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
 	void drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> curvePoint, bool hover, bool down) override;
+	void drawFlexAhdsrDragPoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> dragPoint, bool hover, bool down) override;
 
 	Colour nodeColour;
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2728,7 +2728,7 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
 		"drawModulationDragBackground",
 		"drawModulationDragger",
 		"drawFlexAhdsrBackground",
-		"drawFlexAhdsrBallPosition",
+		"drawFlexAhdsrBall",
 		"drawFlexAhdsrCurvePoint",
 		"drawFlexAhdsrDragPoint",
 		"drawFlexAhdsrFullPath",
@@ -5994,10 +5994,10 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrPosition(Graphics&
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrPosition(g_, graph, s, pointOnPath);
 }
 
-void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBallPosition(Graphics& g_,
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBall(Graphics& g_,
 	flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath)
 {
-	if (functionDefined("drawFlexAhdsrBallPosition"))
+	if (functionDefined("drawFlexAhdsrBall"))
     {
         auto obj = new DynamicObject();
 
@@ -6012,11 +6012,11 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBallPosition(Graph
 		obj->setProperty("state", (int)s);
 		obj->setProperty("position", ApiHelpers::getVarFromPoint(pointOnPath));
 
-        if (get()->callWithGraphics(g_, "drawFlexAhdsrBallPosition", var(obj), &graph))
+        if (get()->callWithGraphics(g_, "drawFlexAhdsrBall", var(obj), &graph))
             return;
     }
 
-	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBallPosition(g_, graph, s, pointOnPath);
+	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBall(g_, graph, s, pointOnPath);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrSegment(Graphics& g_,

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5866,6 +5866,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBackground(Graphic
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -5889,6 +5890,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrCurvePoint(Graphic
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -5917,6 +5919,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrDragPoint(Graphics
         auto obj = new DynamicObject();
 
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -5945,6 +5948,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrFullPath(Graphics&
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 		obj->setProperty("pathArea", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat().reduced(10)));
 
@@ -5975,6 +5979,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrPosition(Graphics&
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -6007,6 +6012,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBall(Graphics& g_,
         auto obj = new DynamicObject();
 
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -6033,6 +6039,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrSegment(Graphics& 
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
@@ -6066,6 +6073,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrText(Graphics& g_,
         auto obj = new DynamicObject();
  
 		writeId(obj, &graph);
+		obj->setProperty("enabled", graph.isEnabled());
         obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -2728,7 +2728,9 @@ Array<Identifier> ScriptingObjects::ScriptedLookAndFeel::getAllFunctionNames()
 		"drawModulationDragBackground",
 		"drawModulationDragger",
 		"drawFlexAhdsrBackground",
+		"drawFlexAhdsrBallPosition",
 		"drawFlexAhdsrCurvePoint",
+		"drawFlexAhdsrDragPoint",
 		"drawFlexAhdsrFullPath",
 		"drawFlexAhdsrPosition",
 		"drawFlexAhdsrSegment",
@@ -5903,6 +5905,33 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrCurvePoint(Graphic
     }
 
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrCurvePoint(g_, graph, s, curvePoint, hover, down);
+}
+
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrDragPoint(Graphics& g_,
+	flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> dragPoint, bool hover, bool down)
+{
+	if (functionDefined("drawFlexAhdsrDragPoint"))
+    {
+        auto obj = new DynamicObject();
+
+		writeId(obj, &graph);
+        obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
+
+		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
+		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
+		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
+
+		obj->setProperty("state", (int)s);
+		obj->setProperty("dragPoint", ApiHelpers::getVarFromPoint(dragPoint));
+		obj->setProperty("hover", hover);
+		obj->setProperty("down", down);
+
+        if (get()->callWithGraphics(g_, "drawFlexAhdsrDragPoint", var(obj), &graph))
+            return;
+    }
+
+	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrDragPoint(g_, graph, s, dragPoint, hover, down);
 }
 
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrFullPath(Graphics& g_,

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5965,6 +5965,31 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrPosition(Graphics&
 	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrPosition(g_, graph, s, pointOnPath);
 }
 
+void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBallPosition(Graphics& g_,
+	flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath)
+{
+	if (functionDefined("drawFlexAhdsrBallPosition"))
+    {
+        auto obj = new DynamicObject();
+
+		writeId(obj, &graph);
+        obj->setProperty("area", ApiHelpers::getVarRectangle(useRectangleClass, graph.getLocalBounds().toFloat()));
+
+		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
+		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
+		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
+
+		obj->setProperty("state", (int)s);
+		obj->setProperty("position", ApiHelpers::getVarFromPoint(pointOnPath));
+
+        if (get()->callWithGraphics(g_, "drawFlexAhdsrBallPosition", var(obj), &graph))
+            return;
+    }
+
+	flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBallPosition(g_, graph, s, pointOnPath);
+}
+
 void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrSegment(Graphics& g_,
 	flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active)
 {

--- a/hi_scripting/scripting/api/ScriptingGraphics.cpp
+++ b/hi_scripting/scripting/api/ScriptingGraphics.cpp
@@ -5871,6 +5871,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBackground(Graphic
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 		
         if (get()->callWithGraphics(g_, "drawFlexAhdsrBackground", var(obj), &graph))
@@ -5893,6 +5894,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrCurvePoint(Graphic
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("state", (int)s);
@@ -5920,6 +5922,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrDragPoint(Graphics
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("state", (int)s);
@@ -5948,6 +5951,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrFullPath(Graphics&
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		auto sp = new ScriptingObjects::PathObject(get()->getScriptProcessor());
@@ -5976,6 +5980,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrPosition(Graphics&
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("state", (int)s);
@@ -6007,6 +6012,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrBall(Graphics& g_,
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("state", (int)s);
@@ -6032,6 +6038,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrSegment(Graphics& 
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("state", (int)s);
@@ -6064,6 +6071,7 @@ void ScriptingObjects::ScriptedLookAndFeel::Laf::drawFlexAhdsrText(Graphics& g_,
 		setColourOrBlack(obj, "bgColour", graph, RingBufferComponentBase::ColourId::bgColour);
 		setColourOrBlack(obj, "itemColour", graph, RingBufferComponentBase::ColourId::fillColour);
 		setColourOrBlack(obj, "itemColour2", graph, RingBufferComponentBase::ColourId::lineColour);
+		setColourOrBlack(obj, "itemColour3", graph, RingBufferComponentBase::ColourId::outlineColour);
 		setColourOrBlack(obj, "textColour", graph, HiseColourScheme::ColourIds::ComponentTextColourId);
 
 		obj->setProperty("text", text);

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -963,6 +963,7 @@ namespace ScriptingObjects
 			void drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> curvePoint, bool hover, bool down) override;
 			void drawFlexAhdsrFullPath(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
+			void drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 			void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -964,7 +964,7 @@ namespace ScriptingObjects
 			void drawFlexAhdsrDragPoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> dragPoint, bool hover, bool down) override;
 			void drawFlexAhdsrFullPath(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
-			void drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
+			void drawFlexAhdsrBall(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrSegment(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, const Path& segment, bool hover, bool active) override;
 			void drawFlexAhdsrText(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, const String& text) override;
 

--- a/hi_scripting/scripting/api/ScriptingGraphics.h
+++ b/hi_scripting/scripting/api/ScriptingGraphics.h
@@ -961,6 +961,7 @@ namespace ScriptingObjects
 
 			void drawFlexAhdsrBackground(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 			void drawFlexAhdsrCurvePoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> curvePoint, bool hover, bool down) override;
+			void drawFlexAhdsrDragPoint(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> dragPoint, bool hover, bool down) override;
 			void drawFlexAhdsrFullPath(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph) override;
 			void drawFlexAhdsrPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;
 			void drawFlexAhdsrBallPosition(Graphics& g, flex_ahdsr_base::FlexAhdsrGraph& graph, flex_ahdsr_base::State s, Point<float> pointOnPath) override;

--- a/hi_tools/hi_standalone_components/RingBuffer.cpp
+++ b/hi_tools/hi_standalone_components/RingBuffer.cpp
@@ -842,33 +842,31 @@ void flex_ahdsr_base::FlexAhdsrGraph::paint(Graphics& g)
 			s++;
 		}
 
-		if(isPositiveAndBelow((int)currentPlayState, boxes.size()))
+		Point<float> positionOnPath;
+		auto hasPositionOnPath = isPositiveAndBelow((int)currentPlayState, boxes.size()) && !boxes[(int)currentPlayState].isEmpty();
+
+		if(hasPositionOnPath)
 		{
 			auto b = boxes[(int)currentPlayState];
 
-			if(!b.isEmpty())
+			if(currentPlayState == State::SUSTAIN)
 			{
-				Point<float> pos;
-
-				if(currentPlayState == State::SUSTAIN)
-				{
-					pos = sustainPoint;
-				}
-				else
-				{
-					auto xPos = b.getX() + positionWithinState * b.getWidth();
-					auto yPos = Helpers::getYAt(segments[(int)currentPlayState], xPos);
-					pos = { xPos, yPos };
-				}
-				
-				laf->drawFlexAhdsrPosition(g, *this, currentPlayState, pos);
-
-				if(showBall)
-					laf->drawFlexAhdsrBall(g, *this, currentPlayState, pos);
+				positionOnPath = sustainPoint;
 			}
+			else
+			{
+				auto xPos = b.getX() + positionWithinState * b.getWidth();
+				auto yPos = Helpers::getYAt(segments[(int)currentPlayState], xPos);
+				positionOnPath = { xPos, yPos };
+			}
+
+			laf->drawFlexAhdsrPosition(g, *this, currentPlayState, positionOnPath);
 		}
 
 		laf->drawFlexAhdsrFullPath(g, *this);
+
+		if(hasPositionOnPath && showBall)
+			laf->drawFlexAhdsrBall(g, *this, currentPlayState, positionOnPath);
 
 		s = 0;
 

--- a/hi_tools/hi_standalone_components/RingBuffer.cpp
+++ b/hi_tools/hi_standalone_components/RingBuffer.cpp
@@ -799,6 +799,17 @@ void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrPosition(
 	g.fillRect(0.0f, (float)Margin, (float)pointOnPath.getX(), (float)graph.getHeight() - 2.0f * (float)Margin);
 }
 
+void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBallPosition(Graphics& g, FlexAhdsrGraph& graph,
+	State s, Point<float> pointOnPath)
+{
+	if(s == State::SUSTAIN || s == State::IDLE)
+		return;
+
+	auto circle = Rectangle<float>(pointOnPath, pointOnPath).withSizeKeepingCentre(6.0f, 6.0f);
+	g.setColour(graph.findColour(RingBufferComponentBase::lineColour).withAlpha(1.0f));
+	g.fillRoundedRectangle(circle, 2.0f);
+}
+
 void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrText(Graphics& g, FlexAhdsrGraph& graph,
 	const String& text)
 {
@@ -851,6 +862,9 @@ void flex_ahdsr_base::FlexAhdsrGraph::paint(Graphics& g)
 				}
 				
 				laf->drawFlexAhdsrPosition(g, *this, currentPlayState, pos);
+
+				if(showBall)
+					laf->drawFlexAhdsrBallPosition(g, *this, currentPlayState, pos);
 			}
 		}
 

--- a/hi_tools/hi_standalone_components/RingBuffer.cpp
+++ b/hi_tools/hi_standalone_components/RingBuffer.cpp
@@ -799,7 +799,7 @@ void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrPosition(
 	g.fillRect(0.0f, (float)Margin, (float)pointOnPath.getX(), (float)graph.getHeight() - 2.0f * (float)Margin);
 }
 
-void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBallPosition(Graphics& g, FlexAhdsrGraph& graph,
+void flex_ahdsr_base::FlexAhdsrGraph::LookAndFeelMethods::drawFlexAhdsrBall(Graphics& g, FlexAhdsrGraph& graph,
 	State s, Point<float> pointOnPath)
 {
 	if(s == State::SUSTAIN || s == State::IDLE)
@@ -864,7 +864,7 @@ void flex_ahdsr_base::FlexAhdsrGraph::paint(Graphics& g)
 				laf->drawFlexAhdsrPosition(g, *this, currentPlayState, pos);
 
 				if(showBall)
-					laf->drawFlexAhdsrBallPosition(g, *this, currentPlayState, pos);
+					laf->drawFlexAhdsrBall(g, *this, currentPlayState, pos);
 			}
 		}
 

--- a/hi_tools/hi_standalone_components/RingBuffer.h
+++ b/hi_tools/hi_standalone_components/RingBuffer.h
@@ -527,7 +527,7 @@ struct flex_ahdsr_base: public SimpleRingBuffer::WriterBase
 			virtual void drawFlexAhdsrDragPoint(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> dragPoint, bool hover, bool down);
 			virtual void drawFlexAhdsrCurvePoint(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> curvePoint, bool hover, bool down);
 			virtual void drawFlexAhdsrPosition(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> pointOnPath);
-			virtual void drawFlexAhdsrBallPosition(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> pointOnPath);
+			virtual void drawFlexAhdsrBall(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> pointOnPath);
 			virtual void drawFlexAhdsrText(Graphics& g, FlexAhdsrGraph& graph, const String& text);
 		};
 

--- a/hi_tools/hi_standalone_components/RingBuffer.h
+++ b/hi_tools/hi_standalone_components/RingBuffer.h
@@ -294,6 +294,7 @@ struct RingBufferComponentBase : public ComplexDataUIBase::EditorBase,
 		bgColour = 12,
 		fillColour,
 		lineColour,
+		outlineColour,
 		numColourIds
 	};
 
@@ -511,6 +512,7 @@ struct flex_ahdsr_base: public SimpleRingBuffer::WriterBase
 			setColour(RingBufferComponentBase::ColourId::bgColour, Colours::black.withAlpha(0.6f));
 			setColour(RingBufferComponentBase::ColourId::fillColour, Colours::white.withAlpha(0.2f));
 			setColour(RingBufferComponentBase::ColourId::lineColour, Colours::white);
+			setColour(RingBufferComponentBase::ColourId::outlineColour, Colours::black.withAlpha(0.3f));
 			setColour(HiseColourScheme::ColourIds::ComponentTextColourId, Colours::white);
 
 			setSpecialLookAndFeel(new DefaultLookAndFeel(), true);

--- a/hi_tools/hi_standalone_components/RingBuffer.h
+++ b/hi_tools/hi_standalone_components/RingBuffer.h
@@ -527,6 +527,7 @@ struct flex_ahdsr_base: public SimpleRingBuffer::WriterBase
 			virtual void drawFlexAhdsrDragPoint(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> dragPoint, bool hover, bool down);
 			virtual void drawFlexAhdsrCurvePoint(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> curvePoint, bool hover, bool down);
 			virtual void drawFlexAhdsrPosition(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> pointOnPath);
+			virtual void drawFlexAhdsrBallPosition(Graphics& g, FlexAhdsrGraph& graph, State s, Point<float> pointOnPath);
 			virtual void drawFlexAhdsrText(Graphics& g, FlexAhdsrGraph& graph, const String& text);
 		};
 
@@ -594,6 +595,7 @@ struct flex_ahdsr_base: public SimpleRingBuffer::WriterBase
 		}
 
 		bool useOneDimensionalDrag = false;
+		bool showBall = false;
 		float curveTolerance = 20.0f;
 
 		Path fullPath;


### PR DESCRIPTION
Brings the Flex AHDSR graph up to parity with the regular AHDSR envelope's look-and-feel customisation:

- Adds an optional ball position indicator (drawFlexAhdsrBall), gated behind a new ShowBall floating tile property, with default/scriptnode-skin/HiseScript overrides.
- Makes the square drag handles themeable via drawFlexAhdsrDragPoint (scriptnode skin + HiseScript callback), matching the existing curve point handling.
- Adds a third custom colour (itemColour3 / outlineColour), wired from the floating tile panel and exposed in all drawFlexAhdsr* script callbacks.