### PR TITLE
Fix the Channel column width in the MIDI learn table

### DIFF
--- a/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
+++ b/hi_core/hi_components/floating_layout/FrontendPanelTypes.cpp
@@ -1773,7 +1773,12 @@ void TableFloatingTileBase::initTable(bool addChannelColumn)
 	table.getHeader().addColumn(getIndexName(), CCNumber, fWidth, 30, -1, TableHeaderComponent::visible);
 
 	if(addChannelColumn)
-		table.getHeader().addColumn("Channel", Channel, fWidth, 30, -1, TableHeaderComponent::visible);
+	{
+		// MIDI channels are at most two characters (1-16), so size the column to its
+		// header text and keep it fixed rather than letting it stretch with Parameter.
+		auto channelWidth = (int)font.getStringWidthFloat("Channel") + 20;
+		table.getHeader().addColumn("Channel", Channel, channelWidth, channelWidth, channelWidth, TableHeaderComponent::visible);
+	}
 
 	table.getHeader().addColumn("Parameter", ParameterName, 70, 30, -1);
 	table.getHeader().addColumn("Inverted", Inverted, 70, 70, 70);


### PR DESCRIPTION
Like the CC # column (#1032), the optional Channel column in the MIDI Learn table (shown when `HISE_USE_MIDI_CHANNELS_FOR_AUTOMATION` is set) had no maximum width and stretched with the Parameter column. Its content is at most two characters (1-16), so this sizes it to its header text plus padding and keeps it fixed, leaving the slack to Parameter.

Independent of the CC # change; both apply cleanly on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qEJby5aYbvVsZ8Eq9P1b6
