### PR TITLE
Add UserPresetHandler::abortPresetLoad and script-facing abortLoad()

### DIFF
--- a/hi_core/hi_core/MainController.h
+++ b/hi_core/hi_core/MainController.h
@@ -1005,6 +1005,8 @@ public:
 
 		void postPresetSave();
 
+		void abortPresetLoad() { abortCurrentLoad = true; }
+
 		bool setCustomAutomationData(CustomAutomationData::List newList);
 
 		void setUseCustomDataModel(bool shouldUseCustomModel, bool usePersistentObject);
@@ -1087,6 +1089,7 @@ public:
 
 		MainController* mc;
 		bool useUndoForPresetLoads = false;
+		bool abortCurrentLoad = false;
 
 		struct CustomStateManager : public UserPresetStateManager
 		{

--- a/hi_core/hi_core/UserPresetHandler.cpp
+++ b/hi_core/hi_core/UserPresetHandler.cpp
@@ -495,7 +495,18 @@ void MainController::UserPresetHandler::loadUserPresetFromValueTree(const ValueT
 			return SafeFunctionCall::OK;
 		};
 
+		abortCurrentLoad = false;
+
 		preprocess(pendingPreset);
+
+		if (abortCurrentLoad)
+		{
+			abortCurrentLoad = false;
+			currentlyLoadedFile = oldFile;
+			pendingPreset = {};
+
+			return;
+		}
 
 		// Send a note off to stop the arpeggiator etc...
 		mc->allNotesOff(false);

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -43,6 +43,7 @@ struct ScriptUserPresetHandler::Wrapper
 	API_VOID_METHOD_WRAPPER_1(ScriptUserPresetHandler, setCustomAutomation);
 	API_VOID_METHOD_WRAPPER_3(ScriptUserPresetHandler, setUseCustomUserPresetModel);
 	API_METHOD_WRAPPER_1(ScriptUserPresetHandler, isOldVersion);
+	API_VOID_METHOD_WRAPPER_0(ScriptUserPresetHandler, abortLoad);
     API_METHOD_WRAPPER_0(ScriptUserPresetHandler, isInternalPresetLoad);
 	API_METHOD_WRAPPER_0(ScriptUserPresetHandler, isCurrentlyLoadingPreset);
 	API_VOID_METHOD_WRAPPER_0(ScriptUserPresetHandler, clearAttachedCallbacks);
@@ -81,6 +82,7 @@ ScriptUserPresetHandler::ScriptUserPresetHandler(ProcessorWithScriptingContent* 
 	getMainController()->getLockFreeDispatcher().addPresetLoadListener(this);
 
 	ADD_API_METHOD_1(isOldVersion);
+	ADD_API_METHOD_0(abortLoad);
     ADD_API_METHOD_0(isInternalPresetLoad);
 	ADD_API_METHOD_0(isCurrentlyLoadingPreset);
 	ADD_TYPED_API_METHOD_1(setPostCallback, VarTypeChecker::Function);
@@ -273,6 +275,11 @@ bool ScriptUserPresetHandler::isOldVersion(const String& version)
 	SemanticVersionChecker svs(version, thisVersion);
 
 	return svs.isUpdate();
+}
+
+void ScriptUserPresetHandler::abortLoad()
+{
+	getMainController()->getUserPresetHandler().abortPresetLoad();
 }
 
 

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -85,6 +85,9 @@ public:
 	/** Checks if the given version string is a older version than the current project version number. */
 	bool isOldVersion(const String& version);
 
+	/** Aborts the preset that is currently being loaded (call this synchronously from the pre-load callback). Reverts to the previously loaded preset and updates any attached preset browser selection. */
+	void abortLoad();
+
 	/** Disables the default user preset data model and allows a manual data handling. */
 	void setUseCustomUserPresetModel(var loadCallback, var saveCallback, bool usePersistentObject);
 


### PR DESCRIPTION
Allows a prePresetLoad listener (eg. a script preprocessor) to cancel the current user preset load synchronously. On abort, the previous preset stays active and postPresetLoad() fires so listeners such as the preset browser revert their selection, instead of relying on callers to manually strip every branch of the incoming preset data.

My reason for this is I'm putting out a newer version of an instrument that is incompatible with presets for older versions. So I will show the user a message and then abort the load if they attempt to load an old preset. 