### PR TITLE
Fix segfault in FlexAhdsrEnvelope from stale voice index in allNotesO…

### DIFF
--- a/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.cpp
+++ b/hi_core/hi_modules/modulators/mods/FlexAhdsrEnvelope.cpp
@@ -265,11 +265,15 @@ float FlexAhdsrEnvelope::startVoice(int voiceIndex)
 
 		auto ownerSynth = static_cast<ModulatorSynth*>(getParentProcessor(true));
 		auto ownerVoice = static_cast<ModulatorSynthVoice*>(ownerSynth->getVoice(voiceIndex));
-		auto e = ownerVoice->getCurrentHiseEvent();
 
-		// reset the smoothers
-		obj.reset();
-		obj.handleHiseEvent(e);
+		if (ownerVoice != nullptr)
+		{
+			auto e = ownerVoice->getCurrentHiseEvent();
+
+			// reset the smoothers
+			obj.reset();
+			obj.handleHiseEvent(e);
+		}
 	}
 
 	span<float, 1> data = { 1.0f };
@@ -308,9 +312,13 @@ void FlexAhdsrEnvelope::stopVoice(int voiceIndex)
 
 		auto ownerSynth = static_cast<ModulatorSynth*>(getParentProcessor(true));
 		auto ownerVoice = static_cast<ModulatorSynthVoice*>(ownerSynth->getVoice(voiceIndex));
-		auto e = ownerVoice->getCurrentHiseEvent();
-		e.setType(HiseEvent::Type::NoteOff);
-		obj.handleHiseEvent(e);
+
+		if (ownerVoice != nullptr)
+		{
+			auto e = ownerVoice->getCurrentHiseEvent();
+			e.setType(HiseEvent::Type::NoteOff);
+			obj.handleHiseEvent(e);
+		}
 	}
 }
 
@@ -361,6 +369,9 @@ void FlexAhdsrEnvelope::calculateBlock(int startSample, int numSamples)
 	{
 		auto os = static_cast<ModulatorSynth*>(getParentProcessor(true, true));
 		auto msv = static_cast<ModulatorSynthVoice*>(os->getVoice(voiceIndex));
+
+		if (msv == nullptr)
+			return;
 
 		const int pseudoOffset = startSample * HISE_CONTROL_RATE_DOWNSAMPLING_FACTOR;
 		const int pseudoSize = numSamples * HISE_CONTROL_RATE_DOWNSAMPLING_FACTOR;


### PR DESCRIPTION
…ff()

Backtrace from gdb showed the real crash: VoiceModulation::allNotesOff() iterates voice indices up to polyManager.getVoiceAmount(), which can exceed the owning ModulatorSynth's actual instantiated voice count. FlexAhdsrEnvelope::stopVoice()/startVoice()/calculateBlock() dereferenced ownerSynth->getVoice(voiceIndex) without checking for null, so an out-of-range index (129 in the reported crash) returned nullptr and the next call crashed inside HiseEvent's copy constructor.

EnvelopeModulator::render() already null-checks this same getVoice() call, so this brings FlexAhdsrEnvelope in line with that existing pattern instead of assuming the index is always valid.

This is called from MainController::allNotesOff() during preset restore, matching the reported "crash after script loading" symptom on large projects.


Claude-Session: https://claude.ai/code/session_012guUbc21rF36T8y6nYcwTn