### PR TITLE
Fix timestretched sampler voices being primed with garbage at note on

### DIFF
--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
@@ -674,7 +674,7 @@ void StreamingSamplerVoice::startNote(int /*midiNoteNumber*/,
 
 void StreamingSamplerVoice::skipTimestretchSilenceAtStart()
 {
-	// Use roundToInt to match skipLatency's rounding — mismatched rounding causes a
+	// Use roundToInt to match skipLatency's rounding - mismatched rounding causes a
 	// one-sample buffer overread into uninitialised memory at certain stretch ratios.
 	auto numBeforeOutput = roundToInt(stretcher.getLatency(stretchRatio));
 
@@ -683,7 +683,15 @@ void StreamingSamplerVoice::skipTimestretchSilenceAtStart()
 	auto outL = (float*)alloca(sizeof(float) * numBeforeOutput);
 	auto outR = (float*)alloca(sizeof(float) * numBeforeOutput);
 
+	// interpolateFromStereoData sizes its normalisation scratch from pitchCounter, which holds
+	// the block length here, while the interpolation below reads numBeforeOutput samples.
+	// Restore it afterwards, the caller is mid block and still needs it.
+	const auto prevPitchCounter = pitchCounter;
+	pitchCounter = (double)numBeforeOutput;
+
 	interpolateFromStereoData(0, outL, outR, numBeforeOutput, nullptr, 1.0, 0.0, data, numBeforeOutput);
+
+	pitchCounter = prevPitchCounter;
 
 	float* inp[2] = { outL, outR };
 
@@ -926,7 +934,7 @@ void StreamingSamplerVoice::interpolateFromStereoData(int startSample, float* ou
 		}
 		else
 		{
-			interpolateStereoSamples<int16, false>(inL, inR, pitchData, outL, outR, startSample, indexInBuffer, thisUptimeDelta, numSamplesToCalculate, indexInBuffer + samplesAvailable);
+			interpolateStereoSamples<int16, false>(inL, inR, pitchDataToUse, outL, outR, startSample, indexInBuffer, thisUptimeDelta, numSamplesToCalculate, indexInBuffer + samplesAvailable);
 		}
 	}
 }


### PR DESCRIPTION
Timestretching multi-mic samples with group crossfades gave clicks and noise bursts on every note on. Each mic of each active group primes its own stretch engine at note start, so the fault fired several times per note.

interpolateFromStereoData() takes a pitchDataToUse parameter so a caller can ask for a pass without pitch modulation, but the non-normalised int16 branch ignores it and reads the pitchData member instead. skipTimestretchSilenceAtStart() passes null while requesting getLatency() samples for the pre-roll, a few thousand at the default 4096 sample FFT window. The branch therefore takes the modulated path and reads one pitch entry per output sample from an array only one audio block long, accumulating the values past the end into the running buffer index. That index is only bounds checked at the upper end, so the engine gets primed from arbitrary memory.

renderNextBlock() nulls the same parameter whenever timestretch is on, because the engine applies the pitch shift itself, so this branch was also applying pitch modulation twice during normal playback.

Also sizes the interpolation's normalisation scratch from the pre-roll length instead of pitchCounter, which holds the block length. That path is taken by normalised int16 sources.


Claude-Session: https://claude.ai/code/session_01FPQjHRF29wNEvskFRtWHQs