### PR TITLE
Fix default upDecayFactor freezing routing matrix peak meters at zero

### DIFF
--- a/hi_core/hi_dsp/Routing.h
+++ b/hi_core/hi_dsp/Routing.h
@@ -149,7 +149,7 @@ public:
 		bool forcePeakMeters = false;
 		bool anyActive = false;
 
-        float upDecayFactor = 1.0f;
+        float upDecayFactor = 0.0f;
         float downDecayFactor = 0.97f;
         
 		void refreshSourceUseStates();


### PR DESCRIPTION
PR #985 unified the up/down decay branches in
MatrixData::setGainValues to a single alpha-weighted lerp where alpha is the weight on the retained (old) value. upDecayFactor's class default of 1.0f was left over from the previous formula, where it meant instant attack. Under the new formula that same value means "always keep the old value", so any matrix using default settings (nothing else in the codebase calls setDecayCoefficients) has its peak meter permanently frozen at zero the first time signal appears. 0.0f is the correct default for instant attack under the new formula.


Claude-Session: https://claude.ai/code/session_015KahTyzUP5GGSh9iYL5qBp