### PR TITLE
Fix out-of-bounds read in the string width table for non-ASCII characters

### DIFF
--- a/hi_core/hi_core/MainController.cpp
+++ b/hi_core/hi_core/MainController.cpp
@@ -1764,6 +1764,8 @@ MainController::CustomTypeFace::CustomTypeFace(ReferenceCountedObjectPtr<juce::T
 	memset(characterWidths, 0, sizeof(float) * 128);
 
 	String s;
+	float sum = 0.0f;
+
 	for(char i = 32; i < 127; i++)
 	{
 		s = String::fromUTF8((&i), 1);
@@ -1774,7 +1776,12 @@ MainController::CustomTypeFace::CustomTypeFace(ReferenceCountedObjectPtr<juce::T
 	characterWidths[i] = tf->getStringWidth(s);
 #endif
 
+		sum += characterWidths[i];
 	}
+
+	// Slot 127 holds the average printable width and is used as an estimate for
+	// any character outside the ASCII table (see getStringWidthFloat).
+	characterWidths[127] = sum / (float)(127 - 32);
 }
 
 void MainController::prepareToPlay(double sampleRate_, int samplesPerBlock)

--- a/hi_core/hi_core/MainController.h
+++ b/hi_core/hi_core/MainController.h
@@ -2325,7 +2325,12 @@ private:
 			while(pos != end)
 			{
 				auto c = *pos++;
-				normalisedLength += characterWidths[jlimit<uint8>(31, 128, c)];
+
+				// 32..126 are measured, 31 is zero (control characters), 127 holds the
+				// average width used for anything outside the table (non-ASCII glyphs).
+				const int index = c < 32 ? 31 : (c > 126 ? 127 : (int)c);
+
+				normalisedLength += characterWidths[index];
 				normalisedLength += kerning;
 			}
 


### PR DESCRIPTION
## Problem

`MainController::CustomTypeFace::getStringWidthFloat()` (used by `g.getStringWidth()` and `Engine.getStringWidth()`) indexes its 128-entry `characterWidths` table with `jlimit<uint8>(31, 128, c)`. That truncates the `juce_wchar` code point to a byte and then clamps to 128, which is one past the end of the array. Any character outside the table (degree signs, dashes, accented letters, ...) either reads past the buffer or aliases an unrelated ASCII entry.

## Fix

Compute the index on the full code point: control characters map to the zero slot (31), 32..126 are the measured glyphs, and everything else uses slot 127. The constructor now fills slot 127 with the average printable glyph width so non-ASCII text is estimated rather than measured as zero width.

Independent of, but related to, the `"Default"` font size / measuring PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
