### PR TITLE
Fix the AutoStartRestServer setting never starting the REST server

### DIFF
--- a/hi_backend/backend/BackendRootWindow.cpp
+++ b/hi_backend/backend/BackendRootWindow.cpp
@@ -1000,7 +1000,7 @@ void BackendRootWindow::resized()
 			{
 				restServer.start(bp->commandLineServerPort, "127.0.0.1", corsOrigins);
 			}
-			else if (bp->getSettingsObject().getSetting(HiseSettings::Scripting::AutoStartRestServer).toString() == "Yes")
+			else if ((bool)bp->getSettingsObject().getSetting(HiseSettings::Scripting::AutoStartRestServer))
 			{
 				// Auto-start REST API server if enabled in settings
 				int port = (int)bp->getSettingsObject().getSetting(HiseSettings::Scripting::RestApiPort);


### PR DESCRIPTION
The "Auto Start REST Server" toggle in the Scripting settings has no effect: the server never starts on launch, whatever the setting is set to.

`HiseSettings::Data::getSetting()` normalises Yes/No toggle values into a bool `var` before returning them, so the startup check in `BackendRootWindow::resized()` that compared `.toString()` against `"Yes"` always saw `"1"` and could never match. This reads the setting as a bool instead, matching how the other toggle settings are consumed.

Verified on a local Debug build: with the setting enabled the server starts on launch and shows as running in the Tools menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
