### PR TITLE
Add variation-tagged Full Instrument Expansion exports

### DIFF
--- a/hi_core/hi_core/BackgroundThreads.cpp
+++ b/hi_core/hi_core/BackgroundThreads.cpp
@@ -913,10 +913,14 @@ Array<File> SampleDataExporter::collectMonoliths()
 
 	auto& smPool = handler->pool->getSampleMapPool();
 	auto sampleDirectory = handler->getSubDirectory(FileHandlerBase::Samples);
+	auto variation = getVariationFromHxi();
 
 	for (int i = 0; i < smPool.getNumLoadedFiles(); i++)
 	{
 		auto entry = smPool.loadFromReference(smPool.getReference(i), PoolHelpers::DontCreateNewEntry);
+
+		if (!matchesVariation(entry->data, variation))
+			continue;
 
 		MonolithFileReference mref(entry->data);
 
@@ -1035,6 +1039,45 @@ String SampleDataExporter::getProjectVersion() const
 #else
 	return FrontendHandler::getVersionString();
 #endif
+}
+
+String SampleDataExporter::getVariationFromHxi() const
+{
+	if (!hxiFile->getCurrentFile().existsAsFile())
+		return {};
+
+	if (Expansion::Helpers::isXmlFile(hxiFile->getCurrentFile()))
+	{
+		if (auto xml = XmlDocument::parse(hxiFile->getCurrentFile()))
+		{
+			if (auto c = xml->getChildByName(ExpansionIds::ExpansionInfo.toString()))
+				return c->getStringAttribute(ExpansionIds::Variation.toString());
+		}
+	}
+	else
+	{
+		FileInputStream fis(hxiFile->getCurrentFile());
+		auto v = ValueTree::readFromStream(fis);
+		return v.getChildWithName(ExpansionIds::ExpansionInfo)[ExpansionIds::Variation].toString();
+	}
+
+	return {};
+}
+
+bool SampleDataExporter::matchesVariation(const ValueTree& sampleMapData, const String& variation)
+{
+	if (variation.isEmpty())
+		return true;
+
+	auto tagString = sampleMapData.getProperty("Variations").toString();
+
+	// untagged content is always included
+	if (tagString.isEmpty())
+		return true;
+
+	auto variations = StringArray::fromTokens(tagString, ",", "");
+	variations.trim();
+	return variations.contains(variation);
 }
 
 File SampleDataExporter::getTargetFile() const

--- a/hi_core/hi_core/BackgroundThreads.h
+++ b/hi_core/hi_core/BackgroundThreads.h
@@ -524,6 +524,10 @@ private:
 
 	String getProjectVersion() const;
 
+	String getVariationFromHxi() const;
+
+	static bool matchesVariation(const ValueTree& sampleMapData, const String& variation);
+
 	File getTargetFile() const;
 
 	ModulatorSynthChain* synthChain;

--- a/hi_core/hi_core/ExpansionHandler.h
+++ b/hi_core/hi_core/ExpansionHandler.h
@@ -58,6 +58,7 @@ DECLARE_ID(ProjectName);
 DECLARE_ID(ProjectVersion);
 DECLARE_ID(Version);
 DECLARE_ID(Tags);
+DECLARE_ID(Variation);
 DECLARE_ID(Key);
 DECLARE_ID(Hash);
 DECLARE_ID(PoolData);

--- a/hi_core/hi_core/ExternalFilePool.cpp
+++ b/hi_core/hi_core/ExternalFilePool.cpp
@@ -901,6 +901,10 @@ juce::Result PoolBase::DataProvider::writePool(OutputStream* ownedOutputStream, 
 			return Result::fail("Aborted");
 
 		auto ref = pool->getReference(i);
+
+		if (referenceFilter && !referenceFilter(ref))
+			continue;
+
 		auto additionalData = pool->getAdditionalData(ref);
 
 		ValueTree child = ValueTreeConverters::convertDynamicObjectToValueTree(additionalData, "Item");

--- a/hi_core/hi_core/ExternalFilePool.h
+++ b/hi_core/hi_core/ExternalFilePool.h
@@ -375,7 +375,12 @@ public:
         
         size_t getSizeOfEmbeddedReferences() const;
         
+        /** Skips references that don't match, used to export a subset of a pool. */
+        void setReferenceFilter(const std::function<bool(const PoolReference&)>& newFilter) { referenceFilter = newFilter; }
+        
     private:
+        
+        std::function<bool(const PoolReference&)> referenceFilter;
         
         ValueTree metadata;
         int64 metadataOffset;

--- a/hi_scripting/scripting/api/ScriptExpansion.cpp
+++ b/hi_scripting/scripting/api/ScriptExpansion.cpp
@@ -2360,6 +2360,45 @@ void ScriptEncryptedExpansion::setCompressorForPool(SubDirectories fileType, boo
 	}
 }
 
