### PR TITLE
Remove non-critical HISE engine version mismatch warning for expansions

### DIFF
--- a/hi_core/hi_core/ExpansionHandler.cpp
+++ b/hi_core/hi_core/ExpansionHandler.cpp
@@ -367,24 +367,6 @@ void ExpansionHandler::setCurrentExpansion(Expansion* e, NotificationType notify
 		if (currentExpansion == nullptr)
 			FullInstrumentExpansion::setNewDefault(getMainController(), getMainController()->getMainSynthChain()->exportAsValueTree());
 
-		if (e != nullptr)
-		{
-			auto hiseVersion = e->getPropertyValueTree()[ExpansionIds::HiseVersion].toString();
-			auto thisVersion = GlobalSettingManager::getHiseVersion();
-			
-			SemanticVersionChecker svs(thisVersion, hiseVersion);
-
-			if (svs.isUpdate())
-			{
-				String errorMessage;
-
-				errorMessage << "The expansion " << e->getProperty(ExpansionIds::Name) << " was made with HISE version " + hiseVersion;
-				errorMessage << " but the player was compiled with the HISE version " << thisVersion << ". Please upgrade the player to ensure full compatibility.";
-
-				setErrorMessage(errorMessage, false);
-			}
-		}
-
 		currentExpansion = e;
 		notifier.sendNotification(Notifier::EventType::ExpansionLoaded, notifyListeners);
 	}


### PR DESCRIPTION
The engine-version compatibility check in ExpansionHandler::setCurrentExpansion surfaced an internal build-version detail ("was made with HISE version X but the player was compiled with the HISE version Y") to end users of exported players. This is not something an end user should need to know or act on, and the check never blocked loading anyway, so it only added confusion.

PR #1019 Adds a minimum required player version feature that will achieve the same thing and also block the expansion from loading when there is a version mismatch.


Claude-Session: https://claude.ai/code/session_01BFQLfjaJbJ9S2mbMvhMx4C