### PR TITLE
Fix the CC # column width in the MIDI learn table

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1770,7 +1770,12 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 
 	auto fWidth = (int)font.getStringWidthFloat(first) + 20;
 
-	table.getHeader().addColumn(getIndexName(), CCNumber, fWidth, 30, -1, TableHeaderComponent::visible);
+	auto fixedIndexWidth = getFixedIndexColumnWidth();
+
+	if (fixedIndexWidth > 0)
+		table.getHeader().addColumn(first, CCNumber, fixedIndexWidth, fixedIndexWidth, fixedIndexWidth, TableHeaderComponent::visible);
+	else
+		table.getHeader().addColumn(first, CCNumber, fWidth, 30, -1, TableHeaderComponent::visible);
 
 	if(addChannelColumn)
 		table.getHeader().addColumn("Channel", Channel, fWidth, 30, -1, TableHeaderComponent::visible);

--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.h
@@ -745,6 +745,11 @@ public:
 	virtual void setInverted(int rowIndex, bool value) = 0;
 
 	virtual String getIndexName() const = 0;
+
+	/** Return a width in pixels to give the index column a fixed width, or -1 (the
+	    default) to let it stretch with the Parameter column to fill the table. */
+	virtual int getFixedIndexColumnWidth() const { return -1; }
+
 	virtual String getCellText(int rowNumber, int columnId) const = 0;
 	
 	void paintCell(Graphics& g, int rowNumber, int columnId,
@@ -867,6 +872,9 @@ public:
 	SET_PANEL_NAME("MidiLearnPanel");
 
 	String getIndexName() const override { return "CC #"; };
+
+	// CC numbers are at most three characters (0-127), so the column never needs to stretch.
+	int getFixedIndexColumnWidth() const override { return 50; }
 
 	int getNumRows() override;;
 	void removeEntry(int rowIndex) override;


### PR DESCRIPTION
In the MIDI Learn table the CC # column had no maximum width, so it stretched together with the Parameter column to fill the space left by the fixed-width Inverted, Min and Max columns. Its content is at most three characters (0-127), so the extra width was wasted and made Parameter narrower than it needs to be.

This adds a `getFixedIndexColumnWidth()` hook to `TableFloatingTileBase`, defaulting to -1 (stretch as before), and has `MidiLearnPanel` return 50 so the column is fixed and Parameter absorbs all the slack. `FrontendMacroPanel` is unchanged since its first column shows macro names, which need the room.

Verified in an exported plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qEJby5aYbvVsZ8Eq9P1b6
