### PR TITLE
Only warn about odd buffer sizes by default in FX plugins

### DIFF
--- a/hi_core/hi_core.h
+++ b/hi_core/hi_core.h
@@ -396,10 +396,12 @@ If true, then the FX plugin will have a MIDI input and the MIDI processor chain 
 
 /** Config: HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE
 
-If true then the plugin will complain about the buffer size not being a multiple of HISE_EVENT_RASTER. 
+If true then the plugin will complain about the buffer size not being a multiple of HISE_EVENT_RASTER.
+Instrument plugins pad odd buffer sizes internally, so the warning is only enabled by default for FX plugins,
+where an odd buffer size still results in silence.
 */
 #ifndef HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE
-#define HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE 1
+#define HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE FRONTEND_IS_PLUGIN
 #endif
 
 


### PR DESCRIPTION
## Summary

Default `HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE` to `FRONTEND_IS_PLUGIN` instead of `1`, so the "The audio buffer size should be a multiple of 8. Please adjust your audio settings" overlay is only shown by default in FX exports. Instruments, MIDI FX and standalone builds no longer show it. One line of code plus the doc comment.

## Why

The warning dates from Feb 2022 (526a10891), when an odd block size stopped rendering entirely. Since d2db5f94c (Aug 2022) `prepareToPlay` rounds the size up to the raster, and since 1eeba5d3f (Oct 2022) the render shutdown is gone: `DelayedRenderer::processWrapped` pads odd blocks to `HISE_EVENT_RASTER` and carries the leftover samples into the next block. Nothing in the audio path reads the flag any more; the only two readers are the two overlay message calls. For instrument exports the overlay is pure noise. Christoph has said as much twice on the forum:

> "I'll still leave the error message in place for people who try to educate their end users (unless you define HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE=0), but it won't shut the engine down anymore."
> [HISE Compatibility with Windows 11 and Cubase 12, 26 Aug 2022](https://forum.hise.audio/post/54000), the post that introduced the macro

> "I fixed this recently so now it should cope with any buffer size you throw at it (with a slight performance hit at weird buffer sizes). You can safely deactivate the macro."
> [Audio Buffer Size...Multiple of 8- Error Message, 1 Dec 2022](https://forum.hise.audio/post/59057)

Since then the standard forum answer has been to set the macro to 0 (for example [8478](https://forum.hise.audio/topic/8478/fl-studio-au-version-error), [12569](https://forum.hise.audio/topic/12569/buffer-warning-when-plugin-runs)), which suggests the default is simply wrong for instruments.

FL Studio makes it worse in practice: it reports an odd maximum block size to `prepareToPlay` regardless of the buffer length in its audio settings, so the message fires with the buffer already at 256 or 512, tells the user to change a setting that is not the cause, and never clears for the life of the instance. Other synths (Vital, Surge, Arturia, UVI) show nothing in the same session, so it makes a HISE plugin look broken when it is not.

The odd-block padding is compiled out for FX exports (`FRONTEND_IS_PLUGIN`), where an odd block still results in a cleared buffer, so the warning is genuinely useful there and stays on.

## Behaviour

| Export | Before | After |
|---|---|---|
| Instrument | overlay | none |
| MIDI FX | overlay | none |
| Standalone | overlay | none |
| FX | overlay | overlay |

Projects that want the old behaviour can set `HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE=1` in their extra definitions, the mirror of what everyone sets to `0` today. `FRONTEND_IS_PLUGIN` is defined earlier in the same header, and both usage sites test the macro with `#if` / `&&`, so a 0 or 1 value works in both.

Not touched here: the overlay never clearing once shown. The wording pointing at audio settings when the FL fix is the wrapper "Use fixed size buffers" option is addressed separately in #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmHvUmFHqxQvmobVW3gkQ


