### PR TITLE
Make the "Default" font honour the requested size and measure consistently

### DIFF
--- a/hi_core/hi_core/MainController.cpp
+++ b/hi_core/hi_core/MainController.cpp
@@ -2033,7 +2033,7 @@ float MainController::getStringWidthFromEmbeddedFont(const String& text, const S
 Font MainController::getFontFromString(const String& fontName, float fontSize) const
 {
 	if (fontName == "Default")
-		return globalFont;
+		return globalFont.withHeight(fontSize);
 
 	const Identifier id(fontName);
 
@@ -2076,6 +2076,11 @@ void MainController::setGlobalFont(const String& fontName)
 		globalFont = GLOBAL_FONT();
 	else 
 		globalFont = getFontFromString(fontName, 14.0f);
+
+	// Keep the "Default" measuring table in sync with the typeface that "Default" now draws with,
+	// so getStringWidth() agrees with drawText() for the global font.
+	if (auto tf = globalFont.getTypefacePtr())
+		defaultFont = CustomTypeFace(tf, "Default");
 
 	mainLookAndFeel->setComboBoxFont(globalFont);
 }


### PR DESCRIPTION
## Problem

`MainController::getFontFromString()` returns `globalFont` unchanged when the name is `"Default"`, ignoring the `fontSize` argument. Every other font name applies the size, so `g.setFont("Default", 30)` silently draws at the global font's own height (13 px, or 14 px after `Engine.setGlobalFont()`), and `g.setFontWithSpacing("Default", 30, x)` scales its letter spacing by that height rather than the requested one. The same applies to every other caller that resolves a font name (`LookAndFeel.setGlobalFont`, label / floating tile font properties, markdown style data, ...).

On top of that, `g.getStringWidth()` / `Engine.getStringWidth()` fall back to a per-character width table for `"Default"` that is built once from the stock global font typeface and never updated. So it measures the wrong typeface once a project sets a global font, and, combined with the size bug above, returned widths that did not match the drawn text (about 2.3x too wide for a 30 px request).

## Fix

- `getFontFromString("Default", size)` returns `globalFont.withHeight(fontSize)`.
- `setGlobalFont()` rebuilds the `"Default"` measuring table from the global font's typeface, so `getStringWidth()` agrees with what `drawText()` renders.

I checked all callers of `getFontFromString()`: they all pass real sizes (14/16 or property defaults of 14), so nothing was relying on the size being dropped. The width table itself is kept as-is since it was introduced to avoid the Windows threading issue with `Font::getStringWidthFloat()` on the scripting thread.

## Verification

Repro script drawing `MMMMM` centred with `setFontWithSpacing("Default", 30, spacing)` and correcting via `getStringWidth()`: before, the text rendered at 13 px and the measured correction landed ~35 px off centre; after, the text renders at 30 px and the measured correction is centred, matching a `loadFontAs` font used as a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
