### PR TITLE
Stop plugin parameters echoing non-user changes to the host (Ableton Live automation override)

### DIFF
--- a/hi_core/hi_core/MacroControlledComponents.h
+++ b/hi_core/hi_core/MacroControlledComponents.h
@@ -188,9 +188,41 @@ struct HisePluginParameterBase: public ControlledObject,
 		{
 			parameterValueToSend = v;
 
+			// The host already holds this value: it is the one it sent us last. Do not echo it
+			// back. This catches the listener events that were queued while the dispatcher was
+			// paused (editor teardown) and fire after the sendToHost scope in setValue() ended.
+			if(v == lastHostValue)
+				return;
+
 			if(sendToHost)
 				refreshParameterValue();
 		}
+	}
+
+	/** Called by the host-facing setValue() overrides with the normalised value the host
+	    sent, converted exactly the way onUpdate() converts the resulting attribute, so the
+	    two compare equal for stepped and skewed ranges too. */
+	void setLastHostValue(float normalisedValue)
+	{
+		lastHostValue = normalisedValue;
+	}
+
+	/** Returns true while a parameter change must not be reported to the host.
+
+	    Three situations set a value without the user (or the host) asking for it: the host
+	    restoring plugin state, the interface being created, and the internal preset load that
+	    runs inside the state restore. Reporting those back with performEdit() makes Ableton Live
+	    treat them as manual edits: it disables the automation lane of every affected parameter
+	    and lights "Re-Enable Automation" (forum topic 15004, GitHub issue 749). The host does
+	    not need the report either - JUCE already announces restored values through
+	    restartComponent(kParamValuesChanged) after setStateInformation(). */
+	bool shouldSkipHostNotification()
+	{
+		auto mc = getMainController();
+
+		return mc->getKillStateHandler().getStateLoadFlag() ||
+		       mc->getInterfaceCreationFlag() ||
+		       mc->getUserPresetHandler().isInternalPresetLoad();
 	}
 
 	void refreshParameterValue()
@@ -202,6 +234,9 @@ struct HisePluginParameterBase: public ControlledObject,
 		if(!getMainController()->getPluginParameterUpdateState())
 			return;
 
+		if(shouldSkipHostNotification())
+			return;
+
 		if(defer)
 			triggerAsyncUpdate();
 		else
@@ -210,6 +245,14 @@ struct HisePluginParameterBase: public ControlledObject,
 
 	void handleAsyncUpdate() override
 	{
+		// A deferred update queued before a state load began must not land in the middle of it.
+		if(shouldSkipHostNotification())
+			return;
+
+		// A deferred update that was overtaken by a host write carries the host's own value.
+		if(parameterValueToSend == lastHostValue)
+			return;
+
 		auto mc = getMainController();
 		
 		ScopedValueSetter<bool> svs(recursive, true);
@@ -222,6 +265,7 @@ struct HisePluginParameterBase: public ControlledObject,
     
 	int parameterIndex = -1;
 	float parameterValueToSend = 0.0f;
+	float lastHostValue = -1.0f;
 	bool recursive = false;
 
 	dispatch::library::CustomAutomationSource::Listener autoListener;

--- a/hi_core/hi_core/MacroControlledComponents.h
+++ b/hi_core/hi_core/MacroControlledComponents.h
@@ -259,6 +259,11 @@ struct HisePluginParameterBase: public ControlledObject,
 		ScopedValueSetter<bool> setter(mc->getPluginParameterUpdateState(), false, true);
 
 		getWrappedParameter()->asJuceParameter()->setValueNotifyingHost(parameterValueToSend);
+
+		// The host now holds the value we just sent. Without this the memo goes stale after a user
+		// edit: a later user change back to the last host-written value would compare equal and
+		// never be reported (host-facing setValue() is blocked by the recursive flag above).
+		lastHostValue = parameterValueToSend;
 	}
 
     virtual void cleanup() { cleanupCalled = true; }

--- a/hi_core/hi_dsp/plugin_parameter/PluginParameterProcessor.cpp
+++ b/hi_core/hi_dsp/plugin_parameter/PluginParameterProcessor.cpp
@@ -103,6 +103,7 @@ struct CustomAutomationParameter : public juce::AudioProcessorParameterWithID,
 		ScopedValueSetter<bool> svs(sendToHost, false);
 
 		newValue = data->range.convertFrom0to1(newValue);
