### PR TITLE
Set download data properties before the download thread is spawned

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiObjects.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiObjects.cpp
@@ -1276,12 +1276,13 @@ bool ScriptingObjects::ScriptDownloadObject::resumeInternal()
                 options.extraHeaders = rangeHeader;
                 options.listener = this;
                 
-				download = downloadURL.downloadToFile(resumeFile, options).release();
-
+				// downloadToFile() spawns the download thread, which writes to data from progress()
 				data->setProperty("numTotal", numTotal);
 				data->setProperty("numDownloaded", existingBytesBeforeResuming);
 				data->setProperty("finished", false);
 				data->setProperty("success", false);
+
+				download = downloadURL.downloadToFile(resumeFile, options).release();
 			}
 			else
 			{
@@ -1470,13 +1471,14 @@ void ScriptingObjects::ScriptDownloadObject::start()
         options.timeoutMs = HISE_SCRIPT_SERVER_TIMEOUT;
 		options.extraHeaders = extraHeaders;
 		
-		download = downloadURL.downloadToFile(targetFile, options).release();
-
+		// downloadToFile() spawns the download thread, which writes to data from progress()
 		data->setProperty("numTotal", 0);
 		data->setProperty("numDownloaded", 0);
 		data->setProperty("finished", false);
 		data->setProperty("success", false);
 		data->setProperty("aborted", false);
+
+		download = downloadURL.downloadToFile(targetFile, options).release();
 
 		call(true);
 	}


### PR DESCRIPTION
It was noted that under certain circumstances a plugin would crash during download. This PR fixes it.


URL::downloadToFile() starts the DownloadTask thread before it returns, and that thread calls the listener's progress() as soon as the first bytes arrive. ScriptDownloadObject::start() and resumeInternal() both wrote the initial data properties after that call, so progress() could be adding numTotal and numDownloaded on the download thread while the server thread was still adding the same keys to the same DynamicObject.

Two threads adding to one NamedValueSet reallocate the value array under each other, leaving an element that was never constructed. Assigning to it dereferences its null var type and segfaults in var::operator=, reached through DynamicObject::setProperty from progress() on the DownloadTask thread.

Moving the property writes above downloadToFile() closes the window. The thread does not exist until every key is present, so progress() only ever assigns to existing elements and the array never grows while it runs.