### PR TITLE
Expose the timestretch FFT window and overlap to scripting

### DIFF
--- a/hi_core/hi_sampler/sampler/ModulatorSampler.h
+++ b/hi_core/hi_sampler/sampler/ModulatorSampler.h
@@ -279,6 +279,12 @@ public:
 		double sourceBpm = 0.0;
 		Identifier engineId;
 
+		/** The overlap sets how many FFTs per second the engine runs, so it sets the CPU cost. */
+		int fftSize = 4096;
+		int overlap = 8;
+
+		int getStretchInterval() const { return jmax(32, fftSize / overlap); }
+
 		void reset()
 		{
 			mode = TimestretchMode::Disabled;
@@ -287,6 +293,8 @@ public:
 			numQuarters = 0.0;
 			sourceBpm = 0.0;
 			engineId = {};
+			fftSize = 4096;
+			overlap = 8;
 		}
 
 		var toJSON() const
@@ -300,6 +308,8 @@ public:
 			obj->setProperty("NumQuarters", numQuarters);
 			obj->setProperty("SourceBPM", sourceBpm);
 			obj->setProperty("PreferredEngine", engineId.toString());
+			obj->setProperty("FFTSize", fftSize);
+			obj->setProperty("Overlap", overlap);
 
 			return {obj.get()};
 		}
@@ -313,6 +323,8 @@ public:
 			mode = static_cast<TimestretchMode>(modes.indexOf(json.getProperty("Mode", "Disabled").toString()));
 			numQuarters = json.getProperty("NumQuarters", 0.0);
 			sourceBpm = jmax(0.0, static_cast<double>(json.getProperty("SourceBPM", 0.0)));
+			fftSize = jlimit(256, 4096, nextPowerOfTwo(static_cast<int>(json.getProperty("FFTSize", 4096))));
+			overlap = jlimit(2, 16, static_cast<int>(json.getProperty("Overlap", 8)));
 
 			auto id = json.getProperty("PreferredEngine", "").toString();
 

