### PR TITLE
Point the odd buffer size warning at the FL Studio wrapper option

### DIFF
--- a/hi_core/hi_core/MainControllerHelpers.cpp
+++ b/hi_core/hi_core/MainControllerHelpers.cpp
@@ -1878,7 +1878,21 @@ String OverlayMessageBroadcaster::getOverlayTextMessage(State s) const
 	case IllegalBufferSize:
 	{
 		String s;
-		s << "The audio buffer size should be a multiple of " << String(HISE_EVENT_RASTER) << ". Please adjust your audio settings";
+		s << "The audio buffer size should be a multiple of " << String(HISE_EVENT_RASTER) << ". ";
+
+		// FL Studio reports odd block sizes regardless of the buffer length in its audio settings,
+		// so the generic advice is wrong there. The per-plugin wrapper option is the actual fix.
+		bool isFruityLoops = false;
+
+#if !(IS_STANDALONE_APP || IS_STANDALONE_FRONTEND)
+		isFruityLoops = PluginHostType().isFruityLoops();
+#endif
+
+		if (isFruityLoops)
+			s << "In FL Studio enable 'Use fixed size buffers' for this plugin.";
+		else
+			s << "Please adjust your audio settings";
+
 		return s;
 	}
 	case SamplesNotFound:


### PR DESCRIPTION
## Summary

When the host is FL Studio, the "audio buffer size should be a multiple of 8" overlay now ends with:

> In FL Studio enable 'Use fixed size buffers' for this plugin.

instead of "Please adjust your audio settings". Every other host keeps the existing text. Companion to #1039 but independent of it: #1039 turns the warning off by default for instruments, this one fixes what the warning says where it still shows (FX exports, or projects that opt back in).

## Why

In FL Studio the current advice sends users to the wrong place. FL reports an odd maximum block size to `prepareToPlay` regardless of the buffer length chosen in its audio settings, so the user sets the buffer to 256 or 512 and the message stays. The actual fix is the per-plugin wrapper option "Use fixed size buffers" (Plugin settings > Troubleshooting tab), which makes FL deliver constant blocks. Verified in FL Studio 2025 with an exported instrument built on this branch (`HISE_COMPLAIN_ABOUT_ILLEGAL_BUFFER_SIZE=1` to force the warning on): the FL-specific sentence shows, and enabling the wrapper option makes the overlay go away.

## Implementation

`OverlayMessageBroadcaster::getOverlayTextMessage` checks `PluginHostType().isFruityLoops()` and picks the closing sentence. The check is guarded by `!(IS_STANDALONE_APP || IS_STANDALONE_FRONTEND)`, the same guard `DelayedRenderer::Pimpl` already uses for its `PluginHostType` member in this file.

Not touched here: the overlay never clearing once shown, even after a later legal `prepareToPlay`. Happy to follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmHvUmFHqxQvmobVW3gkQ

