### PR TITLE
Add minimum required player version check for full expansions

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -383,6 +383,30 @@ void ExpansionHandler::setCurrentExpansion(Expansion* e, NotificationType notify
 
 				setErrorMessage(errorMessage, false);
 			}
+
+			auto requiredPlayerVersion = e->getPropertyValueTree()[ExpansionIds::RequiredPlayerVersion].toString();
+
+			if (requiredPlayerVersion.isNotEmpty())
+			{
+#if USE_BACKEND
+				auto playerVersion = GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::Project::Version).toString();
+#else
+				auto playerVersion = FrontendHandler::getVersionString();
+#endif
+
+				SemanticVersionChecker playerVersionCheck(playerVersion, requiredPlayerVersion);
+
+				if (playerVersionCheck.isUpdate())
+				{
+					String errorMessage;
+
+					errorMessage << "The expansion " << e->getProperty(ExpansionIds::Name) << " requires player version " << requiredPlayerVersion;
+					errorMessage << " but this player is version " << playerVersion << ". Please update the player to use this expansion.";
+
+					setErrorMessage(errorMessage, true);
+					return;
+				}
+			}
 		}
 
 		currentExpansion = e;

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -57,6 +57,7 @@ DECLARE_ID(Name);
 DECLARE_ID(ProjectName);
 DECLARE_ID(ProjectVersion);
 DECLARE_ID(Version);
+DECLARE_ID(RequiredPlayerVersion);
 DECLARE_ID(Tags);
 DECLARE_ID(Key);
 DECLARE_ID(Hash);

--- a/hi_core/hi_core/HiseSettings.cpp
+++ b/hi_core/hi_core/HiseSettings.cpp
@@ -154,6 +154,7 @@ Array<juce::Identifier> HiseSettings::ExpansionSettings::getAllIds()
 	ids.add(UUID);
 	ids.add(Tags);
 	ids.add(Description);
+	ids.add(RequiredPlayerVersion);
 
 	return ids;
 }
@@ -662,6 +663,11 @@ Array<juce::Identifier> HiseSettings::SnexWorkbench::getAllIds()
 
 		P(HiseSettings::ExpansionSettings::Description);
 		D("A markdown formatted text that will be written into the metadata of the full instrument expansion");
+		P_();
+
+		P(HiseSettings::ExpansionSettings::RequiredPlayerVersion);
+		D("The minimum version of the player that is required to load this expansion (eg. `1.2.0`). Leave empty if there is no minimum version requirement.");
+		D("If a player with a lower version tries to load this expansion, it will show a critical error message instead of loading it.");
 		P_();
 
 		P(HiseSettings::Scripting::GlobalScriptPath);
@@ -1414,6 +1420,17 @@ juce::Result HiseSettings::Data::checkInput(const Identifier& id, const var& new
 		{
 			return Result::fail("The version number is not a valid semantic version number. Use something like 1.0.0.\n " \
 				"This is required for the user presets to detect whether it should ask for updating the presets after a version bump.");
+		};
+	}
+
+	if (id == ExpansionSettings::RequiredPlayerVersion && newValue.toString().isNotEmpty())
+	{
+		const String version = newValue.toString();
+		SemanticVersionChecker versionChecker(version, version);
+
+		if (!versionChecker.newVersionNumberIsValid())
+		{
+			return Result::fail("The version number is not a valid semantic version number. Use something like 1.0.0, or leave it empty if there is no minimum version requirement.");
 		};
 	}
 

--- a/hi_core/hi_core/HiseSettings.h
+++ b/hi_core/hi_core/HiseSettings.h
@@ -131,6 +131,7 @@ namespace ExpansionSettings
 DECLARE_ID(UUID);
 DECLARE_ID(Tags);
 DECLARE_ID(Description);
+DECLARE_ID(RequiredPlayerVersion);
 
 Array<Identifier> getAllIds();
 }

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -3087,6 +3087,7 @@ void ExpansionEncodingWindow::run()
 		mData.setProperty(ExpansionIds::Description, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::Description), nullptr);
 		mData.setProperty(ExpansionIds::Tags, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::Tags), nullptr);
 		mData.setProperty(ExpansionIds::UUID, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::UUID), nullptr);
+		mData.setProperty(ExpansionIds::RequiredPlayerVersion, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::RequiredPlayerVersion), nullptr);
 		mData.setProperty(ExpansionIds::HiseVersion, PresetHandler::getVersionString(), nullptr);
 
 		if (exportMode == ExportMode::HiseProject)


### PR DESCRIPTION
Adds an editable "Required Player Version" field (Project Settings -> Expansion Settings) that gets stamped into the exported .hxi metadata alongside the existing HiseVersion/Description/Tags/UUID fields.

When an expansion becomes the current expansion, ExpansionHandler now compares this required version against the running player's own version (project version in the backend, FrontendHandler::getVersionString() in a compiled plugin) using the existing SemanticVersionChecker. If the player is too old, it reports a critical error through the existing error handler and bails out before switching to the expansion, so the expansion is not loaded - the same way the missing-samples critical error path already blocks without needing a bool return threaded through the call chain. This mirrors the existing (non-critical) HiseVersion compatibility check already used for the HISE engine version.


Claude-Session: https://claude.ai/code/session_012h7GFqSZ6hjUDkBXXBr1kM