+		setLastHostValue(data->range.convertTo0to1(newValue));
 		data->call(newValue, dispatch::DispatchType::sendNotificationSync);
 	}
 
@@ -386,6 +387,8 @@ struct MacroPluginParameter: public juce::HostedAudioProcessorParameter,
 			return;
 
 		ScopedValueSetter<bool> svs(sendToHost, false);
+
+		setLastHostValue(getNormalisableRange().convertTo0to1(getNormalisableRange().convertFrom0to1(newValue)));
 
 		ScopedValueSetter<bool> svs2(recursive, true);
 		md->setValue(newValue * 127.0);

--- a/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
+++ b/hi_scripting/scripting/api/ScriptComponentWrappers.cpp
@@ -3219,6 +3219,8 @@ void ScriptedControlAudioParameter::setValue(float newValue)
 		const float convertedValue = range.convertFrom0to1(newValue);
 		const float snappedValue = range.snapToLegalValue(convertedValue);
 
+		setLastHostValue(range.convertTo0to1(snappedValue));
+
 		scriptProcessor->setAttribute(attributeIndex, snappedValue, sendNotificationSync);
 	}
 }


### PR DESCRIPTION
## Problem

Every exported plugin reports plugin parameter changes back to the host through `HisePluginParameterBase::onUpdate()` -> `setValueNotifyingHost()`, whatever the origin of the change. The only origin that was filtered was the host itself (the `sendToHost` scope from #749). Three other origins are not user edits but still notified the host:

1. `setStateInformation()` restoring every control on project open
2. Editor construction, when the component wrappers sync from the processor
3. The internal preset load that runs inside the state restore

Ableton Live treats a plugin-originated `performEdit` on an automated parameter as a manual takeover: it greys the automation lane and lights "Re-Enable Automation". With a project that has automation drawn, a random subset of lanes was disabled on every project open and on every editor open or close. This is the plugin-to-host mirror of #749 and matches the one-knob repro in forum topic 15004 (fresh project, one knob with `isPluginParameter`, no scripts).

The randomness comes from `refreshParameterValue()` deferring via `triggerAsyncUpdate()` while Live is applying automation on the audio thread at the same time; per parameter, whichever write lands last wins.

Other hosts (Cubase, FL Studio, Reaper, Logic, Bitwig, Maschine) ignore the echo, so only Live showed a symptom.

## Fix

Two layers, both in `HisePluginParameterBase`:

**Gate on origin.** `shouldSkipHostNotification()` returns true while any of three existing flags is set: `KillStateHandler::getStateLoadFlag()`, `MainController::getInterfaceCreationFlag()`, and `UserPresetHandler::isInternalPresetLoad()`. It is checked before the send/defer decision and again at the top of `handleAsyncUpdate()`, so a deferred update queued before a load cannot land in the middle of it. A user's own preset load from the browser does not enter the internal-load scope, so it still notifies.

**Never echo the host's own value.** The flags alone left two leaks, both a notification queued while a guard was up and fired after it dropped, carrying a value the host itself had supplied: dispatcher events held during editor teardown (`SUSPEND_GLOBAL_DISPATCH` in `~ScriptContentComponent`) firing after the `sendToHost` scope ended, and async updates deferred during a load firing after it. Every host-facing `setValue()` override now records `lastHostValue` with the same `convertTo0to1(snapped)` arithmetic `onUpdate()` uses, and a notification equal to it is not sent. The second commit keeps that memo correct after a user edit as well (the recursive flag blocks the parameter's own `setValue()` during the send, and both JUCE wrappers drop the host's echo when the value already matches), so a user change back to the last host-written value is still reported.

The host loses nothing from the skipped notifications: JUCE's VST3 wrapper calls `restartComponent(kParamValuesChanged)` after a state restore and the AU wrapper posts the equivalent property change.

## Why not the value guard proposed in topic 15004

Adding `if (getValue() == newValue) return;` to `setValueNotifyingHost()` silences the echo because HISE stores the attribute before notifying. But that ordering also holds for the user's own drags, so the host would never be told about a user move at all, which breaks automation writing and the host's parameter display.

## Verification

Live 12, VST3, six automated parameters (continuous and stepped): all lanes stay active over five project opens and repeated editor open/close while playing and stopped; Automation Arm still records knob moves; a stepped parameter toggled away from and back to a host-written value is reported both ways. Cubase, Reaper, Logic and FL Studio unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ju9vzCuchu6jeCfCcXzXEs
