### PR TITLE
Fire value-listener broadcasters when a SliderPack slider changes

### DIFF
--- a/hi_scripting/scripting/api/ScriptingApiContent.cpp
+++ b/hi_scripting/scripting/api/ScriptingApiContent.cpp
@@ -3838,6 +3838,7 @@ void ScriptingApi::Content::ScriptSliderPack::onComplexDataEvent(ComplexDataUIUp
 void ScriptingApi::Content::ScriptSliderPack::changed()
 {
 	getScriptProcessor()->controlCallback(this, value);
+	sendValueListenerMessage();
 }
 
 juce::var ScriptingApi::Content::ScriptSliderPack::getDataAsBuffer()

--- a/hi_scripting/scripting/api/ScriptingApiContent.h
+++ b/hi_scripting/scripting/api/ScriptingApiContent.h
@@ -834,6 +834,10 @@ public:
 		juce::SharedResourcePointer<hise::ScriptComponentPropertyTypeSelector> selectorTypes;
 #endif
 
+	protected:
+
+		void sendValueListenerMessage();
+
 	private:
 
 		enum class AllCatchBehaviour
@@ -844,8 +848,6 @@ public:
 		};
 
 		int pseudoState = 0;
-
-		void sendValueListenerMessage();
 
 		var localLookAndFeel;
 


### PR DESCRIPTION
ScriptSliderPack::changed() overrode the base ScriptComponent::changed() and only fired the raw control callback, skipping sendValueListenerMessage(). This meant ScriptBroadcaster.attachToComponentValue() never triggered for SliderPack components, even though dragging a slider does call changed().

sendValueListenerMessage() was private to ScriptComponent, so it is now declared protected to allow this call from the subclass.


Claude-Session: https://claude.ai/code/session_01XuyKw9Bji4TE1F1kzD7LaJ