### PR TITLE
Centre the Inverted, Min and Max headers in the MIDI learn and macro tables

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1760,6 +1760,10 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 
 	laf = new TableHeaderLookAndFeel();
 
+	// Inverted holds a centred toggle, Min/Max centred value sliders - centre their
+	// headers over them. CC # / Channel / Parameter stay left like their text cells.
+	laf->centredColumnIds = { Inverted, Minimum, Maximum };
+
 	table.getHeader().setLookAndFeel(laf);
 	table.getHeader().setSize(getWidth(), 22);
 	table.getViewport()->setScrollBarsShown(true, false, true, false);

--- a/hi_tools/hi_tools/HI_LookAndFeels.cpp
+++ b/hi_tools/hi_tools/HI_LookAndFeels.cpp
@@ -1768,7 +1768,7 @@ void TableHeaderLookAndFeel::drawTableHeaderBackground(Graphics& graphics, Table
 }
 
 void TableHeaderLookAndFeel::drawTableHeaderColumn(Graphics& g, TableHeaderComponent& tableHeaderComponent,
-	const String& columnName, int i, int width, int height, bool cond, bool cond1, int i1)
+	const String& columnName, int columnId, int width, int height, bool cond, bool cond1, int i1)
 {
 	if (width > 0)
 	{
@@ -1779,7 +1779,10 @@ void TableHeaderLookAndFeel::drawTableHeaderColumn(Graphics& g, TableHeaderCompo
 		g.setFont(f);
 		g.setColour(textColour);
 
-		g.drawText(columnName, 3, 0, width - 3, height, Justification::centredLeft, true);
+		if (centredColumnIds.contains(columnId))
+			g.drawText(columnName, 0, 0, width - 1, height, Justification::centred, true);
+		else
+			g.drawText(columnName, 3, 0, width - 3, height, Justification::centredLeft, true);
 	}
 }
 

--- a/hi_tools/hi_tools/HI_LookAndFeels.h
+++ b/hi_tools/hi_tools/HI_LookAndFeels.h
@@ -207,6 +207,12 @@ public:
 	Font f;
 	Colour bgColour;
 	Colour textColour;
+
+	/** Column ids whose header text is centred instead of left-aligned. Empty by
+	    default so existing tables are unchanged; opt in for columns whose cells hold
+	    centred widgets (toggle buttons, value sliders) so the header lines up with
+	    its content. */
+	Array<int> centredColumnIds;
 };
 
 


### PR DESCRIPTION
In the MIDI Learn and macro tables (`TableFloatingTileBase`), the Inverted column holds a centred toggle button and the Min/Max columns hold centred value sliders, but their headers are drawn left-aligned like the text columns, so "Inverted" in particular sits visibly off to the left of the `Normal`/`Inverted` buttons beneath it.

`TableHeaderLookAndFeel::drawTableHeaderColumn` hard-codes `Justification::centredLeft` for every column and JUCE's `TableHeaderComponent` has no per-column justification, so this can't be fixed from a project.

This adds an opt-in `centredColumnIds` list to `TableHeaderLookAndFeel`. It is empty by default, so every other table using this LAF (sample pool, sampler editors, backend panels, scripting panels) keeps its left-aligned headers. `TableFloatingTileBase` opts in the three widget columns. The simple_css header path (`th` rule present) is untouched.

Verified in an exported plugin: headers sit centred over their toggle/sliders both with an empty table and with rows; other tables unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qEJby5aYbvVsZ8Eq9P1b6
