### PR TITLE
Fix monolith split size cap being ignored for wider mic channels

### DIFF
--- a/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
+++ b/hi_core/hi_sampler/sampler/ModulatorSamplerData.cpp
@@ -1238,8 +1238,37 @@ void MonolithExporter::exportCurrentSampleMap(bool overwriteExistingData, bool e
 		return;
 	}
 
+	splitSizeScale = 1.0;
+
 	if (exportSamples)
 	{
+		AudioFormatManager scanFormatManager;
+		scanFormatManager.registerBasicFormats();
+
+		int channel0Width = 1;
+		int widestChannelWidth = 1;
+
+		for (int i = 0; i < numChannels; i++)
+		{
+			auto* channelList = filesToWrite[i];
+
+			if (channelList == nullptr || channelList->isEmpty())
+				continue;
+
+			ScopedPointer<AudioFormatReader> reader = scanFormatManager.createReaderFor(channelList->getUnchecked(0));
+
+			if (reader == nullptr)
+				continue;
+
+			if (i == 0)
+				channel0Width = reader->numChannels;
+
+			widestChannelWidth = jmax(widestChannelWidth, (int)reader->numChannels);
+		}
+
+		if (widestChannelWidth > channel0Width)
+			splitSizeScale = (double)channel0Width / (double)widestChannelWidth;
+
 		for (int i = 0; i < numChannels; i++)
 		{
 			if (threadShouldExit())
@@ -1359,7 +1388,9 @@ int64 MonolithExporter::getNumBytesForSplitSize() const
 
 	auto sixtyMB = 1024 * 1024 * 60;
 
-	return (int64)(mb * 1024 * 1024 - sixtyMB);
+	auto capInBytes = (int64)(mb * 1024 * 1024 - sixtyMB);
+
+	return (int64)(capInBytes * splitSizeScale);
 }
 
 void MonolithExporter::checkSanity()

--- a/hi_core/hi_sampler/sampler/ModulatorSamplerData.h
+++ b/hi_core/hi_sampler/sampler/ModulatorSamplerData.h
@@ -573,6 +573,9 @@ private:
 
 	int64 getNumBytesForSplitSize() const;
 
+	// Scales channel 0's split cap down so wider channels reusing its split points stay under the cap too
+	double splitSizeScale = 1.0;
+
 	void checkSanity();
 
 	File getNextMonolith(const File& f) const;


### PR DESCRIPTION
MonolithExporter::shouldSplit only tracks real bytes written for channel 0; every other channel just reuses channel 0's sample-index split points. If channel 0 is narrower (eg. mono) than another mic position in the samplemap (eg. a stereo mic), that wider channel inherits split points sized for the narrower one and its monolith parts end up far exceeding the configured split size cap (eg. a stereo channel exporting at roughly double the mono channel's part size).

Scan all channel widths before exporting and scale channel 0's accounting cap down by channel0Width/widestChannelWidth, so whichever channel ends up widest still respects the configured cap.