--- a/hi_core/hi_sampler/sampler/ModulatorSamplerVoice.h
+++ b/hi_core/hi_sampler/sampler/ModulatorSamplerVoice.h
@@ -141,6 +141,7 @@ public:
 
 	virtual void setTimestretchOptions(const ModulatorSampler::TimestretchOptions& options)
 	{
+		wrappedVoice.setTimestretchFFTSize(options.fftSize, options.getStretchInterval());
 		wrappedVoice.setEnableTimestretch((bool)options, options.engineId);
 		wrappedVoice.setSkipLatency(options.synchronousSkip ? sendNotificationSync : sendNotificationAsync);
 		wrappedVoice.setTimestretchTonality(options.tonality);
@@ -258,6 +259,7 @@ public:
 	{
 		for (auto v : wrappedVoices)
 		{
+			v->setTimestretchFFTSize(options.fftSize, options.getStretchInterval());
 			v->setEnableTimestretch(options);
 			v->setSkipLatency(options.synchronousSkip ? sendNotificationSync : sendNotificationAsync);
 			v->setTimestretchTonality(options.tonality);

--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.h
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.h
@@ -347,6 +347,11 @@ public:
 		stretcher.setEnabled(shouldBeEnabled, engineId);
 	}
 
+	void setTimestretchFFTSize(int fftSize, int intervalSamples)
+	{
+		stretcher.setFFTSize(fftSize, intervalSamples);
+	}
+
 	void setTimestretchRatio(double newRatio)
 	{
 		stretchRatio = jlimit(0.0625, 2.0, newRatio);

--- a/hi_streaming/timestretch/time_stretcher.cpp
+++ b/hi_streaming/timestretch/time_stretcher.cpp
@@ -54,11 +54,11 @@ struct signal_smith_stretcher: public timestretch_engine_base
         stretcher.reset();
     }
 
-    void setFFTSize(int blockSamples_=4096, int intervalSamples_=512)
+    /** Takes effect on the next configure() call. */
+    void setFFTSize(int blockSamples_, int intervalSamples_) override
     {
 	    blockSamples = blockSamples_;
         intervalSamples = intervalSamples_;
-        configure(numChannels, 44100.0);
     }
 
     void configure(int numChannels_, double sourceSampleRate) override
@@ -254,6 +254,8 @@ void time_stretcher::setEnabled(bool shouldBeEnabled, const Identifier& engineTo
             
             if(engine != nullptr)
             {
+                engine->setFFTSize(blockSamples, intervalSamples);
+
                 if (numChannels != 0 && sourceSampleRate != 0.0)
                 {
                     engine->configure(numChannels, sourceSampleRate);
@@ -374,7 +376,10 @@ double time_stretcher::skipLatency(float** inputs, double ratio)
     engine->reset();
     
     auto numBeforeOutput = roundToInt(getLatency(ratio));
-    
+
+    // A small window can finish the pre-roll before a fixed threshold and stay muted.
+    const double warmupThreshold = jmin((double)numBeforeOutput, 1536.0);
+
     float* thisInputs[2];
     float* outputs[2];
     
@@ -397,7 +402,7 @@ double time_stretcher::skipLatency(float** inputs, double ratio)
         
         currentPos += numInputs;
 
-        if (currentPos >= 1536)
+        if (currentPos >= warmupThreshold)
             engine->setEnableOutput(true);
 
         thisInputs[0] = inputs[0] + static_cast<int>(currentPos);
@@ -476,9 +481,25 @@ void time_stretcher::setTransposeSemitones(double semiTones, double tonality)
     engine->setTransposeSemitones(semiTones, tonality);
 }
 
-void time_stretcher::setFFTSize(int blockSamples, int intervalSamples)
+void time_stretcher::setFFTSize(int blockSamples_, int intervalSamples_)
 {
-	engine->setFFTSize(blockSamples, intervalSamples);
+    if (blockSamples == blockSamples_ && intervalSamples == intervalSamples_)
+        return;
+
+    ScopedLock sl(stretchLock);
+
+    blockSamples = blockSamples_;
+    intervalSamples = intervalSamples_;
+
+    if (engine != nullptr)
+    {
+        engine->setFFTSize(blockSamples, intervalSamples);
+
+        if (numChannels != 0 && sourceSampleRate != 0.0)
+            engine->configure(numChannels, sourceSampleRate);
+
+        engine->reset();
+    }
 }
 
 

--- a/hi_streaming/timestretch/time_stretcher.h
+++ b/hi_streaming/timestretch/time_stretcher.h
@@ -70,6 +70,10 @@ private:
     double playbackRatio = 0.0;
     AudioSampleBuffer resampledBuffer;
 
+    /** Applied to the engine whenever it is created or reconfigured. */
+    int blockSamples = 4096;
+    int intervalSamples = 512;
+
     int numChannels = 0;
     double sourceSampleRate = 0.0;
     


### PR DESCRIPTION
The stretch engine ran a fixed 4096 sample window with a 512 sample hop. Nothing called setFFTSize(), so every sampler in HISE used those numbers and had no way to change them. The hop decides how many FFTs per second the engine runs, so it sets the CPU cost, and 512 against a 4096 window is 8x overlap - twice the overlap the signalsmith presets use. On a multi-mic sampler with group crossfades that is one engine per mic per layer, which made a single note expensive and a chord unplayable.

setTimestretchOptions() now takes FFTSize and Overlap. The hop is FFTSize/Overlap, so the defaults of 4096 and 8 reproduce the old behaviour exactly and no existing project changes. Overlap 4 roughly halves the engine load. Overlap is a plain integer rather than a power of two so that 6 is available as a middle setting; the cost is proportional to it. FFTSize is clamped to a power of two between 256 and 4096, since the pre-roll allocates from the window size on the audio thread.

Lowering the overlap trades against quality on note attacks: the engine derives its pitch mapping from spectral peaks, and both the peak smoothing width and the shape of the analysis window are derived from the overlap factor inside the library, so a larger hop makes the mapping coarser while a note is still transient.

Also clamps the pre-roll's unmute threshold, which the new option makes reachable. skipLatency() runs the engine muted to build up phase history and unmutes it after a hardcoded 1536 samples, but the pre-roll itself is only getLatency() long, which is windowSize/2 * (1 + ratio). At a 4096 window that is always at least 2176, so the unmute always fired. At smaller windows it can finish first, leaving the engine muted with nothing to ever re-enable it and the rest of the note silent. Clamping the threshold to the pre-roll length keeps it reachable at every window size and ratio, and leaves the 4096 window unchanged everywhere.


Claude-Session: https://claude.ai/code/session_01FPQjHRF29wNEvskFRtWHQs