+bool ScriptEncryptedExpansion::matchesVariation(const ValueTree& contentData) const
+{
+	if (variationToExport.isEmpty())
+		return true;
+
+	auto tagString = contentData.getProperty("Variations").toString();
+
+	// untagged content is always included
+	if (tagString.isEmpty())
+		return true;
+
+	auto variations = StringArray::fromTokens(tagString, ",", "");
+	variations.trim();
+	return variations.contains(variationToExport);
+}
+
+void ScriptEncryptedExpansion::pruneUserPresetsForVariation(ValueTree tree) const
+{
+	static const Identifier presetFile("PresetFile");
+
+	for (int i = tree.getNumChildren() - 1; i >= 0; i--)
+	{
+		auto child = tree.getChild(i);
+
+		if (child.getType() == presetFile)
+		{
+			if (!matchesVariation(child.getChild(0)))
+				tree.removeChild(i, nullptr);
+		}
+		else
+		{
+			pruneUserPresetsForVariation(child);
+
+			if (child.getNumChildren() == 0)
+				tree.removeChild(i, nullptr);
+		}
+	}
+}
+
 void ScriptEncryptedExpansion::addDataType(ValueTree& parent, SubDirectories fileType)
 {
 	MemoryBlock mb;
@@ -2370,7 +2409,21 @@ void ScriptEncryptedExpansion::addDataType(ValueTree& parent, SubDirectories fil
 
 	setCompressorForPool(fileType, true);
 
+	if (fileType == FileHandlerBase::SampleMaps && variationToExport.isNotEmpty())
+	{
+		auto& smPool = pool->getSampleMapPool();
+
+		p->getDataProvider()->setReferenceFilter([this, &smPool](const PoolReference& ref)
+		{
+			auto entry = smPool.loadFromReference(ref, PoolHelpers::LoadingType::DontCreateNewEntry);
+			return matchesVariation(entry->data);
+		});
+	}
+
 	p->getDataProvider()->writePool(mos.release());
+
+	if (fileType == FileHandlerBase::SampleMaps)
+		p->getDataProvider()->setReferenceFilter({});
 
 	auto id = getIdentifier(fileType).removeCharacters("/");
 
@@ -2403,6 +2456,9 @@ void ScriptEncryptedExpansion::restorePool(ValueTree encryptedTree, SubDirectori
 void ScriptEncryptedExpansion::addUserPresets(ValueTree encryptedTree)
 {
 	auto userPresets = UserPresetHelpers::collectAllUserPresets(getMainController()->getMainSynthChain(), this);
+
+	if (variationToExport.isNotEmpty())
+		pruneUserPresetsForVariation(userPresets);
 
 	MemoryBlock mb;
 
@@ -2973,6 +3029,34 @@ ExpansionEncodingWindow::ExpansionEncodingWindow(MainController* mc, Expansion* 
 		addComboBox("rhapsody", { "HXI Full Instrument Expansion", "Rhapsody Player Library", "HISE Project Archive" }, "Export Format");
 		getComboBoxComponent("rhapsody")->setSelectedItemIndex((int)exportMode, dontSendNotification);
 
+		{
+			// collect the "Variations" tags used in sample maps and user presets
+			StringArray variationTags;
+
+			Array<File> taggedFiles;
+			h.getSubDirectory(FileHandlerBase::SampleMaps).findChildFiles(taggedFiles, File::findFiles, true, "*.xml");
+			h.getSubDirectory(FileHandlerBase::UserPresets).findChildFiles(taggedFiles, File::findFiles, true, "*.preset");
+
+			for (auto f : taggedFiles)
+			{
+				if (auto xml = XmlDocument::parse(f))
+				{
+					auto tokens = StringArray::fromTokens(xml->getStringAttribute("Variations"), ",", "");
+					tokens.trim();
+
+					for (auto t : tokens)
+						variationTags.addIfNotAlreadyThere(t);
+				}
+			}
+
+			if (!variationTags.isEmpty())
+			{
+				variationTags.insert(0, "All");
+				addComboBox("variation", variationTags, "Variation to export");
+				getComboBoxComponent("variation")->setSelectedItemIndex(0, dontSendNotification);
+			}
+		}
+
 		if (mc->getExpansionHandler().getEncryptionKey({}).isEmpty())
 		{
 			auto k = dynamic_cast<GlobalSettingManager*>(mc)->getSettingsObject().getSetting(HiseSettings::Project::EncryptionKey).toString();
@@ -3076,6 +3160,16 @@ void ExpansionEncodingWindow::run()
 		auto& h = GET_PROJECT_HANDLER(getMainController()->getMainSynthChain());
 		auto f = Expansion::Helpers::getExpansionInfoFile(h.getWorkDirectory(), Expansion::FileBased);
 
+		String selectedVariation;
+
+		if (auto variationBox = getComboBoxComponent("variation"))
+		{
+			selectedVariation = variationBox->getText();
+
+			if (selectedVariation == "All")
+				selectedVariation = {};
+		}
+
 		ValueTree mData(ExpansionIds::ExpansionInfo);
 
 		auto projectName = GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::Project::Name).toString();
@@ -3088,6 +3182,9 @@ void ExpansionEncodingWindow::run()
 		mData.setProperty(ExpansionIds::Tags, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::Tags), nullptr);
 		mData.setProperty(ExpansionIds::UUID, GET_HISE_SETTING(getMainController()->getMainSynthChain(), HiseSettings::ExpansionSettings::UUID), nullptr);
 		mData.setProperty(ExpansionIds::HiseVersion, PresetHandler::getVersionString(), nullptr);
+
+		if (selectedVariation.isNotEmpty())
+			mData.setProperty(ExpansionIds::Variation, selectedVariation, nullptr);
 
 		if (exportMode == ExportMode::HiseProject)
 		{
@@ -3115,6 +3212,7 @@ void ExpansionEncodingWindow::run()
 		ScopedPointer<FullInstrumentExpansion> e = new FullInstrumentExpansion(getMainController(), h.getWorkDirectory());
 		e->initialise();
 		e->setIsProjectExporter();
+		e->variationToExport = selectedVariation;
 		encodeResult = e->encodeExpansion();
 
 		// This file is used by the FullInstrument Expansion so

--- a/hi_scripting/scripting/api/ScriptExpansion.h
+++ b/hi_scripting/scripting/api/ScriptExpansion.h
@@ -377,6 +377,9 @@ public:
 
 	void extractUserPresetsIfEmpty(ValueTree encryptedTree, bool forceExtraction = false);
 
+	/** If set before encodeExpansion(), only content tagged with this variation is exported. */
+	String variationToExport;
+
 protected:
 
 	void encodePoolAndUserPresets(ValueTree &hxiData, bool encodeAdditionalData);
@@ -387,6 +390,9 @@ protected:
 	void addDataType(ValueTree& parent, SubDirectories fileType);
 	void restorePool(ValueTree encryptedTree, SubDirectories fileType);
 	void addUserPresets(ValueTree encryptedTree);
+
+	bool matchesVariation(const ValueTree& contentData) const;
+	void pruneUserPresetsForVariation(ValueTree tree) const;
 
 	Result returnFail(const String& errorMessage);
 };


### PR DESCRIPTION
The purpose of this feature is to allow for creating multiple variations of a full instrument expansion. For example creating a full variation and a lite variation, that have different sample maps, presets, or scripted behaviour.

Sample maps and user presets can carry a "Variations" tag (comma separated, set by hand in the XML/preset file). The Full Instrument Expansion export dialog scans the project for these tags and shows a Variation combo box only when at least one is found, defaulting to "All" (no filtering, same as current behavior).

Selecting a variation filters which sample maps and user presets get embedded, via a new optional reference filter on PoolBase::DataProvider::writePool(), and stamps the chosen variation onto the expansion's own metadata (ExpansionIds::Variation) so it is readable from script via createExpansionHandler().getCurrentExpansion().getProperties().Variation.


Claude-Session: https://claude.ai/code/session_01D1oCLkMUMWdc6GK6oMuzdJ