### PR TITLE
Fix garbage right-channel normalisation for mono samples in monolith …

### DIFF
--- a/hi_lac/hlac/HlacAudioFormatReader.cpp
+++ b/hi_lac/hlac/HlacAudioFormatReader.cpp
@@ -581,12 +581,14 @@ void HlacSubSectionReader::readIntoFixedBuffer(HiseSampleBuffer& buffer, int sta
 	}
 	else
 	{
-		internalReader->fixedBufferRead(buffer, numChannels, startSample, start + readerStartSample, numSamples);
-
+		// Must be set before the read, otherwise the normalisation flush picks up
+		// stale values from the unwritten right map.
 		if (buffer.getNumChannels() == 1 || numChannels == 1)
 		{
 			buffer.setUseOneMap(true);
 		}
+
+		internalReader->fixedBufferRead(buffer, numChannels, startSample, start + readerStartSample, numSamples);
 	}
 }
 

--- a/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
+++ b/hi_streaming/hi_streaming/StreamingSamplerVoice.cpp
@@ -1057,6 +1057,9 @@ void StreamingSamplerVoice::renderNextBlock(AudioSampleBuffer &outputBuffer, int
 
 			if(data.b != tempVoiceBuffer)
 			{
+				// copy() doesn't carry this over and the temp buffer is shared
+				tempVoiceBuffer->setUseOneMap(data.b->useOneMap);
+
 				hlac::HiseSampleBuffer::copy(*tempVoiceBuffer, *data.b, 0, data.offsetInBuffer, numToFadeIn);
 				data.b = tempVoiceBuffer;
 				data.offsetInBuffer = 0;


### PR DESCRIPTION
…mode

I noticed I was getting popping sounds sometimes when the release part of a sample triggered. It was in a multi-mic project where two mics where mono and one was stereo. The glitch only occurred on the mono channels.

A mono HLAC decode only ever populates channel 0's normalisation table, but HiseSampleBuffer::flushNormalisationInfo() (called at the end of HlacDecoder::decode()) reads channel 1's table unless useOneMap is set. HlacSubSectionReader::readIntoFixedBuffer() set that flag after calling fixedBufferRead(), so the flush had already run with the flag still false and picked up whatever stale bytes the right map held from an earlier fill, storing them as rightNormalisation. NormalisationInfo::apply() then scales the right channel by 1/(1 << rightNormalisation), so a stale non-zero value produces an abrupt level jump on the right channel only. Setting the flag before the read makes the flush use channel 0's map and write rightNormalisation as 0.

The release-start crossfade in StreamingSamplerVoice::renderNextBlock() also copies its source into a temporary voice buffer that is shared between sounds, and HiseSampleBuffer::copy() does not carry useOneMap across, so the temp buffer retained the flag from whatever filled it last. A stale false made a mono source read its unwritten right channel and apply right normalisation, and a stale true collapsed a stereo source to mono for the duration of the fade.

Playback only: the monolith files themselves are unaffected and do not need to be re-encoded.