### PR TITLE
Fix MIDI CC assignments not restoring manually changed parameters

### DIFF
--- a/hi_core/hi_core/MainControllerHelpers.cpp
+++ b/hi_core/hi_core/MainControllerHelpers.cpp
@@ -995,10 +995,29 @@ bool MidiControllerAutomationHandler::handleControllerMessage(const HiseEvent& e
 			}
 			else
 			{
-				if (a.lastValue != snappedValue)
-				{
-					auto& uph = a.processor->getMainController()->getUserPresetHandler();
+				// The control can also be changed directly by the UI (or host
+				// automation). In that case the cached CC value alone is not enough
+				// to decide whether this event can be skipped: an identical CC value
+				// must restore the value it represents.
+				bool targetValueChanged = a.lastValue != snappedValue;
 
+				auto& uph = a.processor->getMainController()->getUserPresetHandler();
+
+				if (!targetValueChanged)
+				{
+					if (uph.isUsingCustomDataModel())
+					{
+						if (auto ad = uph.getCustomAutomationData(a.attribute))
+							targetValueChanged = ad->lastValue != snappedValue;
+					}
+					else
+					{
+						targetValueChanged = a.processor->getAttribute(a.attribute) != snappedValue;
+					}
+				}
+
+				if (targetValueChanged)
+				{
 					if (uph.isUsingCustomDataModel())
 					{
 						if (auto ad = uph.getCustomAutomationData(a.attribute))


### PR DESCRIPTION
When a MIDI CC-mapped parameter is changed manually in the UI, receiving the
same CC value again did not restore its CC-mapped value. The automation handler
only compared against its cached previous CC value.

This change additionally checks the actual target parameter value when receiving
an identical CC value, so manually changed controls are restored correctly while
unchanged repeated CC messages remain filtered.