### PR TITLE
Fix expansion load check for split monolith sample files

### DIFF
--- a/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
+++ b/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
@@ -914,22 +914,24 @@ juce::String SampleMap::checkReferences(MainController* mc, ValueTree& v, const 
 	const std::string channelNames = v.getProperty("MicPositions").toString().toStdString();
 	const size_t numChannels = std::count(channelNames.begin(), channelNames.end(), ';');
 
-	const String sampleMapName = v.getProperty("ID").toString().replace("/", "_");
-
 	if (isMonolith)
 	{
-		for (size_t i = 0; i < numChannels; i++)
+		// Accounts for split monolith parts (eg. ".ch1a", ".ch1b"), unlike a plain "sampleMapName.chN" guess
+		MonolithFileReference info(v);
+		info.addSampleDirectory(sampleRootFolder);
+		info.setFileNotFoundBehaviour(MonolithFileReference::FileNotFoundBehaviour::DoNothing);
+
+		info.channelIndex = 0;
+		info.partIndex = 0;
+
+		do
 		{
-			const String fileName = sampleMapName + ".ch" + String(i + 1);
-
-			File f = sampleRootFolder.getChildFile(fileName);
-
+			File f = info.getFile(false);
 
 			if (!f.existsAsFile())
-			{
 				return f.getFullPathName();
-			}
-		}
+
+		} while (info.bumpToNextMonolith(true));
 	}
 	else
 	{


### PR DESCRIPTION
SampleMap::checkReferences validated monolith sample maps by reconstructing filenames as "sampleMapName.chN", which does not account for HISE's monolith split feature: large per-channel sample data gets split into multiple files with a letter suffix (eg. ".ch1a", ".ch1b", ...) once it exceeds the single-file size cap. This caused expansions with large split samples to fail loading with a false "missing sample" error, even though the actual monolith loading code (SampleMap::setCurrentMonolith) already resolves split parts fine. Reuse MonolithFileReference, the same class the real loader uses, so the pre-flight check understands split parts consistently.